### PR TITLE
Skip simData.cPickle round-trip in parca → sim handoff

### DIFF
--- a/reports/workflow_report.py
+++ b/reports/workflow_report.py
@@ -47,7 +47,7 @@ except ImportError:
     V1_ROOT_PATH = os.getcwd()
     V1_AVAILABLE = False
 
-from v2ecoli.composite import make_composite, _build_core, save_cache
+from v2ecoli.composite import make_composite, _build_core, save_cache, save_sim_input
 from v2ecoli.library.schema import attrs as ecoli_attrs
 from process_bigraph import Composite
 from v2ecoli.generate import build_document, FLOW_ORDER, build_execution_layers, DEFAULT_FEATURES
@@ -1028,6 +1028,9 @@ def step_parca():
 
     parca_ran = False
     simdata_source = 'unknown'
+    # Live sim_data populated in the fresh-hydrate branches below; lets the
+    # cache build skip the dill round-trip via save_sim_input(...).
+    sim_data = None
     if os.path.exists(sim_data_cache):
         print(f"    Cache exists at {CACHE_DIR}")
         parca_time = 0.0
@@ -1110,7 +1113,13 @@ def step_parca():
     if not os.path.exists(sim_data_cache):
         print("    Generating cache (initial_state.json + sim_data_cache.dill)...")
         t0 = time.time()
-        save_cache(sim_data_path, CACHE_DIR)
+        if sim_data is not None:
+            # Fast path — sim_data is already in memory from the fresh-hydrate
+            # branches above; skip the ~300 MB dill round-trip.
+            save_sim_input(sim_data, CACHE_DIR)
+        else:
+            # Legacy path — only a path-on-disk simData.cPickle is available.
+            save_cache(sim_data_path, CACHE_DIR)
         cache_time = time.time() - t0
         print(f"    Cache generated in {cache_time:.1f}s")
     else:

