### PR TITLE
Add robustness tests, hoist imports, remove dead outputs() override

### DIFF
--- a/tests/_state_equal.py
+++ b/tests/_state_equal.py
@@ -1,0 +1,91 @@
+"""Deep equality helper for comparing simulation state trees.
+
+Used by tests that need to assert two state dicts are identical across
+round-trips (JSON save/load) or repeat runs (determinism). Handles the
+full vocabulary that shows up in v2ecoli states:
+
+  - dict, list, tuple                         — recurse
+  - numpy.ndarray (incl. structured dtypes)   — dtype + shape + contents
+  - MetadataArray                              — ndarray + metadata dict
+  - pint.Quantity (incl. array magnitudes)    — units + magnitude
+  - set, bytes, None, scalars                 — direct comparison
+
+Returns (True, '') on equality, (False, reason) with a dotted path on
+mismatch so test failures localize the divergent leaf.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+
+def _arrays_equal(a: np.ndarray, b: np.ndarray) -> bool:
+    if a.dtype != b.dtype or a.shape != b.shape:
+        return False
+    if a.dtype.names:
+        return all(_arrays_equal(a[n], b[n]) for n in a.dtype.names)
+    try:
+        return bool(np.array_equal(a, b, equal_nan=True))
+    except (TypeError, ValueError):
+        return bool(np.array_equal(a, b))
+
+
+def _is_quantity(x):
+    return hasattr(x, 'magnitude') and hasattr(x, 'units')
+
+
+def deep_equal(a, b, path: str = '') -> tuple[bool, str]:
+    """Recursively compare two state values. Return (equal, reason)."""
+    # numpy first — ndarrays are not == comparable directly.
+    if isinstance(a, np.ndarray) or isinstance(b, np.ndarray):
+        if not (isinstance(a, np.ndarray) and isinstance(b, np.ndarray)):
+            return False, f'{path}: ndarray vs {type(b).__name__}'
+        ok = _arrays_equal(a, b)
+        meta_a = getattr(a, 'metadata', None)
+        meta_b = getattr(b, 'metadata', None)
+        if meta_a != meta_b:
+            return False, f'{path}: MetadataArray.metadata differs'
+        return (ok, '' if ok else f'{path}: ndarray contents differ')
+
+    if _is_quantity(a) or _is_quantity(b):
+        if not (_is_quantity(a) and _is_quantity(b)):
+            return False, f'{path}: Quantity vs {type(b).__name__}'
+        if str(a.units) != str(b.units):
+            return False, f'{path}: units differ {a.units!s} vs {b.units!s}'
+        return deep_equal(a.magnitude, b.magnitude, f'{path}.magnitude')
+
+    if isinstance(a, dict):
+        if not isinstance(b, dict):
+            return False, f'{path}: dict vs {type(b).__name__}'
+        if set(a) != set(b):
+            only_a = set(a) - set(b)
+            only_b = set(b) - set(a)
+            return False, f'{path}: key diff only_a={only_a} only_b={only_b}'
+        for k in a:
+            ok, reason = deep_equal(a[k], b[k], f'{path}.{k}')
+            if not ok:
+                return False, reason
+        return True, ''
+
+    if isinstance(a, (list, tuple)):
+        if type(a) is not type(b):
+            return False, f'{path}: {type(a).__name__} vs {type(b).__name__}'
+        if len(a) != len(b):
+            return False, f'{path}: length {len(a)} vs {len(b)}'
+        for i, (x, y) in enumerate(zip(a, b)):
+            ok, reason = deep_equal(x, y, f'{path}[{i}]')
+            if not ok:
+                return False, reason
+        return True, ''
+
+    if isinstance(a, set):
+        if not isinstance(b, set) or a != b:
+            return False, f'{path}: set contents differ'
+        return True, ''
+
+    if isinstance(a, (float, np.floating)) and isinstance(b, (float, np.floating)):
+        if np.isnan(a) and np.isnan(b):
+            return True, ''
+        return (a == b, '' if a == b else f'{path}: {a!r} != {b!r}')
+
+    ok = a == b
+    return (ok, '' if ok else f'{path}: {a!r} != {b!r}')

--- a/tests/test_pickle_allowlist.py
+++ b/tests/test_pickle_allowlist.py
@@ -1,0 +1,140 @@
+"""Pickle/dill/cloudpickle allowlist.
+
+AGENTS.md:112-114 bans pickle, dill, and cloudpickle from save-state paths.
+The only exceptions are ParCa-cache and parameter-compilation artifacts.
+
+This test scans `v2ecoli/` for any import of pickle/dill/cloudpickle and
+fails if a file appears that isn't in ALLOWLIST (for individual files) or
+under an allowlisted package prefix. It catches three kinds of import:
+
+  * ``import pickle``
+  * ``from pickle import ...``
+  * ``__import__('pickle')``  (and same for dill, cloudpickle)
+
+To legitimately add an import, add the path to ALLOWLIST with a one-line
+justification — future reviewers can judge whether the exception holds.
+"""
+from __future__ import annotations
+
+import ast
+import os
+from pathlib import Path
+
+import pytest
+
+
+pytestmark = pytest.mark.fast
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+V2ECOLI_DIR = REPO_ROOT / 'v2ecoli'
+
+BANNED = frozenset({'pickle', 'dill', 'cloudpickle'})
+
+# File-level allowlist (paths relative to v2ecoli/). Value explains why.
+ALLOWLIST: dict[str, str] = {
+    'composite.py':
+        'loads ParCa sim_data_cache.dill (ParCa cache — AGENTS.md:114 exception)',
+    'bridge.py':
+        'loads ParCa sim_data_cache.dill',
+    'library/sim_data.py':
+        'loads ParCa-produced sim_data pickle; dill for compiled rate fns',
+    'library/ecoli_step.py':
+        'loads config_defaults.pickle (ParCa-derived defaults)',
+    'library/function_registry.py':
+        'base64-dill for compiled rate functions (parameter compilation)',
+}
+
+# Package-prefix allowlist (paths starting with these are ParCa internal,
+# blanket-allowed per AGENTS.md:113).
+ALLOWED_PREFIXES: tuple[str, ...] = (
+    'processes/parca/',
+)
+
+
+def _banned_imports(tree: ast.AST) -> list[str]:
+    """Return the sorted set of BANNED module names imported anywhere in
+    the AST. Catches top-level and nested imports as well as __import__."""
+    found: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                root = alias.name.split('.')[0]
+                if root in BANNED:
+                    found.add(root)
+        elif isinstance(node, ast.ImportFrom):
+            if node.module:
+                root = node.module.split('.')[0]
+                if root in BANNED:
+                    found.add(root)
+        elif isinstance(node, ast.Call):
+            func = node.func
+            name = (
+                func.id if isinstance(func, ast.Name)
+                else func.attr if isinstance(func, ast.Attribute) else None
+            )
+            if name == '__import__' and node.args:
+                arg = node.args[0]
+                if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                    root = arg.value.split('.')[0]
+                    if root in BANNED:
+                        found.add(root)
+    return sorted(found)
+
+
+def _scan() -> dict[str, list[str]]:
+    """Return {relative_path: [imported_banned_modules]} for every .py
+    file under v2ecoli/ that imports at least one banned module."""
+    offenders: dict[str, list[str]] = {}
+    for dirpath, _dirnames, filenames in os.walk(V2ECOLI_DIR):
+        for fn in filenames:
+            if not fn.endswith('.py'):
+                continue
+            full = Path(dirpath) / fn
+            rel = str(full.relative_to(V2ECOLI_DIR))
+            try:
+                tree = ast.parse(full.read_text())
+            except (SyntaxError, UnicodeDecodeError):
+                continue
+            banned = _banned_imports(tree)
+            if banned:
+                offenders[rel] = banned
+    return offenders
+
+
+def _is_allowed(rel_path: str) -> bool:
+    norm = rel_path.replace(os.sep, '/')
+    if norm in ALLOWLIST:
+        return True
+    return any(norm.startswith(prefix) for prefix in ALLOWED_PREFIXES)
+
+
+# Scan once at module load; both tests query the same result.
+_OFFENDERS: dict[str, list[str]] = _scan()
+
+
+def test_no_new_pickle_dill_cloudpickle_imports():
+    """Every file under v2ecoli/ that imports pickle/dill/cloudpickle must
+    be in ALLOWLIST or under an allowlisted ParCa prefix. New offenders
+    mean either (a) a new ParCa-adjacent file that should be added to
+    ALLOWLIST with a justification, or (b) a save-state path regression
+    that must be rewritten onto the bigraph-schema JSON API."""
+    unexpected = {p: m for p, m in _OFFENDERS.items() if not _is_allowed(p)}
+    assert not unexpected, (
+        'New files import pickle/dill/cloudpickle without being on the '
+        'allowlist. Either rewrite using v2ecoli.cache (JSON) or add the '
+        'path to ALLOWLIST in this file with a one-line justification:\n'
+        + '\n'.join(f'  {p}: imports {mods}' for p, mods in unexpected.items())
+    )
+
+
+def test_allowlist_has_no_stale_entries():
+    """Every ALLOWLIST entry must still import a banned module. Stale
+    entries mean someone removed the pickle usage but left the exception
+    behind — clean them up so the allowlist stays informative."""
+    stale = [path for path in ALLOWLIST if path not in _OFFENDERS]
+    assert not stale, (
+        'ALLOWLIST contains paths that no longer import any banned module. '
+        'Remove them to keep the allowlist meaningful:\n'
+        + '\n'.join(f'  {p}' for p in stale)
+    )

--- a/tests/test_save_state_json_roundtrip.py
+++ b/tests/test_save_state_json_roundtrip.py
@@ -1,0 +1,110 @@
+"""Save-state JSON round-trip tests.
+
+AGENTS.md:43 and the `feedback_save_state_format` memory pin the
+save-state format to bigraph-schema JSON:
+
+    serialize(state) -> JSON -> deserialize  must reproduce the original
+
+Two layers:
+
+1. Low-level encoder — `v2ecoli.cache.save_json` / `load_json` must round-
+   trip the full tricky-type vocabulary: numpy arrays (1D and structured),
+   pint Quantities (scalar and array), sets, bytes, tuples. This runs
+   always (no fixture required) so a broken encoder fails fast in CI.
+
+2. Whole-state — `save_initial_state` / `load_initial_state` must round-
+   trip the blessed pre-division fixture. Skipped if the fixture is not
+   present (via the `predivision_state` fixture in conftest.py).
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from v2ecoli.cache import (
+    load_initial_state, load_json, save_initial_state, save_json,
+)
+from v2ecoli.types.quantity import ureg
+
+from _state_equal import deep_equal
+
+
+pytestmark = pytest.mark.fast
+
+
+# ---------------------------------------------------------------------------
+# 1. Encoder round-trip over the tricky-type vocabulary.
+# ---------------------------------------------------------------------------
+
+def _synthetic_state():
+    """A dict that exercises every branch of NumpyJSONEncoder."""
+    struct_dtype = np.dtype([
+        ('id', 'i8'),
+        ('name', 'U16'),
+        ('pos', 'f8', (3,)),
+    ])
+    struct = np.array(
+        [(1, 'alpha', [0.0, 1.0, 2.0]), (2, 'beta', [3.0, 4.0, 5.0])],
+        dtype=struct_dtype,
+    )
+    return {
+        'scalar_int': 42,
+        'scalar_float': 3.14,
+        'scalar_bool': True,
+        'scalar_str': 'hello',
+        'none': None,
+        'plain_array_f64': np.arange(10, dtype=np.float64),
+        'plain_array_i32': np.array([[1, 2], [3, 4]], dtype=np.int32),
+        'structured': struct,
+        'pint_scalar': 2.5 * ureg.fg,
+        'pint_array': ureg.Quantity(np.arange(5, dtype=np.float64), 'mmol / L'),
+        'a_set': {'a', 'b', 'c'},
+        'some_bytes': b'\x00\x01\x02\xff',
+        'nested': {
+            'deep': {
+                'arr': np.array([1.0, 2.0, 3.0]),
+                'tags': ['x', 'y'],
+            },
+        },
+    }
+
+
+def test_json_encoder_roundtrips_tricky_types(tmp_path):
+    """save_json → load_json reproduces numpy arrays, pint Quantities,
+    structured dtypes, sets, bytes, and nested dicts without loss."""
+    state = _synthetic_state()
+    path = tmp_path / 'synth.json'
+    save_json(state, str(path))
+    reloaded = load_json(str(path))
+
+    ok, reason = deep_equal(state, reloaded)
+    assert ok, f'round-trip mismatch: {reason}'
+
+
+def test_json_encoder_roundtrips_gzipped(tmp_path):
+    """The .gz extension activates gzip transparently. Mid-pipeline
+    artifacts (pre_division_state.json.gz) rely on this."""
+    state = _synthetic_state()
+    path = tmp_path / 'synth.json.gz'
+    save_json(state, str(path))
+    reloaded = load_json(str(path))
+
+    ok, reason = deep_equal(state, reloaded)
+    assert ok, f'gzipped round-trip mismatch: {reason}'
+
+
+# ---------------------------------------------------------------------------
+# 2. Whole-state round-trip on the blessed pre-division fixture.
+# ---------------------------------------------------------------------------
+
+def test_predivision_state_roundtrips(predivision_state, tmp_path):
+    """The checkpoint that tests/test_model_behavior.py resumes from must
+    round-trip losslessly through save_initial_state / load_initial_state.
+    A break here means any resumed behavior test can silently start from a
+    mutated state. Skipped by the fixture if the checkpoint is absent."""
+    out_path = tmp_path / 'predivision.json'
+    save_initial_state(predivision_state, str(out_path))
+    reloaded = load_initial_state(str(out_path))
+
+    ok, reason = deep_equal(predivision_state, reloaded)
+    assert ok, f'pre-division round-trip mismatch: {reason}'

