### PR TITLE
Remove xfail on test_daughters_build_and_grow

### DIFF
--- a/tests/test_model_behavior.py
+++ b/tests/test_model_behavior.py
@@ -166,12 +166,6 @@ DAUGHTER_RUN_SECONDS = 60.0
 DAUGHTER_MIN_GROWTH_FG = 0.5
 
 
-@pytest.mark.xfail(
-    strict=False,
-    reason='Unum round-trip bug in exchange_constraints; fixed by '
-           'PR #5 (unum-to-pint migration). Remove this marker after '
-           'that PR merges.',
-)
 def test_daughters_build_and_grow(predivision_state, sim_data_cache):
     """Build two daughter composites from the split state and run each
     for 60 s. Each must (a) build without exception and (b) gain at


### PR DESCRIPTION
## Summary

- Removes the `@pytest.mark.xfail` marker on `test_daughters_build_and_grow` now that the unum→pint migration (#5) has landed and fixed the underlying `exchange_constraints` unit-mismatch bug.

The test passes locally against a ParCa cache (~163 s). In CI it still skips because `out/cache/` isn't present — committing a cache fixture to CI is a separate follow-up.

## Test plan

- [x] `pytest tests/test_model_behavior.py::test_daughters_build_and_grow` passes locally (163 s)
- [ ] CI green on this PR (test skips, rest still pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)