### PR TITLE
Add `models/parca.pbg`: structural JSON document of the 9-Step pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,11 @@ rather than threaded through a deeply-mutated `sim_data` blob.
 The per-step port manifests ship in
 [`v2ecoli/processes/parca/steps/`](v2ecoli/processes/parca/steps/); the
 wire table is [`STORE_PATH`](v2ecoli/processes/parca/composite.py).
+A static [`models/parca.pbg`](models/parca.pbg) (~16 KB) captures the
+same 9-Step pipeline as a process-bigraph JSON document — addresses +
+port wiring, no fitted data — for tooling that wants to inspect the
+pipeline shape without importing v2ecoli.  Regenerated automatically
+by `python reports/workflow_report.py` alongside `models/partitioned.pbg`.
 
 ### Using the fitted `sim_data`
 

--- a/models/parca.pbg
+++ b/models/parca.pbg
@@ -1,0 +1,811 @@
+{
+  "global_time": 0.0,
+  "initialize": {
+    "_type": "step",
+    "address": "local:InitializeStep",
+    "inputs": {},
+    "outputs": {
+      "tick_1": [
+        "tick_1"
+      ],
+      "transcription": [
+        "process",
+        "transcription"
+      ],
+      "translation": [
+        "process",
+        "translation"
+      ],
+      "metabolism": [
+        "process",
+        "metabolism"
+      ],
+      "rna_decay": [
+        "process",
+        "rna_decay"
+      ],
+      "complexation": [
+        "process",
+        "complexation"
+      ],
+      "equilibrium": [
+        "process",
+        "equilibrium"
+      ],
+      "two_component_system": [
+        "process",
+        "two_component_system"
+      ],
+      "transcription_regulation": [
+        "process",
+        "transcription_regulation"
+      ],
+      "replication": [
+        "process",
+        "replication"
+      ],
+      "mass": [
+        "mass"
+      ],
+      "constants": [
+        "constants"
+      ],
+      "growth_rate_parameters": [
+        "growth_rate_parameters"
+      ],
+      "adjustments": [
+        "adjustments"
+      ],
+      "molecule_groups": [
+        "molecule_groups"
+      ],
+      "molecule_ids": [
+        "molecule_ids"
+      ],
+      "relation": [
+        "relation"
+      ],
+      "getter": [
+        "getter"
+      ],
+      "bulk_molecules": [
+        "internal_state",
+        "bulk_molecules"
+      ],
+      "external_state": [
+        "external_state"
+      ],
+      "sim_data_root": [
+        "sim_data_root"
+      ],
+      "tf_to_active_inactive_conditions": [
+        "tf_to_active_inactive_conditions"
+      ],
+      "conditions": [
+        "conditions"
+      ],
+      "condition_to_doubling_time": [
+        "condition_to_doubling_time"
+      ],
+      "tf_to_fold_change": [
+        "tf_to_fold_change"
+      ],
+      "tf_to_direction": [
+        "tf_to_direction"
+      ],
+      "condition_active_tfs": [
+        "condition_active_tfs"
+      ],
+      "condition_inactive_tfs": [
+        "condition_inactive_tfs"
+      ],
+      "cell_specs": [
+        "cell_specs"
+      ],
+      "translation_supply_rate": [
+        "translation_supply_rate"
+      ],
+      "expected_dry_mass_increase_dict": [
+        "expected_dry_mass_increase_dict"
+      ],
+      "pPromoterBound": [
+        "pPromoterBound"
+      ],
+      "condition": [
+        "condition"
+      ]
+    }
+  },
+  "input_adjustments": {
+    "_type": "step",
+    "address": "local:InputAdjustmentsStep",
+    "inputs": {
+      "tick_1": [
+        "tick_1"
+      ],
+      "transcription": [
+        "process",
+        "transcription"
+      ],
+      "translation": [
+        "process",
+        "translation"
+      ],
+      "adjustments": [
+        "adjustments"
+      ],
+      "tf_to_active_inactive_conditions": [
+        "tf_to_active_inactive_conditions"
+      ]
+    },
+    "outputs": {
+      "tick_2": [
+        "tick_2"
+      ],
+      "transcription": [
+        "process",
+        "transcription"
+      ],
+      "translation": [
+        "process",
+        "translation"
+      ],
+      "tf_to_active_inactive_conditions": [
+        "tf_to_active_inactive_conditions"
+      ]
+    }
+  },
+  "basal_specs": {
+    "_type": "step",
+    "address": "local:BasalSpecsStep",
+    "inputs": {
+      "tick_2": [
+        "tick_2"
+      ],
+      "transcription": [
+        "process",
+        "transcription"
+      ],
+      "translation": [
+        "process",
+        "translation"
+      ],
+      "metabolism": [
+        "process",
+        "metabolism"
+      ],
+      "rna_decay": [
+        "process",
+        "rna_decay"
+      ],
+      "complexation": [
+        "process",
+        "complexation"
+      ],
+      "replication": [
+        "process",
+        "replication"
+      ],
+      "mass": [
+        "mass"
+      ],
+      "constants": [
+        "constants"
+      ],
+      "growth_rate_parameters": [
+        "growth_rate_parameters"
+      ],
+      "molecule_groups": [
+        "molecule_groups"
+      ],
+      "molecule_ids": [
+        "molecule_ids"
+      ],
+      "relation": [
+        "relation"
+      ],
+      "getter": [
+        "getter"
+      ],
+      "bulk_molecules": [
+        "internal_state",
+        "bulk_molecules"
+      ],
+      "sim_data_root": [
+        "sim_data_root"
+      ],
+      "condition_to_doubling_time": [
+        "condition_to_doubling_time"
+      ],
+      "cell_specs": [
+        "cell_specs"
+      ]
+    },
+    "outputs": {
+      "tick_3": [
+        "tick_3"
+      ],
+      "transcription": [
+        "process",
+        "transcription"
+      ],
+      "mass": [
+        "mass"
+      ],
+      "constants": [
+        "constants"
+      ],
+      "rna_decay": [
+        "process",
+        "rna_decay"
+      ],
+      "cell_specs": [
+        "cell_specs"
+      ]
+    }
+  },
+  "tf_condition_specs": {
+    "_type": "step",
+    "address": "local:TfConditionSpecsStep",
+    "inputs": {
+      "tick_3": [
+        "tick_3"
+      ],
+      "transcription": [
+        "process",
+        "transcription"
+      ],
+      "translation": [
+        "process",
+        "translation"
+      ],
+      "metabolism": [
+        "process",
+        "metabolism"
+      ],
+      "rna_decay": [
+        "process",
+        "rna_decay"
+      ],
+      "complexation": [
+        "process",
+        "complexation"
+      ],
+      "equilibrium": [
+        "process",
+        "equilibrium"
+      ],
+      "two_component_system": [
+        "process",
+        "two_component_system"
+      ],
+      "transcription_regulation": [
+        "process",
+        "transcription_regulation"
+      ],
+      "replication": [
+        "process",
+        "replication"
+      ],
+      "mass": [
+        "mass"
+      ],
+      "constants": [
+        "constants"
+      ],
+      "growth_rate_parameters": [
+        "growth_rate_parameters"
+      ],
+      "molecule_groups": [
+        "molecule_groups"
+      ],
+      "molecule_ids": [
+        "molecule_ids"
+      ],
+      "relation": [
+        "relation"
+      ],
+      "getter": [
+        "getter"
+      ],
+      "bulk_molecules": [
+        "internal_state",
+        "bulk_molecules"
+      ],
+      "sim_data_root": [
+        "sim_data_root"
+      ],
+      "tf_to_active_inactive_conditions": [
+        "tf_to_active_inactive_conditions"
+      ],
+      "conditions": [
+        "conditions"
+      ],
+      "condition_to_doubling_time": [
+        "condition_to_doubling_time"
+      ],
+      "tf_to_fold_change": [
+        "tf_to_fold_change"
+      ],
+      "condition_active_tfs": [
+        "condition_active_tfs"
+      ],
+      "condition_inactive_tfs": [
+        "condition_inactive_tfs"
+      ],
+      "cell_specs": [
+        "cell_specs"
+      ]
+    },
+    "outputs": {
+      "tick_4": [
+        "tick_4"
+      ],
+      "transcription": [
+        "process",
+        "transcription"
+      ],
+      "cell_specs": [
+        "cell_specs"
+      ]
+    }
+  },
+  "fit_condition": {
+    "_type": "step",
+    "address": "local:FitConditionStep",
+    "inputs": {
+      "tick_4": [
+        "tick_4"
+      ],
+      "transcription": [
+        "process",
+        "transcription"
+      ],
+      "translation": [
+        "process",
+        "translation"
+      ],
+      "complexation": [
+        "process",
+        "complexation"
+      ],
+      "equilibrium": [
+        "process",
+        "equilibrium"
+      ],
+      "two_component_system": [
+        "process",
+        "two_component_system"
+      ],
+      "mass": [
+        "mass"
+      ],
+      "constants": [
+        "constants"
+      ],
+      "growth_rate_parameters": [
+        "growth_rate_parameters"
+      ],
+      "molecule_ids": [
+        "molecule_ids"
+      ],
+      "relation": [
+        "relation"
+      ],
+      "molecule_groups": [
+        "molecule_groups"
+      ],
+      "getter": [
+        "getter"
+      ],
+      "bulk_molecules": [
+        "internal_state",
+        "bulk_molecules"
+      ],
+      "sim_data_root": [
+        "sim_data_root"
+      ],
+      "conditions": [
+        "conditions"
+      ],
+      "cell_specs": [
+        "cell_specs"
+      ]
+    },
+    "outputs": {
+      "tick_5": [
+        "tick_5"
+      ],
+      "cell_specs": [
+        "cell_specs"
+      ],
+      "translation_supply_rate": [
+        "translation_supply_rate"
+      ]
+    }
+  },
+  "promoter_binding": {
+    "_type": "step",
+    "address": "local:PromoterBindingStep",
+    "inputs": {
+      "tick_5": [
+        "tick_5"
+      ],
+      "transcription": [
+        "process",
+        "transcription"
+      ],
+      "transcription_regulation": [
+        "process",
+        "transcription_regulation"
+      ],
+      "equilibrium": [
+        "process",
+        "equilibrium"
+      ],
+      "two_component_system": [
+        "process",
+        "two_component_system"
+      ],
+      "replication": [
+        "process",
+        "replication"
+      ],
+      "mass": [
+        "mass"
+      ],
+      "constants": [
+        "constants"
+      ],
+      "molecule_ids": [
+        "molecule_ids"
+      ],
+      "molecule_groups": [
+        "molecule_groups"
+      ],
+      "relation": [
+        "relation"
+      ],
+      "getter": [
+        "getter"
+      ],
+      "bulk_molecules": [
+        "internal_state",
+        "bulk_molecules"
+      ],
+      "sim_data_root": [
+        "sim_data_root"
+      ],
+      "conditions": [
+        "conditions"
+      ],
+      "condition_to_doubling_time": [
+        "condition_to_doubling_time"
+      ],
+      "tf_to_active_inactive_conditions": [
+        "tf_to_active_inactive_conditions"
+      ],
+      "tf_to_fold_change": [
+        "tf_to_fold_change"
+      ],
+      "tf_to_direction": [
+        "tf_to_direction"
+      ],
+      "condition_active_tfs": [
+        "condition_active_tfs"
+      ],
+      "condition_inactive_tfs": [
+        "condition_inactive_tfs"
+      ],
+      "cell_specs": [
+        "cell_specs"
+      ]
+    },
+    "outputs": {
+      "tick_6": [
+        "tick_6"
+      ],
+      "transcription": [
+        "process",
+        "transcription"
+      ],
+      "transcription_regulation": [
+        "process",
+        "transcription_regulation"
+      ],
+      "cell_specs": [
+        "cell_specs"
+      ],
+      "pPromoterBound": [
+        "pPromoterBound"
+      ]
+    }
+  },
+  "adjust_promoters": {
+    "_type": "step",
+    "address": "local:AdjustPromotersStep",
+    "inputs": {
+      "tick_6": [
+        "tick_6"
+      ],
+      "transcription": [
+        "process",
+        "transcription"
+      ],
+      "transcription_regulation": [
+        "process",
+        "transcription_regulation"
+      ],
+      "equilibrium": [
+        "process",
+        "equilibrium"
+      ],
+      "two_component_system": [
+        "process",
+        "two_component_system"
+      ],
+      "metabolism": [
+        "process",
+        "metabolism"
+      ],
+      "replication": [
+        "process",
+        "replication"
+      ],
+      "mass": [
+        "mass"
+      ],
+      "constants": [
+        "constants"
+      ],
+      "molecule_ids": [
+        "molecule_ids"
+      ],
+      "molecule_groups": [
+        "molecule_groups"
+      ],
+      "relation": [
+        "relation"
+      ],
+      "getter": [
+        "getter"
+      ],
+      "bulk_molecules": [
+        "internal_state",
+        "bulk_molecules"
+      ],
+      "sim_data_root": [
+        "sim_data_root"
+      ],
+      "conditions": [
+        "conditions"
+      ],
+      "condition_to_doubling_time": [
+        "condition_to_doubling_time"
+      ],
+      "tf_to_active_inactive_conditions": [
+        "tf_to_active_inactive_conditions"
+      ],
+      "tf_to_fold_change": [
+        "tf_to_fold_change"
+      ],
+      "tf_to_direction": [
+        "tf_to_direction"
+      ],
+      "condition_active_tfs": [
+        "condition_active_tfs"
+      ],
+      "condition_inactive_tfs": [
+        "condition_inactive_tfs"
+      ],
+      "cell_specs": [
+        "cell_specs"
+      ],
+      "pPromoterBound": [
+        "pPromoterBound"
+      ]
+    },
+    "outputs": {
+      "tick_7": [
+        "tick_7"
+      ],
+      "transcription_regulation": [
+        "process",
+        "transcription_regulation"
+      ],
+      "metabolism": [
+        "process",
+        "metabolism"
+      ],
+      "equilibrium": [
+        "process",
+        "equilibrium"
+      ]
+    }
+  },
+  "set_conditions": {
+    "_type": "step",
+    "address": "local:SetConditionsStep",
+    "inputs": {
+      "tick_7": [
+        "tick_7"
+      ],
+      "transcription": [
+        "process",
+        "transcription"
+      ],
+      "translation": [
+        "process",
+        "translation"
+      ],
+      "metabolism": [
+        "process",
+        "metabolism"
+      ],
+      "mass": [
+        "mass"
+      ],
+      "constants": [
+        "constants"
+      ],
+      "growth_rate_parameters": [
+        "growth_rate_parameters"
+      ],
+      "getter": [
+        "getter"
+      ],
+      "sim_data_root": [
+        "sim_data_root"
+      ],
+      "conditions": [
+        "conditions"
+      ],
+      "condition_to_doubling_time": [
+        "condition_to_doubling_time"
+      ],
+      "cell_specs": [
+        "cell_specs"
+      ]
+    },
+    "outputs": {
+      "tick_8": [
+        "tick_8"
+      ],
+      "transcription": [
+        "process",
+        "transcription"
+      ],
+      "translation": [
+        "process",
+        "translation"
+      ],
+      "cell_specs": [
+        "cell_specs"
+      ],
+      "expected_dry_mass_increase_dict": [
+        "expected_dry_mass_increase_dict"
+      ]
+    }
+  },
+  "final_adjustments": {
+    "_type": "step",
+    "address": "local:FinalAdjustmentsStep",
+    "inputs": {
+      "tick_8": [
+        "tick_8"
+      ],
+      "transcription": [
+        "process",
+        "transcription"
+      ],
+      "translation": [
+        "process",
+        "translation"
+      ],
+      "metabolism": [
+        "process",
+        "metabolism"
+      ],
+      "complexation": [
+        "process",
+        "complexation"
+      ],
+      "equilibrium": [
+        "process",
+        "equilibrium"
+      ],
+      "two_component_system": [
+        "process",
+        "two_component_system"
+      ],
+      "transcription_regulation": [
+        "process",
+        "transcription_regulation"
+      ],
+      "replication": [
+        "process",
+        "replication"
+      ],
+      "mass": [
+        "mass"
+      ],
+      "constants": [
+        "constants"
+      ],
+      "growth_rate_parameters": [
+        "growth_rate_parameters"
+      ],
+      "molecule_ids": [
+        "molecule_ids"
+      ],
+      "molecule_groups": [
+        "molecule_groups"
+      ],
+      "relation": [
+        "relation"
+      ],
+      "getter": [
+        "getter"
+      ],
+      "bulk_molecules": [
+        "internal_state",
+        "bulk_molecules"
+      ],
+      "sim_data_root": [
+        "sim_data_root"
+      ],
+      "conditions": [
+        "conditions"
+      ],
+      "condition_to_doubling_time": [
+        "condition_to_doubling_time"
+      ],
+      "tf_to_active_inactive_conditions": [
+        "tf_to_active_inactive_conditions"
+      ],
+      "tf_to_fold_change": [
+        "tf_to_fold_change"
+      ],
+      "tf_to_direction": [
+        "tf_to_direction"
+      ],
+      "condition_active_tfs": [
+        "condition_active_tfs"
+      ],
+      "condition_inactive_tfs": [
+        "condition_inactive_tfs"
+      ],
+      "cell_specs": [
+        "cell_specs"
+      ],
+      "translation_supply_rate": [
+        "translation_supply_rate"
+      ],
+      "pPromoterBound": [
+        "pPromoterBound"
+      ],
+      "external_state": [
+        "external_state"
+      ],
+      "condition": [
+        "condition"
+      ]
+    },
+    "outputs": {
+      "tick_9": [
+        "tick_9"
+      ],
+      "transcription": [
+        "process",
+        "transcription"
+      ],
+      "metabolism": [
+        "process",
+        "metabolism"
+      ],
+      "constants": [
+        "constants"
+      ]
+    }
+  }
+}