--- a/scripts/build_cache.py
+++ b/scripts/build_cache.py
@@ -1,8 +1,9 @@
 """Build out/cache/ from the shipped ParCa fixture.
 
-Fast path: hydrates models/parca/parca_state.pkl.gz (committed to the repo)
-into a simData pickle, then runs save_cache to produce initial_state.json,
-sim_data_cache.dill, and cache_version.json.  No ParCa re-run.
+Hydrates models/parca/parca_state.pkl.gz into a SimulationDataEcoli
+in memory and emits the simulation-input bundle (initial_state.json,
+sim_data_cache.dill, metadata.json, .cache_version) directly — no
+intermediate ``simData.cPickle`` round-trip. No ParCa re-run.
 
 Use this whenever:
   - You pulled a branch that changed sim_data.py, the pint boundary,
@@ -24,11 +25,9 @@ import os
 import sys
 import time
 
-import dill
-
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from v2ecoli.composite import save_cache
+from v2ecoli.composite import save_sim_input
 from v2ecoli.library.cache_version import write_cache_version
 from v2ecoli.processes.parca.data_loader import (
     hydrate_sim_data_from_state, load_parca_state,
@@ -37,10 +36,9 @@ from v2ecoli.processes.parca.data_loader import (
 
 DEFAULT_FIXTURE = "models/parca/parca_state.pkl.gz"
 DEFAULT_CACHE_DIR = "out/cache"
-DEFAULT_WORKDIR = "out/workflow"
 
 
-def build_cache(fixture: str, cache_dir: str, workdir: str) -> None:
+def build_cache(fixture: str, cache_dir: str) -> None:
     repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     os.chdir(repo_root)
 
@@ -54,25 +52,16 @@ def build_cache(fixture: str, cache_dir: str, workdir: str) -> None:
     sim_data = hydrate_sim_data_from_state(state)
     print(f"    hydrated in {time.time()-t1:.1f}s")
 
-    os.makedirs(workdir, exist_ok=True)
-    sd_path = os.path.join(workdir, "simData.cPickle")
     t2 = time.time()
-    print(f"[{time.strftime('%H:%M:%S')}] Pickling sim_data -> {sd_path} ...")
-    with open(sd_path, "wb") as f:
-        dill.dump(sim_data, f)
-    print(f"    pickled in {time.time()-t2:.1f}s "
-          f"({os.path.getsize(sd_path)/1e6:.1f} MB)")
-
-    t3 = time.time()
-    print(f"[{time.strftime('%H:%M:%S')}] Building cache at {cache_dir} ...")
-    save_cache(sd_path, cache_dir)
+    print(f"[{time.strftime('%H:%M:%S')}] Building bundle at {cache_dir} ...")
+    save_sim_input(sim_data, cache_dir)
 
     version = write_cache_version(cache_dir, repo_root=repo_root)
-    print(f"    cache built in {time.time()-t3:.1f}s")
+    print(f"    bundle built in {time.time()-t2:.1f}s")
     print(f"    inputs_hash: {version.inputs_hash[:16]}...")
 
     print(f"\nTotal: {time.time()-t0:.1f}s")
-    print("Cache contents:")
+    print("Bundle contents:")
     for f in sorted(os.listdir(cache_dir)):
         p = os.path.join(cache_dir, f)
         print(f"  {f}: {os.path.getsize(p)/1e6:.2f} MB")
@@ -84,12 +73,9 @@ def main() -> None:
     parser.add_argument("--fixture", default=DEFAULT_FIXTURE,
                         help=f"ParCa fixture pickle (default: {DEFAULT_FIXTURE})")
     parser.add_argument("--cache", default=DEFAULT_CACHE_DIR, dest="cache_dir",
-                        help=f"output cache dir (default: {DEFAULT_CACHE_DIR})")
-    parser.add_argument("--workdir", default=DEFAULT_WORKDIR,
-                        help=f"intermediate simData.cPickle dir "
-                             f"(default: {DEFAULT_WORKDIR})")
+                        help=f"output bundle dir (default: {DEFAULT_CACHE_DIR})")
     args = parser.parse_args()
-    build_cache(args.fixture, args.cache_dir, args.workdir)
+    build_cache(args.fixture, args.cache_dir)
 
 
 if __name__ == "__main__":

--- a/tests/test_save_sim_input.py
+++ b/tests/test_save_sim_input.py
@@ -1,0 +1,54 @@
+"""Tests for ``v2ecoli.composite.save_sim_input``.
+
+The function takes a live ``SimulationDataEcoli`` and writes the
+simulation-input bundle (initial_state.json + sim_data_cache.dill +
+metadata.json + cache_version) directly — skipping the ~300 MB dill
+round-trip that ``save_cache(sim_data_path, ...)`` performs to load
+the same object from disk.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+pytestmark = pytest.mark.fast
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+FIXTURE_PATH = REPO_ROOT / 'models' / 'parca' / 'parca_state.pkl.gz'
+
+
+@pytest.mark.skipif(not FIXTURE_PATH.exists(),
+                    reason=f'fixture absent at {FIXTURE_PATH}')
+def test_save_sim_input_writes_full_bundle(tmp_path):
+    """``save_sim_input`` produces all four bundle artifacts a downstream
+    ``make_composite(cache_dir=...)`` expects."""
+    from v2ecoli.composite import save_sim_input
+    from v2ecoli.processes.parca.data_loader import (
+        hydrate_sim_data_from_state, load_parca_state,
+    )
+
+    state = load_parca_state(str(FIXTURE_PATH))
+    sim_data = hydrate_sim_data_from_state(state)
+
+    bundle = tmp_path / 'bundle'
+    save_sim_input(sim_data, str(bundle))
+
+    expected = {'initial_state.json', 'sim_data_cache.dill',
+                'metadata.json', 'cache_version.json'}
+    actual = {p.name for p in bundle.iterdir()}
+    missing = expected - actual
+    assert not missing, f'bundle is missing files: {missing}'
+    for name in expected:
+        path = bundle / name
+        assert path.stat().st_size > 0, f'{name} is empty'
+
+
+def test_load_sim_data_rejects_no_input():
+    """``LoadSimData`` requires at least one of sim_data_path or sim_data."""
+    from v2ecoli.library.sim_data import LoadSimData
+
+    with pytest.raises(ValueError, match='sim_data_path or sim_data'):
+        LoadSimData()

