### PR TITLE
Wire perform_update gate — restore tick-skip logic for 14+ listeners/steps

### DIFF
--- a/tests/test_perform_update_gate.py
+++ b/tests/test_perform_update_gate.py
@@ -1,0 +1,107 @@
+"""Tests for the EcoliStep.perform_update gate.
+
+Pins the contract that:
+
+  1. By default, `invoke` calls `update` — the base `perform_update`
+     returns True.
+  2. When a subclass overrides `perform_update` to return False,
+     `invoke` short-circuits with an empty update and does NOT call
+     `update` (no hot-path work, no state changes).
+  3. `perform_update` receives the same `state` dict that `invoke`
+     was called with, so subclasses can gate on `global_time`,
+     `timestep`, or any other port value.
+
+This is the gate machinery ported from vEcoli composite-branch
+commit 35003119. Listeners that define a legacy
+`update_condition(timestep, states)` were previously dead code in
+v2ecoli because `invoke` never consulted them; moving the logic into
+`perform_update` restores the intended skip-on-non-emit-tick
+behavior.
+"""
+from __future__ import annotations
+
+import pytest
+
+from v2ecoli.library.ecoli_step import EcoliStep
+
+
+pytestmark = pytest.mark.fast
+
+
+class _CountingStep(EcoliStep):
+    """Test double: records every update() call and whether it ran."""
+
+    config_schema = {}
+
+    def initialize(self, config):
+        self.update_calls = 0
+        self.last_state = None
+
+    def update(self, state, interval=None):
+        self.update_calls += 1
+        self.last_state = state
+        return {'ran': True}
+
+
+class _GatedStep(_CountingStep):
+    """A step that only runs when `state['gate']` is truthy."""
+
+    def perform_update(self, state):
+        return bool(state.get('gate', False))
+
+
+class _TimestepGatedStep(_CountingStep):
+    """Listener-style gate: run only when global_time is a timestep multiple."""
+
+    def perform_update(self, state):
+        global_t = state.get('global_time')
+        timestep = state.get('timestep')
+        if global_t is None or timestep is None or timestep == 0:
+            return True
+        return (global_t % timestep) == 0
+
+
+def test_default_perform_update_is_true():
+    """A step that doesn't override perform_update always runs."""
+    step = _CountingStep(parameters={})
+    result = step.invoke({'foo': 1}, interval=1.0)
+
+    assert step.update_calls == 1
+    # SyncUpdate wraps the return value; the inner dict is what update returned
+    assert result.update == {'ran': True}
+
+
+def test_perform_update_false_skips_update():
+    """When perform_update returns False, invoke returns an empty update
+    and the update() body is not executed."""
+    step = _GatedStep(parameters={})
+    result = step.invoke({'gate': False}, interval=1.0)
+
+    assert step.update_calls == 0
+    assert step.last_state is None
+    assert result.update == {}
+
+
+def test_perform_update_true_runs_update():
+    """Sanity: when perform_update returns True, update runs normally."""
+    step = _GatedStep(parameters={})
+    result = step.invoke({'gate': True}, interval=1.0)
+
+    assert step.update_calls == 1
+    assert result.update == {'ran': True}
+
+
+def test_perform_update_sees_invoke_state():
+    """The state dict passed to invoke reaches perform_update unchanged —
+    so subclasses can gate on global_time/timestep/etc."""
+    step = _TimestepGatedStep(parameters={})
+
+    # global_time=10, timestep=5 → 10 % 5 == 0 → runs.
+    r1 = step.invoke({'global_time': 10.0, 'timestep': 5.0}, interval=1.0)
+    assert step.update_calls == 1
+    assert r1.update == {'ran': True}
+
+    # global_time=13, timestep=5 → 13 % 5 == 3 → skipped.
+    r2 = step.invoke({'global_time': 13.0, 'timestep': 5.0}, interval=1.0)
+    assert step.update_calls == 1  # unchanged
+    assert r2.update == {}

--- a/tests/test_perform_update_gate.py
+++ b/tests/test_perform_update_gate.py
@@ -91,6 +91,47 @@ def test_perform_update_true_runs_update():
     assert result.update == {'ran': True}
 
 
+class _LegacyUpdateConditionStep(_CountingStep):
+    """Legacy vivarium-v1 pattern: defines update_condition, not perform_update.
+    The base EcoliStep.perform_update must auto-delegate."""
+
+    def update_condition(self, timestep, states):
+        return bool(states.get('gate', False))
+
+
+def test_perform_update_delegates_to_legacy_update_condition():
+    """The 11+ v2ecoli listeners that still define
+    `update_condition(timestep, states)` should have their gates
+    honored without any per-listener migration — the base
+    `perform_update` walks the MRO and delegates."""
+    step = _LegacyUpdateConditionStep(parameters={})
+
+    r_skip = step.invoke({'gate': False}, interval=1.0)
+    assert step.update_calls == 0
+    assert r_skip.update == {}
+
+    r_run = step.invoke({'gate': True}, interval=1.0)
+    assert step.update_calls == 1
+    assert r_run.update == {'ran': True}
+
+
+def test_perform_update_override_beats_update_condition():
+    """If a subclass defines both, perform_update wins (explicit over
+    legacy) because the base delegation is only reached via super()."""
+
+    class _BothStep(_CountingStep):
+        def update_condition(self, timestep, states):
+            # Would skip — but perform_update override should win.
+            return False
+
+        def perform_update(self, state):
+            return True
+
+    step = _BothStep(parameters={})
+    step.invoke({}, interval=1.0)
+    assert step.update_calls == 1
+
+
 def test_perform_update_sees_invoke_state():
     """The state dict passed to invoke reaches perform_update unchanged —
     so subclasses can gate on global_time/timestep/etc."""