--- a/reports/workflow_report.py
+++ b/reports/workflow_report.py
@@ -2319,10 +2319,13 @@ def run_workflow():
 
     # Update .pbg model files
     print("  Updating .pbg model files...")
-    from v2ecoli.pbg import save_pbg
+    from v2ecoli.pbg import save_pbg, save_pbg_doc
+    from v2ecoli.processes.parca.composite import build_parca_document
     os.makedirs('models', exist_ok=True)
     save_pbg(diag_composite, 'models/partitioned.pbg')
     print(f"    models/partitioned.pbg updated")
+    save_pbg_doc(build_parca_document(), 'models/parca.pbg')
+    print(f"    models/parca.pbg updated")
 
     # Network Visualization (Cytoscape.js interactive viewer)
     print("  Generating interactive network visualization...")

--- a/tests/test_parca_pbg_document.py
+++ b/tests/test_parca_pbg_document.py
@@ -1,0 +1,64 @@
+"""Drift check for ``models/parca.pbg``.
+
+The file is the structural document for the 9-Step ParCa pipeline —
+addresses + port wiring, no fitted data. It ships in-tree so other
+tooling (visualization, comparisons) can read the pipeline shape
+without importing v2ecoli at all.
+
+When STORE_PATH or any step's INPUT_PORTS / OUTPUT_PORTS changes, the
+file must be regenerated (workflow_report's `## Update .pbg model
+files` block does this automatically). This test fails fast when the
+committed file falls out of sync.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from v2ecoli.pbg import save_pbg_doc
+from v2ecoli.processes.parca.composite import (
+    STEP_ORDER, build_parca_document,
+)
+
+
+pytestmark = pytest.mark.fast
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PBG_PATH = REPO_ROOT / 'models' / 'parca.pbg'
+
+
+def test_parca_pbg_exists():
+    assert PBG_PATH.exists(), (
+        f"{PBG_PATH} is missing. Run `python reports/workflow_report.py` "
+        "or regenerate via "
+        "`save_pbg_doc(build_parca_document(), 'models/parca.pbg')`.")
+
+
+def test_parca_pbg_matches_live_spec(tmp_path):
+    """The committed .pbg must round-trip to the live spec."""
+    fresh_path = tmp_path / 'parca.pbg'
+    save_pbg_doc(build_parca_document(), str(fresh_path))
+
+    with open(PBG_PATH) as f:
+        committed = json.load(f)
+    with open(fresh_path) as f:
+        fresh = json.load(f)
+
+    assert committed == fresh, (
+        f"{PBG_PATH} is out of date with the live spec. Regenerate via "
+        "`save_pbg_doc(build_parca_document(), 'models/parca.pbg')`.")
+
+
+def test_parca_pbg_has_all_steps():
+    with open(PBG_PATH) as f:
+        doc = json.load(f)
+    for step in STEP_ORDER:
+        assert step in doc, f"missing step entry: {step}"
+        entry = doc[step]
+        assert entry.get('_type') == 'step'
+        assert entry.get('address', '').startswith('local:')
+        assert isinstance(entry.get('inputs'), dict)
+        assert isinstance(entry.get('outputs'), dict)

--- a/v2ecoli/pbg.py
+++ b/v2ecoli/pbg.py
@@ -107,6 +107,37 @@ def _serialize_array(arr):
     return arr
 
 
+def save_pbg_doc(state_dict, path):
+    """Save a flat composite state dict (no agents/0 wrapping) as .pbg JSON.
+
+    Use this for composites whose top-level state isn't wrapped in the
+    multi-cell ``agents/0`` pattern — e.g. the ParCa pipeline, where each
+    Step entry sits directly at the top level alongside data leaves.
+    Output mirrors ``save_pbg``: ``_type`` entries become {address, inputs,
+    outputs} stubs (configs stripped), nested data dicts are serialized
+    recursively, numpy arrays are JSON-friendly.
+    """
+    doc = {'global_time': 0.0}
+    for key, val in state_dict.items():
+        if isinstance(val, dict) and '_type' in val:
+            doc[key] = {
+                '_type': val.get('_type'),
+                'address': val.get('address'),
+                'inputs': _clean_wiring(val.get('inputs', {})),
+                'outputs': _clean_wiring(val.get('outputs', {})),
+            }
+        elif isinstance(val, dict):
+            doc[key] = _serialize_state(val)
+        elif hasattr(val, 'dtype'):
+            doc[key] = _serialize_array(val)
+        else:
+            doc[key] = val
+    os.makedirs(os.path.dirname(path) or '.', exist_ok=True)
+    with open(path, 'w') as f:
+        json.dump(doc, f, cls=PbgEncoder, indent=2)
+    return path
+
+
 def load_pbg(path):
     """Load a .pbg file and return the document dict."""
     with open(path) as f:

--- a/v2ecoli/processes/parca/composite.py
+++ b/v2ecoli/processes/parca/composite.py
@@ -80,41 +80,20 @@ def _wires(port_names):
     return {name: STORE_PATH[name] for name in port_names}
 
 
-def build_parca_composite(raw_data, debug=False, cpus=1,
-                          cache_dir='', core=None,
-                          variable_elongation_transcription=True,
-                          variable_elongation_translation=False,
-                          disable_ribosome_capacity_fitting=False,
-                          disable_rnapoly_capacity_fitting=False,
-                          resume_from_step=1, resume_state=None):
-    """Build a Composite that runs the 9-step ParCa pipeline.
+STEP_ORDER = [
+    'initialize', 'input_adjustments', 'basal_specs', 'tf_condition_specs',
+    'fit_condition', 'promoter_binding', 'adjust_promoters',
+    'set_conditions', 'final_adjustments',
+]
 