--- a/tests/test_workflow_parca_integration.py
+++ b/tests/test_workflow_parca_integration.py
@@ -129,10 +129,11 @@ def test_step_parca_hydrates_fixture(tmp_path, monkeypatch):
     monkeypatch.setattr(workflow, 'CACHE_DIR', str(tmp_path / 'cache'))
     monkeypatch.setattr(workflow, 'load_meta', lambda _n: None)
     monkeypatch.setattr(workflow, 'save_meta', lambda _n, _m: None)
-    # Stub save_cache — we don't want to generate the full initial
-    # state JSON during this test (that's a separate step with its own
-    # coverage).  We assert the dill file is well-formed instead.
+    # Stub the bundle writers — we don't want to generate the full
+    # initial state JSON during this test (that's a separate step with
+    # its own coverage).  We assert the dill file is well-formed instead.
     monkeypatch.setattr(workflow, 'save_cache', lambda *a, **k: None)
+    monkeypatch.setattr(workflow, 'save_sim_input', lambda *a, **k: None)
 
     # Force the fixture path (not a composite rerun)
     assert workflow._OPTIONS.get('parca_rerun') is not True
@@ -174,6 +175,7 @@ def test_step_parca_fixture_is_fast(tmp_path, monkeypatch):
     monkeypatch.setattr(workflow, 'load_meta', lambda _n: None)
     monkeypatch.setattr(workflow, 'save_meta', lambda _n, _m: None)
     monkeypatch.setattr(workflow, 'save_cache', lambda *a, **k: None)
+    monkeypatch.setattr(workflow, 'save_sim_input', lambda *a, **k: None)
 
     cwd = os.getcwd()
     os.chdir(REPO_ROOT)

--- a/v2ecoli/composite.py
+++ b/v2ecoli/composite.py
@@ -142,39 +142,37 @@ def _build_from_cache(cache_dir, core, seed=0, features=None):
     )
 
 