--- a/tests/test_seed_determinism.py
+++ b/tests/test_seed_determinism.py
@@ -1,0 +1,58 @@
+"""Determinism under a fixed seed.
+
+Two independent `make_composite(cache_dir=..., seed=0)` calls, each run
+for the same duration, must produce identical simulation state. A failure
+means something in the process-bigraph graph or in v2ecoli's processes is
+reading from an unseeded source (dict iteration order, set iteration,
+hash randomization, uninitialized RNG, etc.) — a silent hazard for every
+reproducibility claim downstream.
+
+Skipped if `out/cache` is not present, matching test_architectures_grow.py.
+
+Only the baseline architecture is checked here; extend to departitioned /
+reconciled if determinism in those variants also becomes a concern.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from v2ecoli.composite import make_composite
+
+from _state_equal import deep_equal
+
+
+CACHE_DIR = 'out/cache'
+DURATION = 60.0
+
+
+pytestmark = [
+    pytest.mark.sim,
+    pytest.mark.skipif(
+        not os.path.isdir(CACHE_DIR),
+        reason=f'cache dir {CACHE_DIR!r} not present (run scripts/cache_predivision.py)',
+    ),
+]
+
+
+def _run_baseline(duration: float):
+    composite = make_composite(cache_dir=CACHE_DIR, seed=0)
+    composite.run(duration)
+    return composite.state
+
+
+def test_baseline_is_deterministic_under_fixed_seed():
+    """Two fresh baseline runs with seed=0 produce identical state after
+    the same duration. Localizes the first divergent leaf so the failure
+    message points at the nondeterministic process."""
+    state_a = _run_baseline(DURATION)
+    state_b = _run_baseline(DURATION)
+
+    ok, reason = deep_equal(state_a, state_b)
+    assert ok, (
+        f'Baseline simulation is nondeterministic under seed=0: {reason}. '
+        f'The first divergent leaf is named above — look for unseeded RNG, '
+        f'dict/set iteration order, or hash-dependent ordering in that '
+        f'process or upstream producer.'
+    )

--- a/v2ecoli/bridge.py
+++ b/v2ecoli/bridge.py
@@ -25,6 +25,12 @@ Usage in a multi_cell document::
     }
 """
 