--- a/v2ecoli/library/ecoli_step.py
+++ b/v2ecoli/library/ecoli_step.py
@@ -148,14 +148,24 @@ class EcoliStep(Step):
     def perform_update(self, state):
         """Gate for step execution. Return True to run, False to skip.
 
-        Default always runs. Override to implement variable-timestep
-        listeners (e.g. run every N seconds of simulated time) without
-        paying the cost of the full update body on skipped ticks. Ported
-        from upstream vEcoli composite-branch commit 35003119 — the v1
-        `update_condition(timestep, states)` that several v2ecoli
-        listeners still define was never consulted by v2ecoli's invoke
-        path, so those ticks ran unconditionally.
+        Default behavior: if a subclass defines the legacy
+        `update_condition(self, timestep, states)` method (11+
+        listeners still do), delegate to it — vEcoli's v1 gate was
+        dead code in v2ecoli until this commit because `invoke` never
+        consulted it. Otherwise always run. Override directly for
+        custom gating on any port value.
+
+        Ported from upstream vEcoli composite-branch commit 35003119;
+        the method name differs from v1's `update_condition` to avoid
+        collision on classes that might dual-inherit from both the v1
+        and v2 stacks.
         """
+        for klass in type(self).__mro__:
+            if klass is EcoliStep:
+                break
+            if 'update_condition' in klass.__dict__:
+                timestep = state.get('timestep', 1)
+                return klass.__dict__['update_condition'](self, timestep, state)
         return True
 
     def invoke(self, state, interval=None):

--- a/v2ecoli/library/ecoli_step.py
+++ b/v2ecoli/library/ecoli_step.py
@@ -145,8 +145,23 @@ class EcoliStep(Step):
         """Auto-extract ``_default`` values from ``inputs()``."""
         return _extract_defaults(self.inputs())
 
+    def perform_update(self, state):
+        """Gate for step execution. Return True to run, False to skip.
+
+        Default always runs. Override to implement variable-timestep
+        listeners (e.g. run every N seconds of simulated time) without
+        paying the cost of the full update body on skipped ticks. Ported
+        from upstream vEcoli composite-branch commit 35003119 — the v1
+        `update_condition(timestep, states)` that several v2ecoli
+        listeners still define was never consulted by v2ecoli's invoke
+        path, so those ticks ran unconditionally.
+        """
+        return True
+
     def invoke(self, state, interval=None):
         from process_bigraph.composite import SyncUpdate
+        if not self.perform_update(state):
+            return SyncUpdate({})
         update = self.update(state, interval)
         return SyncUpdate(update)
 


### PR DESCRIPTION
## Summary

Ports the step-execution gate from upstream vEcoli composite-branch commit `35003119` into v2ecoli, with a delegation twist that avoids touching any listener files.

**The problem:** v2ecoli's 14+ listener/step classes define a legacy `update_condition(self, timestep, states) -> bool` method (mass_listener, ribosome_data, rnap_data, rna_counts, rna_synth_prob, monomer_counts, replication_data, dna_supercoiling, unique_molecule_counts, partition, departitioned, reconciled, tf_binding, tf_unbinding, chromosome_structure, metabolism — also `PostDivisionMassListener`). But v2ecoli's `EcoliStep.invoke` never consulted it. Every listener ran its full `update()` body every tick regardless of the intended emit cadence. The `update_condition` methods were effectively dead code.

**The fix:**

1. Add `perform_update(self, state) -> bool` to `EcoliStep` (default: `True`).
2. Gate `invoke` on `perform_update` before calling `self.update(...)` — a False return yields an empty `SyncUpdate({})` and skips the update body entirely.
3. Have the base `perform_update` walk the subclass MRO and delegate to the legacy `update_condition(1, state)` when a subclass defines one. No per-listener file changes required.

## Why delegate instead of renaming 14 methods

Single source of truth, low-risk: zero diffs in listener files, one small method on `EcoliStep` is the full change (alongside tests). Any new listener that defines `update_condition` auto-opts into the gate. Explicit `perform_update` overrides still win (an override on the subclass is reached before the base delegation).

## Not addressed here (on purpose)

- **The `update_condition` methods themselves** remain in place. Some pass `timestep` explicitly; I pass `state.get('timestep', 1)`. If any existing body depends on the actual ParCa-tuned timestep rather than what's in `state['timestep']`, that's a correctness concern to chase separately. A future PR could migrate listeners to define `perform_update` directly and drop the delegation.
- **Perf measurement:** the gain depends on how often listeners' update bodies were formerly no-ops vs. real work per tick. Not measured here — this PR restores documented behavior that was silently broken.

## Test plan

- [x] `pytest tests/test_perform_update_gate.py -v` — 6/6 pass covering: default returns True, False skips, True runs, legacy `update_condition` delegation, explicit `perform_update` override beats inherited `update_condition`, state dict reaches `perform_update` unchanged.
- [x] `pytest -m "not sim and not slow"` — 94 passing, 7 pre-existing Cython failures unchanged (verified no new regressions).
- [ ] CI passes — behavior tests (`test_architectures_grow`, `test_model_behavior`) will exercise the real gate path with listener subclasses that define `update_condition`.

## Audit context

This was flagged as one of two perf-relevant commits on vEcoli's `composite` branch worth porting to v2ecoli (see `35003119 perform update`). The other (`8a32e3dc unique array apply`) was declined because vEcoli and v2ecoli use architecturally different unique-array update paths — porting the fix would be a design change, not a copy-paste.

🤖 Generated with [Claude Code](https://claude.com/claude-code)