-def save_cache(sim_data_path, cache_dir='out/cache', seed=0):
-    """Generate and save cache files from simData (vEcoli ParCa output).
+_CACHE_CONFIG_NAMES = [
+    'post-division-mass-listener', 'ecoli-mass-listener', 'media_update',
+    'exchange_data', 'ecoli-tf-unbinding', 'ecoli-tf-binding',
+    'ecoli-equilibrium', 'ecoli-two-component-system', 'ecoli-rna-maturation',
+    'ecoli-transcript-initiation', 'ecoli-polypeptide-initiation',
+    'ecoli-chromosome-replication', 'ecoli-protein-degradation',
+    'ecoli-rna-degradation', 'ecoli-complexation',
+    'ecoli-transcript-elongation', 'ecoli-polypeptide-elongation',
+    'ecoli-chromosome-structure', 'ecoli-metabolism',
+    'RNA_counts_listener', 'rna_synth_prob_listener',
+    'monomer_counts_listener', 'dna_supercoiling_listener',
+    'ribosome_data_listener', 'rnap_data_listener',
+    'unique_molecule_counts', 'allocator',
+]
 
-    Creates:
-    - cache_dir/initial_state.json
-    - cache_dir/sim_data_cache.dill
-    - cache_dir/metadata.json
+
+def _write_sim_input_bundle(loader, bundle_dir):
+    """Write the simulation-input bundle from an instantiated LoadSimData.
+
+    Shared body of ``save_cache`` (path-based) and ``save_sim_input``
+    (live-object). Emits ``initial_state.json``, ``sim_data_cache.dill``,
+    ``metadata.json``, and the cache-version marker into ``bundle_dir``.
     """
-    from v2ecoli.library.sim_data import LoadSimData
-
-    os.makedirs(cache_dir, exist_ok=True)
-
-    loader = LoadSimData(sim_data_path=sim_data_path, seed=seed)
+    os.makedirs(bundle_dir, exist_ok=True)
 
     state = loader.generate_initial_state()
-    save_initial_state(state, os.path.join(cache_dir, 'initial_state.json'))
+    save_initial_state(state, os.path.join(bundle_dir, 'initial_state.json'))
 
     configs = {}
     failed: list[tuple[str, Exception]] = []
-    for name in [
-        'post-division-mass-listener', 'ecoli-mass-listener', 'media_update',
-        'exchange_data', 'ecoli-tf-unbinding', 'ecoli-tf-binding',
-        'ecoli-equilibrium', 'ecoli-two-component-system', 'ecoli-rna-maturation',
-        'ecoli-transcript-initiation', 'ecoli-polypeptide-initiation',
-        'ecoli-chromosome-replication', 'ecoli-protein-degradation',
-        'ecoli-rna-degradation', 'ecoli-complexation',
-        'ecoli-transcript-elongation', 'ecoli-polypeptide-elongation',
-        'ecoli-chromosome-structure', 'ecoli-metabolism',
-        'RNA_counts_listener', 'rna_synth_prob_listener',
-        'monomer_counts_listener', 'dna_supercoiling_listener',
-        'ribosome_data_listener', 'rnap_data_listener',
-        'unique_molecule_counts', 'allocator',
-    ]:
+    for name in _CACHE_CONFIG_NAMES:
         try:
             configs[name] = loader.get_config_by_name(name)
         except Exception as e:  # noqa: BLE001 — surface the name+error, don't lose it
@@ -188,8 +186,8 @@ def save_cache(sim_data_path, cache_dir='out/cache', seed=0):
             # ``listeners.mass.cell_mass``, which is obscure to debug.
             failed.append((name, e))
     if failed:
-        print(f"  save_cache: {len(failed)} config(s) failed to build and "
-              f"were omitted from the cache:")
+        print(f"  sim-input bundle: {len(failed)} config(s) failed to build "
+              f"and were omitted:")
         for name, exc in failed:
             print(f"    - {name}: {type(exc).__name__}: {exc}")
 
@@ -204,10 +202,37 @@ def save_cache(sim_data_path, cache_dir='out/cache', seed=0):
         'unique_names': unique_names,
         'dry_mass_inc_dict': dry_mass_inc,
     }
-    cache_path = os.path.join(cache_dir, 'sim_data_cache.dill')
+    cache_path = os.path.join(bundle_dir, 'sim_data_cache.dill')
     with open(cache_path, 'wb') as f:
         dill.dump(cache, f)
 
-    save_json({'unique_names': unique_names}, os.path.join(cache_dir, 'metadata.json'))
-    write_cache_version(cache_dir)
-    print(f"Cache saved to {cache_dir}")
+    save_json({'unique_names': unique_names},
+              os.path.join(bundle_dir, 'metadata.json'))
+    write_cache_version(bundle_dir)
+    print(f"Sim-input bundle saved to {bundle_dir}")
+
+
+def save_cache(sim_data_path, cache_dir='out/cache', seed=0):
+    """Generate the simulation-input bundle from a dilled SimulationDataEcoli.
+
+    Prefer ``save_sim_input(sim_data, ...)`` when the SimulationDataEcoli is
+    already in memory — this entry point exists for callers that only have a
+    pickle path (legacy vEcoli ``simData.cPickle``).
+    """
+    from v2ecoli.library.sim_data import LoadSimData
+    loader = LoadSimData(sim_data_path=sim_data_path, seed=seed)
+    _write_sim_input_bundle(loader, cache_dir)
+
+
+def save_sim_input(sim_data, bundle_dir='out/cache', seed=0):
+    """Generate the simulation-input bundle from a live ``SimulationDataEcoli``.
+
+    Skips the ~300 MB dill round-trip that ``save_cache`` performs to load
+    sim_data from disk. Use this when you already have a hydrated
+    ``SimulationDataEcoli`` in hand (e.g. straight off the parca composite or
+    its fixture) — the resulting bundle is byte-for-byte equivalent to what
+    ``save_cache`` would produce from the same sim_data dilled to a file.
+    """
+    from v2ecoli.library.sim_data import LoadSimData
+    loader = LoadSimData(sim_data=sim_data, seed=seed)
+    _write_sim_input_bundle(loader, bundle_dir)

--- a/v2ecoli/library/sim_data.py
+++ b/v2ecoli/library/sim_data.py
@@ -32,8 +32,9 @@ RAND_MAX = 2**31
 class LoadSimData:
     def __init__(
         self,
-        sim_data_path: str,
+        sim_data_path: Optional[str] = None,
         seed: int = 0,
+        sim_data: Optional["SimulationDataEcoli"] = None,
         max_duration: int = 10,
         fixed_media: Optional[str] = None,
         media_timeline: tuple[tuple[int, str]] = (
@@ -168,9 +169,18 @@ class LoadSimData:
         # when calculating degradation
         self.degrade_misc = False
 
-        # load sim_data
-        with open(sim_data_path, "rb") as sim_data_file:
-            self.sim_data: "SimulationDataEcoli" = pickle.load(sim_data_file)
+        # load sim_data — either from a pickle path or a pre-hydrated object.
+        # Skipping the pickle round-trip is the v2ecoli ParCa fast path: the
+        # composite produces a live ``SimulationDataEcoli`` we can hand in
+        # directly, which saves a ~300 MB dump + reload.
+        if sim_data is not None:
+            self.sim_data: "SimulationDataEcoli" = sim_data
+        elif sim_data_path is not None:
+            with open(sim_data_path, "rb") as sim_data_file:
+                self.sim_data: "SimulationDataEcoli" = pickle.load(sim_data_file)
+        else:
+            raise ValueError(
+                "LoadSimData requires either sim_data_path or sim_data")
 
         if condition is not None:
             self.sim_data.condition = condition


### PR DESCRIPTION
**Stacked on #31 (and #30 underneath) — review/merge those first.**

## Summary
- The parca fixture / 9-Step composite produces a live `SimulationDataEcoli`. The workflow then dilled it (~300 MB) to `out/workflow/simData.cPickle` and immediately reloaded it inside `LoadSimData(sim_data_path=...)` so `save_cache` could extract 27 process configs into the cache bundle. The sim_data was already in memory — the dump+reload was pure waste.
- This PR introduces an in-memory path: `save_sim_input(sim_data, bundle_dir)` produces the same bundle without ever touching disk for sim_data.

## What's new
- `LoadSimData.__init__`: new optional `sim_data` kwarg accepts a pre-hydrated `SimulationDataEcoli` directly (skips the `pickle.load`). Constructor now requires *one of* `sim_data_path` or `sim_data`.
- `v2ecoli/composite.py`: extract `_write_sim_input_bundle(loader, dir)` shared body. Add `save_sim_input(sim_data, bundle_dir, seed=0)`. `save_cache(sim_data_path, ...)` is unchanged externally — kept for callers that only have a pickle path (legacy vEcoli `simData.cPickle`).
- `reports/workflow_report.py:step_parca`: when sim_data is in memory from the fresh-hydrate / composite-run branches, call `save_sim_input` directly; path-only callers still go through `save_cache`. The `simData.cPickle` write is intentionally kept — `step_v1_v2` and similar v1-comparison flows still expect to find one in `WORKFLOW_DIR`.
- `scripts/build_cache.py`: same one-pass path. The intermediate `simData.cPickle` is no longer produced by this script (it was a private build artifact).
- `tests/test_save_sim_input.py` (new): asserts the bundle contains all four expected files and that `LoadSimData()` raises a clear `ValueError` when neither input is given.

## What didn't change
- The bundle format itself (still `initial_state.json` + `sim_data_cache.dill` + `metadata.json` + `cache_version.json`).
- `save_cache(sim_data_path, ...)` is unchanged for backwards compat.
- `models/parca/parca_state.pkl.gz` (the parca composite output fixture).
- v1/v2 comparison flows — `step_parca` still writes `simData.cPickle` for them.

## Test plan
- [x] `pytest tests/test_save_sim_input.py tests/test_workflow_parca_integration.py` — 8 pass.
- [x] `pytest -m fast` — 21 pass, 3 skipped (fixture-dependent, unaffected).
- [x] Smoke test: `load_parca_state → hydrate → save_sim_input → make_composite(cache_dir=...)` builds a Composite with 46 steps and the expected initial dry_mass (379.75 fg).
- [x] Bundle equivalence: same `initial_state.json` (10 MB) + `sim_data_cache.dill` (165 MB) sizes as the legacy path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)