### PR TITLE
Add CODEOWNERS, CONTRIBUTING, and AGENTS/CLAUDE guides

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,17 @@
+# CODEOWNERS — automatic review requests
+# Syntax: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default reviewer for everything
+*                              @eagmon
+
+# High-risk areas — biological processes, type system, composite wiring
+/v2ecoli/processes/            @eagmon
+/v2ecoli/steps/                @eagmon
+/v2ecoli/types/                @eagmon
+/v2ecoli/composite*.py         @eagmon
+/v2ecoli/generate*.py          @eagmon
+
+# CI, build, and fixtures must not change without explicit review
+/.github/                      @eagmon
+/pyproject.toml                @eagmon
+/tests/fixtures/               @eagmon

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,128 @@
+# AGENTS.md
+
+Guidance for AI coding assistants working in this repo. Read this before
+editing biological process code, composite wiring, or the type system.
+Humans should read [CONTRIBUTING.md](CONTRIBUTING.md) instead.
+
+## What this repo is
+
+v2ecoli is a whole-cell *E. coli* model. It ports 55 biological processes
+from [CovertLab/vEcoli](https://github.com/CovertLab/vEcoli) onto
+[process-bigraph](https://github.com/vivarium-collective/process-bigraph)
+and [bigraph-schema](https://github.com/vivarium-collective/bigraph-schema).
+The biology must match upstream unless a PR explicitly justifies a change.
+
+## Frameworks you must understand
+
+### process-bigraph
+
+- A **Composite** = processes + stores (state) + wires (edges from ports to
+  store paths). Composites are assembled in `v2ecoli/composite*.py` and the
+  corresponding `generate*.py` files build them for each architecture.
+- A **Process** declares `inputs` and `outputs` schemas and implements an
+  `update(state, interval) -> update` method. Updates are applied to the
+  shared store after each timestep.
+- A **Step** runs to convergence within a timestep rather than stepping
+  through time. Departitioned fuses partitioned requester/evolver halves
+  into Steps.
+- Don't reinvent composition patterns — copy from an existing process in
+  `v2ecoli/processes/` or `v2ecoli/steps/` and adapt.
+
+### bigraph-schema
+
+- Types describe the shape of stores and ports. Project-specific types live
+  in `v2ecoli/types/`.
+- Types register serializers via `@_serialize.dispatch`. A save state that
+  cannot round-trip through the serializer is broken. Test this.
+- Units are carried as `pint.Quantity` values; schemas enforce dimension.
+
+For deeper questions about either framework, invoke the `pbg-expert` skill.
+
+## Checks you must apply when adding or editing a process
+
+1. **Schema round-trip.** `serialize(state) -> JSON -> deserialize` must
+   reproduce the original state. No pickle anywhere in this path.
+2. **Port contract.** Everything `update` reads must be declared in `inputs`;
+   everything it writes must be declared in `outputs`. Mismatches are silent
+   bugs in process-bigraph.
+3. **Units.** Every dimensioned quantity at a port is a `pint.Quantity`.
+   No bare floats, no `Unum`. The Unum bridge at
+   `v2ecoli/library/unit_bridge.py` exists only for upstream vEcoli interop.
+4. **Conservation.** Mass, molecule counts, and charge must balance across
+   the update unless the process has an explicit source/sink with a stated
+   biological justification.
+5. **Behavior test.** A new process requires `tests/test_behavior_<name>.py`
+   that runs the process inside a composite and asserts on an outcome
+   (growth rate, molecule count, concentration, etc.). A unit test of a
+   helper function does not substitute.
+
+## E. coli domain details
+
+- **EcoCyc** is the reference database for E. coli pathways, genes,
+  transcription units, and regulatory sites. Processes representing a known
+  biological entity should cite the EcoCyc ID (e.g., `EG10001`, `TU0-42`) in
+  the process docstring. Parameters for metabolism, transcription, and
+  translation all descend from EcoCyc via the ParCa pipeline.
+- **ParCa** (Parameter Calculator) builds `sim_data` from raw EcoCyc-derived
+  knowledge bases. It's expensive (minutes to hours). Never run ParCa in CI —
+  CI uses a frozen gzipped cache at `tests/fixtures/cache/`.
+- **Three architectures** all simulate the same cell:
+  - `baseline` — partitioned, 55 processes, upstream-parity.
+  - `departitioned` — 41 steps, requester+evolver halves fused.
+  - `reconciled` — hybrid.
+  A change to a process must work across all three, or the PR must explain
+  why it's scoped. Use the architecture comparison report to verify.
+
+## Reports
+
+Regenerate the relevant report and inspect it before opening a PR that
+touches processes, steps, or composite wiring.
+
+- `workflow.py` → `out/reports/workflow_report.html` — full cell lifecycle,
+  division at ~42 min.
+- `multigeneration.py` → `multigeneration_report.html` — N-generation single
+  lineage with mass trajectories and fold-change.
+- `colony_report.py` → `colony_report.html` — mixed colony with pymunk
+  physics, growth, and division.
+- `compare_report.py` → `comparison_report.html` — baseline vs departitioned
+  vs reconciled, 42-min side-by-side.
+- `network_report.py` → `network_*.html` — per-architecture Cytoscape
+  topology. Click a process to see ports, schemas, config, docstring, math.
+- `compare_v1_v2.py` → `v1_v2_comparison.html` — vEcoli 1.0 vs 2.0 vs v2ecoli.
+
+Published at https://vivarium-collective.github.io/v2ecoli/.
+
+## Tests you must know about
+
+- `tests/test_model_behavior.py` — 7 definitive behavior tests. Gate every
+  PR. Do not weaken thresholds without a reviewed justification.
+- `tests/test_cell_cycle_regressions.py` — slow full-cycle tests. Run in a
+  nightly job, not on every PR. Marked with `@pytest.mark.slow`.
+- `@pytest.mark.sim` separates behavior tests from fast tests. CI splits
+  them into parallel jobs. Don't remove the marker.
+- Behavior fixtures live in `tests/fixtures/`. The pre-division state
+  (`pre_division_state.json.gz`) and ParCa cache (`cache/`) are load-bearing.
+
+## What NOT to do
+
+- Do not modify anything under `tests/fixtures/`. Regenerating a fixture is a
+  deliberate act with its own PR.
+- Do not edit `.github/workflows/` or bump `pyproject.toml` dependencies
+  without explicitly calling it out in the PR description.
+- Do not introduce `pickle`, `dill`, or `cloudpickle` in save-state paths.
+  Save states round-trip through bigraph-schema JSON. ParCa caches are the
+  only exception.
+- Do not bypass the Unum/pint boundary in `v2ecoli/library/unit_bridge.py`.
+  Unum should appear nowhere else.
+- Do not add a process to one architecture without a plan for the other two.
+- Do not commit generated reports (`out/`) or ParCa scratch output.
+
+## Before opening a PR
+
+```bash
+pytest -m "not sim"             # fast tests
+pytest -m sim tests/test_model_behavior.py   # behavior tests
+```
+
+If you changed a process, also run the relevant report script and attach the
+output HTML (or the diff against `main`) to the PR.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+See [AGENTS.md](AGENTS.md).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,137 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in
+our community a harassment-free experience for everyone, regardless of
+age, body size, visible or invisible disability, ethnicity, sex
+characteristics, gender identity and expression, level of experience,
+education, socio-economic status, nationality, personal appearance,
+race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open,
+welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our
+  mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political
+  attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our
+standards of acceptable behavior and will take appropriate and fair
+corrective action in response to any behavior that they deem
+inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other
+contributions that are not aligned to this Code of Conduct, and will
+communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also
+applies when an individual is officially representing the community in
+public spaces. Examples of representing our community include using an
+official e-mail address, posting via an official social media account,
+or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may
+be reported to the Vivarium Authors at the email addresses in
+[`AUTHORS.md`](AUTHORS.md). All complaints will be reviewed and
+investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security
+of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in
+determining the consequences for any action they deem in violation of
+this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior
+deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders,
+providing clarity around the nature of the violation and an explanation
+of why the behavior was inappropriate. A public apology may be
+requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, for a specified period of
+time. This includes avoiding interactions in community spaces as well as
+external channels like social media. Violating these terms may lead to a
+temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards,
+including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No
+public or private interaction with the people involved, including
+unsolicited interaction with those enforcing the Code of Conduct, is
+allowed during this period. Violating these terms may lead to a
+permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of
+individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction
+within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,114 @@
+# Contributing to v2ecoli
+
+Thanks for your interest in contributing. v2ecoli is a whole-cell *E. coli*
+model built on [process-bigraph](https://github.com/vivarium-collective/process-bigraph)
+and [bigraph-schema](https://github.com/vivarium-collective/bigraph-schema).
+Because changes here alter simulated biology, we hold PRs to a higher bar than
+most software projects: behavior must be preserved (or the deviation
+justified), units must be consistent, and new processes must come with tests.
+
+If you are an AI coding assistant, please also read [AGENTS.md](AGENTS.md).
+
+## Getting started
+
+```bash
+git clone https://github.com/vivarium-collective/v2ecoli.git
+cd v2ecoli
+python -m venv venv && source venv/bin/activate
+pip install -e '.[dev]'
+```
+
+The first ParCa (parameter calculator) run builds `sim_data` from raw
+EcoCyc-derived knowledge bases and is cached under `out/cache/`. CI uses a
+frozen gzipped cache in `tests/fixtures/cache/` — don't regenerate it in CI.
+
+## Running tests
+
+Fast tests (unit-level, no simulation):
+
+```bash
+pytest -m "not sim"
+```
+
+Behavior tests (run short simulations, validate model output):
+
+```bash
+pytest -m sim tests/test_model_behavior.py
+```
+
+Full CI-equivalent locally:
+
+```bash
+pytest
+```
+
+Slow end-to-end regressions (`tests/test_cell_cycle_regressions.py`) run in a
+nightly job, not on every PR.
+
+## PR checklist
+
+Before opening a PR:
+
+- [ ] Link to a tracking issue (or open one) describing the motivation.
+- [ ] Tests added or updated. New processes require a
+      `tests/test_behavior_<process>.py`.
+- [ ] Behavior preserved. If a change alters simulated trajectories, re-run
+      `workflow.py` and attach the generated report to the PR, explaining the
+      expected effect.
+- [ ] Units consistent. All quantities at process boundaries use `pint`.
+- [ ] No `pickle`/`dill` in save-state paths. Save states are bigraph-schema
+      JSON (optionally gzipped); see `v2ecoli/cache.py`. (ParCa outputs are
+      the one exception, and live under `out/cache/` / `tests/fixtures/cache/`.)
+- [ ] New processes cite their EcoCyc ID where applicable and reference the
+      upstream vEcoli source when porting.
+- [ ] CI is green.
+
+## Hard rules
+
+These are load-bearing and enforced on review (and, over time, in CI):
+
+1. **Save states are bigraph-schema JSON, never pickle/dill.** Pickled state
+   is not portable across bigraph-schema versions and caused past silent
+   corruption. ParCa caches are the only exception.
+2. **`pint` at every process boundary.** Upstream vEcoli is Unum-native; the
+   translation layer lives in `v2ecoli/library/unit_bridge.py`. Do not
+   re-introduce Unum elsewhere, and do not pass bare floats through ports
+   that carry dimensioned quantities.
+3. **New processes need a behavior test.** A process without a test will not
+   be merged. Unit tests of helpers don't count — the test must run the
+   process inside a composite and check an outcome.
+4. **Three architectures.** v2ecoli runs baseline (partitioned, 55 processes),
+   departitioned (41 steps), and reconciled (hybrid). A change to a process
+   should work across all three, or the PR must explain why it's scoped to
+   one.
+
+## Reports
+
+PRs that touch `v2ecoli/processes/`, `v2ecoli/steps/`, or composite wiring
+should regenerate and sanity-check the relevant reports:
+
+- **Workflow report** (`workflow.py`) — full cell lifecycle, division at
+  ~42 min.
+- **Multigeneration report** (`multigeneration.py`) — N-generation single
+  lineage.
+- **Colony report** (`colony_report.py`) — mixed colony with pymunk physics.
+- **Architecture comparison** (`compare_report.py`) — baseline vs
+  departitioned vs reconciled.
+- **Network views** (`network_report.py`) — per-architecture Cytoscape
+  topology with ports, schemas, and math.
+
+Published versions live at https://vivarium-collective.github.io/v2ecoli/ and
+are republished from `main` on merge.
+
+## Review
+
+`CODEOWNERS` automatically requests review from the maintainer for changes
+in biological process code, the type system, composite wiring, CI, and
+fixtures. Expect a 1–3 day turnaround. For larger changes, open a draft PR
+early so we can align on approach before the work is done.
+
+## Code of conduct
+
+Participation in this project is governed by the
+[Contributor Covenant](CODE_OF_CONDUCT.md). Please report concerns to
+Eran Agmon at `agmon@uchc.edu`.


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` routing review requests to @eagmon for biological process code (`processes/`, `steps/`), the type system (`types/`), composite wiring (`composite*.py`, `generate*.py`), CI (`.github/`, `pyproject.toml`), and fixtures.
- Adds `CONTRIBUTING.md` with setup, test commands, PR checklist, and the project's load-bearing rules (bigraph-schema JSON save states, pint at process boundaries, behavior test required for new processes, three-architecture consistency).
- Adds `AGENTS.md` with LLM-focused guidance: process-bigraph/bigraph-schema primers, the five required checks for new processes (schema round-trip, port contract, units, conservation, behavior test), E. coli domain context (EcoCyc, ParCa), reports, tests, and an explicit "do NOT" list.
- Adds `CLAUDE.md` as a one-line pointer to `AGENTS.md`.

## Follow-ups (separate tracking issue)
- `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1).
- PR scope enforcement (label-based path allowlist + structured scope declaration) to guard against LLM-authored scope creep.
- CI invariant checks (pickle/dill grep-lint, unit-boundary lint, mypy on `types/`).
- Coverage threshold, conservation invariant property tests, supply-chain scanning, PR-summary bot.

## Test plan
- [ ] Merge and confirm GitHub auto-requests @eagmon on a subsequent PR touching `v2ecoli/processes/`.
- [x] Confirm rendered `CONTRIBUTING.md` and `AGENTS.md` on the repo front page are readable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)