-    Args:
-        raw_data: a ``KnowledgeBaseEcoli`` instance.  Passed through
-            InitializeStep's config to keep bigraph-schema from walking
-            its nested KB internals at composite construction time.
-            Required when ``resume_from_step <= 1``; ignored otherwise.
-        debug, cpus, cache_dir, *_elongation*, *_capacity_fitting:
-            forwarded to the relevant Step configs.
-        core: optional pre-built core.
-        resume_from_step: 1-9.  When > 1, steps 1..(N-1) are skipped and
-            the composite's initial store state is seeded from
-            ``resume_state`` (which must be a dict produced by a prior
-            run's ``composite.state``).  Used to debug late-pipeline
-            steps without re-running the expensive Step 5.
-        resume_state: store-state dict from a prior run, required when
-            ``resume_from_step > 1``.
-    Returns:
-        The ``Composite`` instance with the pipeline already executed.
-        The final store state is at ``composite.state``.
+
+def _build_step_slots(raw_data, debug, cpus, cache_dir, _elong):
+    """Build the 9 step entries with addresses, configs, and wiring.
+
+    Shared by ``build_parca_composite`` (which fires the pipeline) and
+    ``build_parca_document`` (which returns the unfired structural state
+    for serialization).
     """
-    if resume_from_step > 1 and resume_state is None:
-        raise ValueError(
-            "resume_from_step > 1 requires resume_state from a prior run")
-    if core is None:
-        core = allocate_core(top=ALL_STEP_CLASSES)
-        register_parca_schema(core)
-
     from v2ecoli.processes.parca.steps.step_01_initialize        import OUTPUT_PORTS as _s1_out
     from v2ecoli.processes.parca.steps.step_02_input_adjustments import (
         INPUT_PORTS as _s2_in, OUTPUT_PORTS as _s2_out)
@@ -133,15 +112,6 @@ def build_parca_composite(raw_data, debug=False, cpus=1,
     from v2ecoli.processes.parca.steps.step_09_final_adjustments import (
         INPUT_PORTS as _s9_in, OUTPUT_PORTS as _s9_out)
 
-    _elong = dict(
-        variable_elongation_transcription=variable_elongation_transcription,
-        variable_elongation_translation=variable_elongation_translation,
-        disable_ribosome_capacity_fitting=disable_ribosome_capacity_fitting,
-        disable_rnapoly_capacity_fitting=disable_rnapoly_capacity_fitting,
-    )
-
-    # Ticks are already baked into each step's INPUT_PORTS / OUTPUT_PORTS
-    # so _wires() picks them up automatically.
     s1i, s1o = {}, _wires(_s1_out.keys())
     s2i, s2o = _wires(_s2_in.keys()), _wires(_s2_out.keys())
     s3i, s3o = _wires(_s3_in.keys()), _wires(_s3_out.keys())
@@ -152,9 +122,7 @@ def build_parca_composite(raw_data, debug=False, cpus=1,
     s8i, s8o = _wires(_s8_in.keys()), _wires(_s8_out.keys())
     s9i, s9o = _wires(_s9_in.keys()), _wires(_s9_out.keys())
 
-    # Each step slot.  We build them once and selectively include them
-    # below according to ``resume_from_step``.
-    step_slots = {
+    return {
         'initialize': {
             '_type': 'step', 'address': 'local:InitializeStep',
             'config': {'raw_data': raw_data},
@@ -202,11 +170,76 @@ def build_parca_composite(raw_data, debug=False, cpus=1,
         },
     }
 
-    STEP_ORDER = [
-        'initialize', 'input_adjustments', 'basal_specs', 'tf_condition_specs',
-        'fit_condition', 'promoter_binding', 'adjust_promoters',
-        'set_conditions', 'final_adjustments',
-    ]
+
+def build_parca_document(debug=False, cpus=1, cache_dir=''):
+    """Return the parca composite spec state dict (steps + wiring, unfired).
+
+    Use with ``v2ecoli.pbg.save_pbg_doc(...)`` to serialize the parca
+    pipeline structure to a ``.pbg`` JSON document without running. The
+    configs that vary per-run (raw_data, cache directories) are
+    placeholders here — ``save_pbg_doc`` strips them out anyway.
+    """
+    _elong = dict(
+        variable_elongation_transcription=True,
+        variable_elongation_translation=False,
+        disable_ribosome_capacity_fitting=False,
+        disable_rnapoly_capacity_fitting=False,
+    )
+    slots = _build_step_slots(
+        raw_data=None, debug=debug, cpus=cpus,
+        cache_dir=cache_dir, _elong=_elong,
+    )
+    return {name: slots[name] for name in STEP_ORDER}
+
+
+def build_parca_composite(raw_data, debug=False, cpus=1,
+                          cache_dir='', core=None,
+                          variable_elongation_transcription=True,
+                          variable_elongation_translation=False,
+                          disable_ribosome_capacity_fitting=False,
+                          disable_rnapoly_capacity_fitting=False,
+                          resume_from_step=1, resume_state=None):
+    """Build a Composite that runs the 9-step ParCa pipeline.
+
+    Args:
+        raw_data: a ``KnowledgeBaseEcoli`` instance.  Passed through
+            InitializeStep's config to keep bigraph-schema from walking
+            its nested KB internals at composite construction time.
+            Required when ``resume_from_step <= 1``; ignored otherwise.
+        debug, cpus, cache_dir, *_elongation*, *_capacity_fitting:
+            forwarded to the relevant Step configs.
+        core: optional pre-built core.
+        resume_from_step: 1-9.  When > 1, steps 1..(N-1) are skipped and
+            the composite's initial store state is seeded from
+            ``resume_state`` (which must be a dict produced by a prior
+            run's ``composite.state``).  Used to debug late-pipeline
+            steps without re-running the expensive Step 5.
+        resume_state: store-state dict from a prior run, required when
+            ``resume_from_step > 1``.
+    Returns:
+        The ``Composite`` instance with the pipeline already executed.
+        The final store state is at ``composite.state``.
+    """
+    if resume_from_step > 1 and resume_state is None:
+        raise ValueError(
+            "resume_from_step > 1 requires resume_state from a prior run")
+    if core is None:
+        core = allocate_core(top=ALL_STEP_CLASSES)
+        register_parca_schema(core)
+
+    _elong = dict(
+        variable_elongation_transcription=variable_elongation_transcription,
+        variable_elongation_translation=variable_elongation_translation,
+        disable_ribosome_capacity_fitting=disable_ribosome_capacity_fitting,
+        disable_rnapoly_capacity_fitting=disable_rnapoly_capacity_fitting,
+    )
+
+    # Ticks are already baked into each step's INPUT_PORTS / OUTPUT_PORTS
+    # so _wires() picks them up automatically.
+    step_slots = _build_step_slots(
+        raw_data=raw_data, debug=debug, cpus=cpus,
+        cache_dir=cache_dir, _elong=_elong,
+    )
 
     state = {}
     # Seed leaves from a prior run when resuming.  Skip composite-internal

--- a/v2ecoli/steps/allocator.py
+++ b/v2ecoli/steps/allocator.py
@@ -60,9 +60,16 @@ class Allocator(Step):
         }
 
     def outputs(self):
+        # Note: do NOT wrap allocate/request in `overwrite[...]`. Bigraph-schema
+        # promotes per-port schemas into self.schema during apply, and an
+        # `overwrite[map[...]]` at the parent map level causes ANY sub-key write
+        # (e.g. a per-process Requester writing only its own slot) to replace
+        # the whole map, dropping siblings. With plain `map[...]`, Map.apply
+        # walks update keys and preserves siblings — which is the behavior
+        # the partitioned execution layers depend on.
         return {
-            'allocate': 'overwrite[map[map[list[integer]]]]',
-            'request': 'overwrite[map[map[list[integer]]]]',
+            'allocate': 'map[map[list[integer]]]',
+            'request': 'map[map[list[integer]]]',
             'listeners': {
                 'atp': {
                     # length n_processes; written as numpy arrays

--- a/v2ecoli/steps/exchange_data.py
+++ b/v2ecoli/steps/exchange_data.py
@@ -54,7 +54,15 @@ class ExchangeData(Step):
         exchange_data = self.external_state.exchange_data_from_concentrations(env_concs)
 
         unconstrained = exchange_data["importUnconstrainedExchangeMolecules"]
-        constrained = exchange_data["importConstrainedExchangeMolecules"]
+        # importConstrainedExchangeMolecules carries unum quantities (mmol/g/h);
+        # the downstream schema is `map[float]` and the metabolism reader
+        # re-attaches the unit. Strip to magnitudes so apply() sees plain floats.
+        constrained = {
+            mol: float(unum_to_pint(val).magnitude)
+            if hasattr(unum_to_pint(val), "magnitude")
+            else float(val)
+            for mol, val in exchange_data["importConstrainedExchangeMolecules"].items()
+        }
         return {
             "environment": {
                 "exchange_data": {


### PR DESCRIPTION
**Stacked on #30 — review/merge that one first.**

## Summary
- Adds `models/parca.pbg` (~16 KB) — a process-bigraph JSON document that captures the parca pipeline structure (9 step entries + port wiring + addresses, no fitted data) alongside the existing `models/partitioned.pbg` and friends.
- Lets tooling (network viz, comparison reports, schema inspectors) read the pipeline shape without importing v2ecoli or running the 70-min ParCa.
- This is the *structural* parca artifact. The fitted-state JSON migration (replacing `models/parca/parca_state.pkl.gz`) is a separate, larger effort — the parca state contains 30+ irreducible Python types (sympy expression trees, Bio.Seq, scipy CubicSpline, sparse matrices, …) that need bespoke serializers; we'll size that work separately.

## What's new
- `v2ecoli/processes/parca/composite.py`: extract step-slot construction into a shared `_build_step_slots(...)` helper, lift `STEP_ORDER` to module scope, and add `build_parca_document(...)` that returns the unfired spec state dict. `build_parca_composite(...)` keeps its external behavior — still fires the pipeline — but now goes through the shared helper.
- `v2ecoli/pbg.py`: new `save_pbg_doc(state_dict, path)` for flat composites that aren't wrapped in the multi-cell `agents/0` pattern. Same step-config-stripping behavior as `save_pbg`.
- `reports/workflow_report.py`: regenerate `models/parca.pbg` next to `models/partitioned.pbg` whenever the workflow report runs.
- `tests/test_parca_pbg_document.py`: drift check that fails fast when the committed `.pbg` falls behind live `STORE_PATH` / port manifests, with a regeneration hint in the failure message.
- `README.md`: short pointer to `models/parca.pbg`.

## Test plan
- [x] `pytest tests/test_parca_pbg_document.py` — 3 new tests pass (file exists, matches live spec, has all 9 steps).
- [x] `pytest tests/test_parca_ports_and_wiring.py tests/test_parca_fixture_roundtrip.py tests/test_workflow_parca_integration.py` — 30 existing parca tests still pass after the `_build_step_slots` refactor.
- [x] `pytest -m fast` — full fast suite (22 tests) passes.
- [x] Manually inspected `models/parca.pbg`: 9 steps, addresses `local:InitializeStep`/etc., wiring resolves to `STORE_PATH` paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)