+import math
+import os
+import traceback
+
+import dill
+import numpy as np
 from process_bigraph import Process, Composite
 
 
@@ -64,7 +70,6 @@ class EcoliWCM(Process):
         from v2ecoli.cache import load_initial_state
         # Import types to trigger resolve dispatch registration
         import v2ecoli.types  # noqa: F401
-        import dill, os
 
         cache_dir = self.config.get('cache_dir', '') or 'out/cache'
         seed = int(self.config.get('seed', 0))
@@ -100,7 +105,6 @@ class EcoliWCM(Process):
 
     def _read_chromosome_state(self):
         """Extract chromosome state snapshot for visualization."""
-        import numpy as np
         cell = self._composite.state.get('agents', {}).get('0', self._composite.state)
         unique = cell.get('unique', {})
 
@@ -164,7 +168,6 @@ class EcoliWCM(Process):
 
         # Compute length from volume using capsule geometry:
         # V = (4/3)πr³ + πr²a, l = a + 2r
-        import math
         radius = 0.5  # µm, E. coli radius
         if cur_volume > 0:
             vol_um3 = cur_volume  # volume in fL ≈ µm³
@@ -196,7 +199,6 @@ class EcoliWCM(Process):
             try:
                 self._build_composite()
             except Exception as e:
-                import traceback
                 print(f"[EcoliWCM] _build_composite failed: {e}")
                 traceback.print_exc()
                 return {'mass': 0.0, 'volume': 0.0, 'exchange': {}}
@@ -273,7 +275,6 @@ class EcoliWCM(Process):
             mx, my = 15.0, 15.0
         mother_angle = float(state.get('angle', 0))
 
-        import math
         offset = 1.5  # µm apart
         dx = offset * math.cos(mother_angle)
         dy = offset * math.sin(mother_angle)

--- a/v2ecoli/bridge.py
+++ b/v2ecoli/bridge.py
@@ -57,13 +57,6 @@ class EcoliWCM(Process):
             'angle': 'float',
         }
 
-    def outputs(self):
-        return {
-            'mass': 'float',
-            'volume': 'float',
-            'exchange': 'map[float]',
-        }
-
     def _build_composite(self):
         """Lazily construct the internal v2ecoli Composite with bridge."""
         from v2ecoli.composite import _build_core

--- a/v2ecoli/cache.py
+++ b/v2ecoli/cache.py
@@ -14,6 +14,10 @@ import json
 
 import numpy as np
 
+from v2ecoli.library.schema import MetadataArray
+from v2ecoli.library.unit_bridge import unum_to_pint
+from v2ecoli.types.quantity import ureg
+
 
 class NumpyJSONEncoder(json.JSONEncoder):
     """JSON encoder that handles numpy types."""
@@ -52,7 +56,6 @@ class NumpyJSONEncoder(json.JSONEncoder):
         if isinstance(obj, bytes):
             return {'__bytes__': True, 'data': obj.hex()}
         # Both Unum and pint round-trip through pint via the bridge.
-        from v2ecoli.library.unit_bridge import unum_to_pint
         q = unum_to_pint(obj)
         if hasattr(q, 'magnitude') and hasattr(q, 'units'):
             mag = q.magnitude
@@ -88,7 +91,6 @@ def numpy_json_hook(obj):
         if obj.get('__bytes__'):
             return bytes.fromhex(obj['data'])
         if obj.get('__pint__') or obj.get('__pint_array__'):
-            from v2ecoli.types.quantity import ureg
             mag = obj.get('magnitude', obj.get('value'))
             if obj.get('__pint_array__'):
                 mag = np.array(mag)
@@ -169,7 +171,6 @@ def save_initial_state(initial_state, path='out/initial_state.json'):
 
 def load_initial_state(path='out/initial_state.json'):
     """Load E. coli initial state from JSON."""
-    from v2ecoli.library.schema import MetadataArray
     state = load_json(path)
 
     # Reconstruct MetadataArray objects for unique molecules

--- a/v2ecoli/library/ecoli_step.py
+++ b/v2ecoli/library/ecoli_step.py
@@ -6,6 +6,9 @@ process-bigraph's Step/Process (config, core=) without importing
 vivarium-core.
 """
 
+import os
+
+import dill
 from process_bigraph import Step, Process
 
 
@@ -38,8 +41,6 @@ def _defaults_from_schema(config_schema):
 
 def _load_pickle(name):
     """Load a pickle from the library directory."""
-    import os
-    import dill
     path = os.path.join(os.path.dirname(__file__), name)
     if os.path.exists(path):
         with open(path, 'rb') as f:

--- a/v2ecoli/steps/exchange_data.py
+++ b/v2ecoli/steps/exchange_data.py
@@ -1,5 +1,7 @@
+from v2ecoli.library.unit_bridge import unum_to_pint
 from v2ecoli.steps.base import V2Step as Step
 from v2ecoli.types.quantity import ureg as units
+from v2ecoli.types.stores import InPlaceDict, ListenerStore
 
 
 class ExchangeData(Step):
@@ -25,14 +27,12 @@ class ExchangeData(Step):
         self.environment_molecules = self.parameters.get("environment_molecules", [])
 
     def inputs(self):
-        from v2ecoli.types.stores import InPlaceDict, ListenerStore
         return {
             "boundary": InPlaceDict(),
             "environment": ListenerStore(),
         }
 
     def outputs(self):
-        from v2ecoli.types.stores import InPlaceDict, ListenerStore
         return {
             "boundary": InPlaceDict(),
             "environment": ListenerStore(),
@@ -42,7 +42,6 @@ class ExchangeData(Step):
         # Set exchange constraints for metabolism. Convert any unit-bearing
         # values (Unum or pint) to plain float magnitudes in their native unit
         # to avoid cross-registry comparison errors after dill round-trips.
-        from v2ecoli.library.unit_bridge import unum_to_pint
         env_concs = {}
         for mol in self.environment_molecules:
             q = unum_to_pint(states["boundary"]["external"][mol])

--- a/v2ecoli/steps/media_update.py
+++ b/v2ecoli/steps/media_update.py
@@ -1,6 +1,7 @@
 import numpy as np
 from v2ecoli.steps.base import V2Step as Step
 from v2ecoli.types.quantity import ureg as units
+from v2ecoli.types.stores import InPlaceDict
 
 
 class MediaUpdate(Step):
@@ -30,11 +31,9 @@ class MediaUpdate(Step):
         self.curr_media_id = self.parameters.get("media_id", "minimal")
 
     def inputs(self):
-        from v2ecoli.types.stores import InPlaceDict
         return {"boundary": InPlaceDict(), "environment": InPlaceDict()}
 
     def outputs(self):
-        from v2ecoli.types.stores import InPlaceDict
         return {"boundary": InPlaceDict(), "environment": InPlaceDict()}
 
     def next_update(self, timestep, states):


### PR DESCRIPTION
## Summary

Closes three AGENTS.md invariants that had no test backing, plus small cleanup on the side.

- **Save-state JSON round-trip** (AGENTS.md:43). `test_save_state_json_roundtrip.py` exercises the full `NumpyJSONEncoder` vocabulary (ndarray, structured dtypes, pint `Quantity`, set, bytes, nested dicts) and round-trips the blessed `pre_division_state` fixture through `save_initial_state` / `load_initial_state`.
- **Pickle/dill/cloudpickle allowlist** (AGENTS.md:112-114). `test_pickle_allowlist.py` is a static AST scan over `v2ecoli/` that fails on any new import outside the five allowlisted ParCa-cache paths or the `processes/parca/` prefix. A companion test rejects stale allowlist entries.
- **Seed determinism.** `test_seed_determinism.py` runs `make_composite(seed=0)` twice and deep-equals the full state after 60 s; pinpoints the first divergent leaf on failure (unseeded RNG, dict/set iteration, hash randomization). Skips if `out/cache` is not present, matching `test_architectures_grow.py`.
- Shared `_state_equal.py` helper walks dicts, lists, ndarrays (incl. structured and `MetadataArray`), pint Quantities, sets, bytes, and scalars; returns `(ok, reason)` with a dotted path so failures localize.
- Remove shadowed `EcoliWCM.outputs()` in `bridge.py` (first definition dead; second already in use).
- Hoist method-level imports to module top in `bridge.py`, `cache.py`, `library/ecoli_step.py`, `steps/media_update.py`, `steps/exchange_data.py`. Deferred imports in `EcoliWCM._build_composite` (`v2ecoli.composite`/`generate`/`cache`/`types` and `multi_cell.processes`) are intentionally left deferred per the class docstring — avoids triggering the full v2ecoli import chain at bigraph-schema discovery time.

Intentionally out of scope (flagged for a focused follow-up):
- Lazy registration in `types/__init__.py` (established pattern, risky to change here).
- `FEATURE_MODULES` dedup across `generate*.py`.
- `composite_departitioned.py` + `composite_reconciled.py` factory unify.

## Test plan

- [x] `pytest -m "not sim and not slow"` — 88 passing, 7 pre-existing failures (Cython `make clean compile` and two `test_initialize` that fail on `main` identically; verified via stash-compare).
- [x] New fast tests pass: `test_pickle_allowlist.py` (2), `test_save_state_json_roundtrip.py` (3).
- [ ] `test_seed_determinism.py` — runs in CI behavior-tests job where `out/cache` is populated; tight deep-equal may need a tolerance if CI reveals floating-point nondeterminism.
- [ ] Confirm CI passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)