### PR TITLE
feat: colony composite_generator + workspace-template investigation specs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,20 +68,27 @@ jobs:
       # cache_version.json) across PRs. The cache key pins to the same
       # input files that cache_version.compute_cache_version fingerprints,
       # so a change to ParCa fixture or the LoadSimData boundary forces
-      # a rebuild on the next CI run.
+      # a rebuild on the next CI run. The hashFiles list mirrors
+      # cache_version.INPUT_FILES, plus cache_version.py itself so future
+      # additions to INPUT_FILES automatically bust the cache.
       - name: Restore ParCa cache
         id: parca-cache
         uses: actions/cache@v4
         with:
           path: out/cache
           key: >-
-            parca-cache-v1-${{ hashFiles(
+            parca-cache-v2-${{ hashFiles(
               'models/parca/parca_state.pkl.gz',
               'v2ecoli/library/sim_data.py',
               'v2ecoli/library/unit_bridge.py',
               'v2ecoli/types/quantity.py',
               'v2ecoli/library/initial_conditions.py',
-              'v2ecoli/composite.py'
+              'v2ecoli/library/cache_version.py',
+              'v2ecoli/core.py',
+              'v2ecoli/composites/baseline.py',
+              'v2ecoli/composites/colony.py',
+              'v2ecoli/composites/departitioned.py',
+              'v2ecoli/composites/reconciled.py'
             ) }}
 
       - name: Build ParCa cache on miss

--- a/docs/workspace-template/investigations/architectures-compare/spec.yaml
+++ b/docs/workspace-template/investigations/architectures-compare/spec.yaml
@@ -1,0 +1,113 @@
+# Skeleton Investigation spec for v2ecoli — three-architecture comparison.
+#
+# Runs baseline (partitioned, 55 procs), departitioned (41 steps fused), and
+# reconciled (hybrid) at a common seed/duration, side-by-side. The catch-
+# regressions Study: if departitioned or reconciled drifts from baseline on
+# mass/growth/RNAP, this is where it shows up first.
+#
+# Requires V2ECOLI_CACHE pointing at v2ecoli/out/cache (built once via
+# `python scripts/build_cache.py`). All three architectures consume the same
+# ParCa cache.
+
+name: architectures-compare
+question: |
+  Do departitioned and reconciled match baseline on mass, growth rate, and
+  RNAP count over a full cycle?
+hypothesis: |
+  All three architectures agree within 5 % on cell_mass and growth_rate
+  trajectories and within 10 % on active RNAP count at division.
+status: draft
+tags: [comparison, regression-gate, all-architectures]
+
+baseline: baseline
+
+variants:
+  - name: baseline
+    source: local:baseline
+    parameters: {seed: 0, cache_dir: ${V2ECOLI_CACHE}}
+
+  - name: departitioned
+    source: local:departitioned
+    parameters: {seed: 0, cache_dir: ${V2ECOLI_CACHE}}
+
+  - name: reconciled
+    source: local:reconciled
+    parameters: {seed: 0, cache_dir: ${V2ECOLI_CACHE}}
+
+observables:
+  - {path: [agents, "0", listeners, mass, cell_mass]}
+  - {path: [agents, "0", listeners, mass, dry_mass]}
+  - {path: [agents, "0", listeners, mass, instantaneous_growth_rate]}
+  - {path: [agents, "0", listeners, mass, volume]}
+  - {path: [agents, "0", listeners, mass, protein_mass]}
+  - {path: [agents, "0", listeners, mass, rRna_mass]}
+  - {path: [agents, "0", listeners, rnap_data, n_active_rnap]}
+  - {path: [agents, "0", divide]}
+
+runs:
+  - {composite: baseline,      params: {seed: 0}, steps: 2520}
+  - {composite: departitioned, params: {seed: 0}, steps: 2520}
+  - {composite: reconciled,    params: {seed: 0}, steps: 2520}
+
+comparisons:
+  - name: arch-mass
+    description: "Cell mass over time, all three architectures."
+    variants: [baseline, departitioned, reconciled]
+    observables: [cell_mass]
+  - name: arch-growth
+    description: "Instantaneous growth rate, all three architectures."
+    variants: [baseline, departitioned, reconciled]
+    observables: [instantaneous_growth_rate]
+  - name: arch-rnap
+    description: "Active RNAP count — sensitive growth-rate indicator (see user_preferences memory)."
+    variants: [baseline, departitioned, reconciled]
+    observables: [n_active_rnap]
+
+visualizations:
+  # CompareVisualization takes a list of composite specs and renders the
+  # canonical v2ecoli architecture-comparison HTML (legacy compare_report).
+  - name: compare-report
+    address: "local:CompareVisualization"
+    inputs:
+      composite_specs:
+        source: variant-documents
+        variants: [baseline, departitioned, reconciled]
+    config:
+      title: "v2ecoli — baseline vs departitioned vs reconciled"
+
+  # Per-comparison timeseries traces. TimeSeriesPlot understands the
+  # `comparison:` shorthand (study-model-design.md) and pulls sources +
+  # observable from the named comparison object.
+  - name: mass-cmp
+    address: "local:TimeSeriesPlot"
+    config: {comparison: arch-mass,   title: "Cell mass — three architectures"}
+  - name: growth-cmp
+    address: "local:TimeSeriesPlot"
+    config: {comparison: arch-growth, title: "Growth rate — three architectures"}
+  - name: rnap-cmp
+    address: "local:TimeSeriesPlot"
+    config: {comparison: arch-rnap,   title: "Active RNAP — three architectures"}
+
+  # Per-architecture process topology.
+  - name: net-baseline
+    address: "local:NetworkVisualization"
+    inputs: {composite_spec: {source: variant-document, variant: baseline}}
+    config: {title: "Baseline topology"}
+  - name: net-departitioned
+    address: "local:NetworkVisualization"
+    inputs: {composite_spec: {source: variant-document, variant: departitioned}}
+    config: {title: "Departitioned topology"}
+  - name: net-reconciled
+    address: "local:NetworkVisualization"
+    inputs: {composite_spec: {source: variant-document, variant: reconciled}}
+    config: {title: "Reconciled topology"}
+
+# ── Notes ───────────────────────────────────────────────────────────────────
+# - The RNAP path uses listeners.rnap_data.n_active_rnap rather than the unique
+#   array path; the listener exists in all three architectures and exposes a
+#   scalar count without an aggregator hop.
+# - All three composite generators consume the same ParCa cache, so cache-rebuild
+#   cost is amortised across this Study.
+# - If a viz fails with "no comparison named X", the orchestrator may not yet
+#   resolve `config.comparison:` → sources/observable; fall back to the
+#   explicit-sources form (config: {sources: [baseline, …], observable: …}).

--- a/docs/workspace-template/investigations/colony/spec.yaml
+++ b/docs/workspace-template/investigations/colony/spec.yaml
@@ -1,0 +1,78 @@
+# Skeleton Investigation spec for v2ecoli — multi-cell colony Study.
+#
+# Uses the `colony` composite generator (added alongside this spec) — each
+# cell embeds the full v2ecoli whole-cell model via the EcoliWCM bridge,
+# and PymunkProcess drives 2D physics.
+#
+# Heavyweight: each step ticks N copies of the 55-process model plus a
+# pymunk integration. Plan for minutes per simulated minute, not realtime.
+
+name: colony
+question: |
+  Does a 3-cell colony grow and divide with physically plausible spatial
+  dynamics over 30 simulated minutes?
+hypothesis: |
+  Colony total mass grows ~exponentially; at least one cell divides by
+  t = 25 min; cells remain inside the environment box.
+status: draft
+tags: [colony, multi-cell, heavy, requires-pymunk, requires-multi-cell]
+
+baseline: colony
+
+variants:
+  - name: colony
+    source: local:colony
+    parameters:
+      seed: 0
+      cache_dir: ${V2ECOLI_CACHE}
+      n_cells: 3
+      env_size: 30
+      physics_interval: 1.0
+      ecoli_interval: 1.0
+
+# Colony state doesn't share v2ecoli's listeners/mass layout — observables
+# come off the per-cell `mass` and `location` stores wired by build_microbe +
+# the EcoliWCM bridge. See v2ecoli/colony.py for the document shape.
+observables:
+  - {path: [cells, "*", mass]}        # per-cell dry mass (fg), wildcard over cell IDs
+  - {path: [cells, "*", volume]}
+  - {path: [cells, "*", location]}
+  - {path: [global_time]}
+
+runs:
+  - {composite: colony, params: {seed: 0}, steps: 1800}    # 30 min sim time at 1-s tick
+
+visualizations:
+  # ColonyVisualization is the canonical port of legacy colony_report —
+  # renders agent positions over time, mass trajectories, and a snapshot
+  # animation. Expects `history` + `metadata`.
+  - name: colony-report
+    address: "local:ColonyVisualization"
+    inputs:
+      history:  {source: run, run: colony-0}
+      metadata: {source: run-meta, run: colony-0}
+    config:
+      title: "3-cell colony — 30 minute simulation"
+
+  # Aggregate colony mass over time (derived: sum of per-cell mass at each
+  # step). If the orchestrator doesn't auto-aggregate wildcard observables,
+  # this will need a small derived-observable preprocessor.
+  - name: total-mass
+    address: "local:TimeSeriesPlot"
+    config:
+      observable: mass            # the orchestrator aggregates cells.*.mass
+      reduce: sum
+      sources: [colony]
+      title: "Total colony mass over time"
+
+# ── Notes ───────────────────────────────────────────────────────────────────
+# - This Study requires `multi_cell` + `pymunk` installed in the workspace
+#   environment. The colony composite_generator imports both lazily inside
+#   the `if core is None` block, so it errors clearly at first use rather
+#   than at module-import time.
+# - The wildcard observable path `[cells, "*", mass]` is a proposed
+#   extension. Confirm the orchestrator supports wildcards; if not, expand
+#   to one observable per cell ID at run time (the orchestrator may need a
+#   pre-pass that reads the rendered composite doc).
+# - 1800 steps × 3 cells × 55 procs is the rate-limiting factor; expect
+#   wall-clock around 30 min on a modern laptop without parallelism.

--- a/docs/workspace-template/investigations/full-lifecycle/spec.yaml
+++ b/docs/workspace-template/investigations/full-lifecycle/spec.yaml
@@ -1,0 +1,107 @@
+# Skeleton Investigation spec for v2ecoli — full single-cell lifecycle.
+#
+# Drop into a freshly-initialised v2ecoli-workspace (or any pbg workspace
+# that pip-installs v2ecoli + pbg-superpowers) under
+# `investigations/full-lifecycle/spec.yaml` and run via /pbg-investigate.
+#
+# The dashboard server expects `V2ECOLI_CACHE` to point at v2ecoli's ParCa
+# cache (e.g. ~/code/v2ecoli/out/cache). Build it once with
+# `python scripts/build_cache.py` in the v2ecoli repo.
+#
+# Composite address `local:baseline` resolves through pbg-superpowers'
+# composite-generator registry once `import v2ecoli.composites` has fired.
+# The dashboard does this on startup as part of its package-discovery sweep.
+
+name: full-lifecycle
+question: |
+  Does the baseline architecture reach division in ~42 minutes with
+  upstream-parity mass dynamics?
+hypothesis: |
+  cell_mass roughly doubles, growth_rate stays in the 1.5e-4–3e-4 s⁻¹
+  band, and a division event fires near t = 2520 s.
+status: draft
+tags: [baseline, lifecycle, fast-smoke]
+
+baseline: baseline
+
+variants:
+  - name: baseline
+    source: local:baseline
+    # `document` is created on first run by the dashboard at
+    # investigations/full-lifecycle/composites/baseline.yaml
+    parameters:
+      seed: 0
+      cache_dir: ${V2ECOLI_CACHE}
+
+observables:
+  - {path: [agents, "0", listeners, mass, cell_mass]}
+  - {path: [agents, "0", listeners, mass, dry_mass]}
+  - {path: [agents, "0", listeners, mass, instantaneous_growth_rate]}
+  - {path: [agents, "0", listeners, mass, volume]}
+  - {path: [agents, "0", listeners, mass, protein_mass]}
+  - {path: [agents, "0", listeners, mass, rRna_mass]}
+  - {path: [agents, "0", listeners, mass, tRna_mass]}
+  - {path: [agents, "0", listeners, mass, mRna_mass]}
+  - {path: [agents, "0", listeners, mass, dna_mass]}
+  - {path: [agents, "0", divide]}
+
+runs:
+  - composite: baseline
+    params: {seed: 0}
+    steps: 2520    # ~42 min at 1-s timestep — closest to upstream division
+
+visualizations:
+  # WorkflowVisualization is the canonical v2ecoli lifecycle report; it
+  # expects `history` (per-step snapshots) + `metadata` (run metadata).
+  - name: workflow
+    address: "local:WorkflowVisualization"
+    inputs:
+      history:  {source: run, run: baseline-0}
+      metadata: {source: run-meta, run: baseline-0}
+    config:
+      title: "Baseline — single-cell lifecycle"
+
+  # Generic per-observable timeseries via pbg-superpowers' TimeSeriesPlot.
+  - name: cell-mass
+    address: "local:TimeSeriesPlot"
+    config:
+      observable: cell_mass
+      sources: [baseline]
+      title: "Cell mass (fg)"
+
+  - name: growth-rate
+    address: "local:TimeSeriesPlot"
+    config:
+      observable: instantaneous_growth_rate
+      sources: [baseline]
+      title: "Instantaneous growth rate (s⁻¹)"
+
+  - name: mass-fractions
+    address: "local:TimeSeriesPlot"
+    config:
+      observables: [protein_mass, rRna_mass, tRna_mass, mRna_mass, dna_mass]
+      sources: [baseline]
+      title: "Mass fractions"
+
+  # NetworkVisualization expects the composite document itself, not a
+  # trajectory — wired to the rendered composites/baseline.yaml.
+  - name: topology
+    address: "local:NetworkVisualization"
+    inputs:
+      composite_spec: {source: variant-document, variant: baseline}
+    config:
+      title: "Baseline — process topology"
+
+# ── Open seams ──────────────────────────────────────────────────────────────
+# 1. The `inputs:` block on each viz (binding ports to per-run / per-variant
+#    sources) is a proposed extension of the current spec.yaml schema; the
+#    Investigation orchestrator may today auto-bind by port name. If a run
+#    fails with "no source for input 'history'", inspect the orchestrator's
+#    binding pass and update either the spec or the binder.
+#
+# 2. The `${V2ECOLI_CACHE}` substitution assumes the spec loader interpolates
+#    environment variables. If it doesn't, replace the literal path before
+#    running or wire interpolation into load_spec.
+#
+# 3. `runs[].composite: baseline` plus a run-id convention `baseline-0` is
+#    inferred — confirm against the orchestrator's actual run-id format.

--- a/docs/workspace-template/investigations/multigeneration/spec.yaml
+++ b/docs/workspace-template/investigations/multigeneration/spec.yaml
@@ -1,0 +1,93 @@
+# Skeleton Investigation spec for v2ecoli — N-seed lineage Study.
+#
+# Runs the baseline architecture across N seeds; useful for catching seed-
+# dependent regressions (mass, growth, fold-change) and for visualising the
+# distribution of division outcomes.
+#
+# Per study-model-design.md, the v2 spec shape uses an explicit `runs:` list
+# rather than the older simulations[kind=seeds] block. Each seed is one run.
+
+name: multigeneration
+question: |
+  Across 5 RNG seeds, do mass + growth dynamics stay within their canonical
+  bands and converge on division near t = 2520 s?
+hypothesis: |
+  cell_mass at division falls within 5 % of the across-seed mean; growth_rate
+  is stable across seeds (std/mean < 0.05).
+status: draft
+tags: [lineage, seed-sweep, regression-gate]
+
+baseline: baseline
+
+variants:
+  - name: baseline
+    source: local:baseline
+    parameters: {cache_dir: ${V2ECOLI_CACHE}}   # seed is set per-run
+
+observables:
+  - {path: [agents, "0", listeners, mass, cell_mass]}
+  - {path: [agents, "0", listeners, mass, dry_mass]}
+  - {path: [agents, "0", listeners, mass, instantaneous_growth_rate]}
+  - {path: [agents, "0", listeners, mass, protein_mass]}
+  - {path: [agents, "0", listeners, mass, rRna_mass]}
+  - {path: [agents, "0", listeners, mass, dna_mass]}
+  - {path: [agents, "0", divide]}
+
+# Five seeds, same architecture + duration. Each row becomes one run in
+# runs.db; the orchestrator groups them by composite-name when feeding viz
+# inputs.
+runs:
+  - {composite: baseline, params: {seed: 0}, steps: 2520}
+  - {composite: baseline, params: {seed: 1}, steps: 2520}
+  - {composite: baseline, params: {seed: 2}, steps: 2520}
+  - {composite: baseline, params: {seed: 3}, steps: 2520}
+  - {composite: baseline, params: {seed: 4}, steps: 2520}
+
+visualizations:
+  # MultigenerationVisualization expects per-seed history + metadata. The
+  # orchestrator must marshal all runs of the baseline variant into a
+  # list-of-histories — or, if it auto-binds only a single history, the
+  # orchestrator needs an aggregator for the seeds case (open seam).
+  - name: multigen
+    address: "local:MultigenerationVisualization"
+    inputs:
+      history:  {source: runs,     variant: baseline}
+      metadata: {source: run-meta, variant: baseline}
+    config:
+      title: "Baseline — 5-seed lineage report"
+
+  # Final-step distributions across seeds, via pbg-superpowers' Distribution.
+  - name: mass-final-distribution
+    address: "local:Distribution"
+    config:
+      observable: cell_mass
+      sources: [baseline]
+      at_step: final
+      kind: histogram
+      title: "cell_mass at division (5 seeds)"
+
+  - name: growth-final-distribution
+    address: "local:Distribution"
+    config:
+      observable: instantaneous_growth_rate
+      sources: [baseline]
+      at_step: final
+      kind: histogram
+      title: "growth_rate at division (5 seeds)"
+
+  # Per-seed cell_mass trajectories overlaid.
+  - name: mass-traj-all-seeds
+    address: "local:TimeSeriesPlot"
+    config:
+      observable: cell_mass
+      sources: [baseline]
+      title: "cell_mass — all 5 seeds"
+
+# ── Notes ───────────────────────────────────────────────────────────────────
+# - If the orchestrator's binding for `history: {source: runs, variant: X}`
+#   isn't implemented, replace with explicit per-run binding (history_0..4) or
+#   shift to the older `simulations: [{kind: seeds, n_seeds: 5}]` shape if the
+#   orchestrator still supports it.
+# - 5 runs × 2520 steps is heavy (~ 5–10 min/run on a modern laptop without
+#   parallelism). The Investigations orchestrator is single-process by design;
+#   plan accordingly.

--- a/docs/workspace-template/investigations/v1-v2-parity/spec.yaml
+++ b/docs/workspace-template/investigations/v1-v2-parity/spec.yaml
@@ -1,0 +1,102 @@
+# Skeleton Investigation spec for v2ecoli — vEcoli 1.0/2.0 parity Study.
+#
+# Runs the v2ecoli baseline, then renders it alongside frozen reference
+# trajectories from upstream vEcoli 1.0 and 2.0. Catches drift between
+# v2ecoli's process-bigraph port and either upstream reference.
+#
+# Unlike the other Studies, V1V2Visualization consumes THREE histories —
+# only one is a fresh v2ecoli run; `history_v1` and `history_v2` must be
+# pre-recorded datasets the workspace ships in `data/`.
+
+name: v1-v2-parity
+question: |
+  Do v2ecoli baseline trajectories agree with upstream vEcoli 1.0 and 2.0
+  reference runs on mass + growth + RNAP dynamics?
+hypothesis: |
+  v2ecoli ≈ vEcoli 2.0 within 5 % on cell_mass over a full cycle; v2ecoli
+  may diverge from vEcoli 1.0 by up to 10 % due to known model updates.
+status: draft
+tags: [parity, regression-gate, requires-vecoli-datasets]
+
+baseline: baseline
+
+variants:
+  - name: baseline
+    source: local:baseline
+    parameters: {seed: 0, cache_dir: ${V2ECOLI_CACHE}}
+
+observables:
+  - {path: [agents, "0", listeners, mass, cell_mass]}
+  - {path: [agents, "0", listeners, mass, dry_mass]}
+  - {path: [agents, "0", listeners, mass, instantaneous_growth_rate]}
+  - {path: [agents, "0", listeners, mass, protein_mass]}
+  - {path: [agents, "0", listeners, mass, rRna_mass]}
+  - {path: [agents, "0", listeners, mass, tRna_mass]}
+  - {path: [agents, "0", listeners, mass, mRna_mass]}
+  - {path: [agents, "0", listeners, mass, dna_mass]}
+
+runs:
+  - {composite: baseline, params: {seed: 0}, steps: 2520}
+
+# External reference trajectories. These files MUST exist in
+# investigations/v1-v2-parity/data/ before running the Study. Format is a
+# pickled list-of-snapshot-dicts in the v2ecoli history shape (one dict per
+# emit tick with `listeners.mass.*` keys). See v2ecoli/reports/v1_v2_report.py
+# for the canonical loader.
+datasets:
+  - name: vecoli-1.0-baseline
+    path: ./data/vecoli_1_0_baseline_history.pkl.gz
+    description: "Upstream vEcoli 1.0 baseline run, seed 0, full cycle."
+  - name: vecoli-2.0-baseline
+    path: ./data/vecoli_2_0_baseline_history.pkl.gz
+    description: "Upstream vEcoli 2.0 baseline run, seed 0, full cycle."
+
+visualizations:
+  # V1V2Visualization expects three history streams + metadata. The v2ecoli
+  # history comes from the live run; the v1/v2 histories must be bound from
+  # the `datasets:` block above.
+  - name: v1-v2-parity
+    address: "local:V1V2Visualization"
+    inputs:
+      history_v1:      {source: dataset, dataset: vecoli-1.0-baseline}
+      history_v2:      {source: dataset, dataset: vecoli-2.0-baseline}
+      history_v2ecoli: {source: run,     run: baseline-0}
+      metadata:        {source: run-meta, run: baseline-0}
+    config:
+      title: "vEcoli 1.0 vs 2.0 vs v2ecoli — full cycle"
+
+  # BenchmarkVisualization just needs v2ecoli + one vEcoli reference for the
+  # speed/throughput comparison plot (legacy benchmark_report).
+  - name: benchmark
+    address: "local:BenchmarkVisualization"
+    inputs:
+      history_v2ecoli: {source: run,     run: baseline-0}
+      history_vecoli:  {source: dataset, dataset: vecoli-2.0-baseline}
+      metadata:        {source: run-meta, run: baseline-0}
+    config:
+      title: "v2ecoli vs vEcoli 2.0 — performance"
+
+  # A bare v2ecoli timeseries (useful even without the reference datasets).
+  - name: v2ecoli-mass
+    address: "local:TimeSeriesPlot"
+    config:
+      observable: cell_mass
+      sources: [baseline]
+      title: "v2ecoli baseline — cell mass"
+
+# ── Notes ───────────────────────────────────────────────────────────────────
+# - The `datasets:` block is a proposed extension. The current spec.yaml
+#   schema supports `overlays:` (experimental-points, reference-range,
+#   cross-investigation-series); pre-recorded trajectories don't fit those
+#   shapes cleanly. Two paths forward:
+#     a) Extend the schema with a `datasets:` block (preferred — preserves
+#        the explicit binding shown above).
+#     b) Convert the v1/v2 histories to CSV summaries and feed via
+#        experimental-points overlays on a TimeSeriesPlot.
+# - The reference dataset files do NOT ship with the workspace. Generate
+#   them once with a v1/v2 vEcoli install and place under data/ before
+#   running this Study; document the regeneration command in the Study's
+#   notes.md.
+# - V1V2Visualization handles missing histories defensively (renders the
+#   present streams + a banner), so the Study still produces useful output
+#   if only one of the two references is on disk.

--- a/tests/test_composites_colony.py
+++ b/tests/test_composites_colony.py
@@ -1,0 +1,47 @@
+"""Unit tests for v2ecoli.composites.colony."""
+
+import os
+
+import pytest
+
+
+@pytest.mark.fast
+def test_colony_function_is_registered():
+    from pbg_superpowers.composite_generator import _REGISTRY
+    from v2ecoli.composites import colony  # noqa: F401 — fires decorator
+    names = {e.name for e in _REGISTRY.values()}
+    assert "colony" in names
+
+
+@pytest.mark.fast
+def test_colony_function_signature():
+    """The generator takes (core, *, seed, cache_dir, n_cells, env_size,
+    physics_interval, ecoli_interval)."""
+    import inspect
+    from v2ecoli.composites.colony import colony
+    sig = inspect.signature(colony)
+    assert set(sig.parameters) == {
+        "core", "seed", "cache_dir",
+        "n_cells", "env_size",
+        "physics_interval", "ecoli_interval",
+    }
+
+
+@pytest.mark.sim
+def test_colony_returns_a_document():
+    """End-to-end: call colony() with the test fixture cache; the document
+    has a 'state' key with 'cells' and 'multibody' wired in."""
+    if not os.path.isdir("out/cache") and not os.environ.get("CI"):
+        pytest.skip("cache dir 'out/cache' not present; build via "
+                    "`python scripts/build_cache.py`")
+    try:
+        from multi_cell import core_import  # noqa: F401
+    except ImportError:
+        pytest.skip("multi_cell package not installed; colony requires it")
+
+    from v2ecoli.composites.colony import colony
+    doc = colony(seed=0, cache_dir="out/cache", n_cells=1)
+    assert isinstance(doc, dict)
+    assert "state" in doc
+    assert "cells" in doc["state"]
+    assert "multibody" in doc["state"]

--- a/v2ecoli/composites/__init__.py
+++ b/v2ecoli/composites/__init__.py
@@ -5,6 +5,6 @@ fires their ``@composite_generator`` decorators and registers the generators
 in ``pbg_superpowers.composite_generator._REGISTRY``.
 """
 
-from v2ecoli.composites import baseline, departitioned, reconciled  # noqa: F401
+from v2ecoli.composites import baseline, colony, departitioned, reconciled  # noqa: F401
 
-__all__ = ["baseline", "departitioned", "reconciled"]
+__all__ = ["baseline", "colony", "departitioned", "reconciled"]

--- a/v2ecoli/composites/colony.py
+++ b/v2ecoli/composites/colony.py
@@ -1,0 +1,108 @@
+"""Colony composite generator — multi-cell E. coli in pymunk 2D physics.
+
+Exposes ``v2ecoli.colony.make_colony_document`` as a process-bigraph
+``@composite_generator`` so the colony shows up alongside ``baseline``,
+``departitioned``, and ``reconciled`` in workspace catalogs / dashboards.
+
+Each cell embeds the full whole-cell model via the ``EcoliWCM`` bridge; a
+``PymunkProcess`` drives 2D physics. See ``v2ecoli/colony.py`` for the
+document body — this module is a thin registration shim.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from pbg_superpowers.composite_generator import composite_generator
+
+from v2ecoli.colony import make_colony_document
+
+
+@composite_generator(
+    name="colony",
+    description=(
+        "Multi-cell colony — whole-cell E. coli agents embedded in a "
+        "pymunk 2D physics environment via the EcoliWCM bridge."
+    ),
+    parameters={
+        "seed": {
+            "type": "integer",
+            "default": 0,
+            "description": "Base RNG seed; per-cell seed is offset by cell index.",
+        },
+        "cache_dir": {
+            "type": "string",
+            "default": "out/cache",
+            "description": "Path to the ParCa cache directory.",
+        },
+        "n_cells": {
+            "type": "integer",
+            "default": 2,
+            "description": "Number of initial cells in the colony.",
+        },
+        "env_size": {
+            "type": "number",
+            "default": 30,
+            "description": "Side length of the 2D environment (micrometers).",
+        },
+        "physics_interval": {
+            "type": "number",
+            "default": 1.0,
+            "description": "Seconds between PymunkProcess updates.",
+        },
+        "ecoli_interval": {
+            "type": "number",
+            "default": 1.0,
+            "description": "Seconds between per-cell EcoliWCM updates.",
+        },
+    },
+)
+def colony(
+    core: Any = None,
+    *,
+    seed: int = 0,
+    cache_dir: str = "out/cache",
+    n_cells: int = 2,
+    env_size: float = 30,
+    physics_interval: float = 1.0,
+    ecoli_interval: float = 1.0,
+) -> dict:
+    """Build the colony composite document.
+
+    The colony requires both the ``multi_cell`` package (``PymunkProcess``,
+    ``build_microbe``) and v2ecoli's ``EcoliWCM`` bridge. If ``core`` is not
+    supplied, one is bootstrapped with both registries; otherwise the caller
+    is responsible for having ``ECOLI_TYPES`` registered and ``EcoliWCM``
+    linked.
+
+    Args:
+        core: bigraph-schema core. If None, builds a colony-ready core.
+        seed: RNG seed for stochastic initialisation; per-cell seeds are
+            ``seed + cell_index``.
+        cache_dir: Path to the ParCa cache directory.
+        n_cells: Number of cells in the initial colony.
+        env_size: 2D environment edge length (micrometers).
+        physics_interval: PymunkProcess step interval (seconds).
+        ecoli_interval: Per-cell EcoliWCM step interval (seconds).
+
+    Returns:
+        Process-bigraph document dict with a single ``state`` key.
+    """
+    if core is None:
+        from multi_cell import core_import
+        from v2ecoli.bridge import EcoliWCM
+        from v2ecoli.types import ECOLI_TYPES
+
+        core = core_import()
+        core.register_types(ECOLI_TYPES)
+        core.register_link("EcoliWCM", EcoliWCM)
+
+    doc = make_colony_document(
+        n_cells=n_cells,
+        env_size=env_size,
+        physics_interval=physics_interval,
+        ecoli_interval=ecoli_interval,
+        cache_dir=cache_dir,
+        seed=seed,
+    )
+
+    return {"state": doc}

--- a/v2ecoli/library/cache_version.py
+++ b/v2ecoli/library/cache_version.py
@@ -54,6 +54,7 @@ INPUT_FILES: tuple[str, ...] = (
     # document shape and silently invalidate a cache built against the
     # old architecture.
     "v2ecoli/composites/baseline.py",
+    "v2ecoli/composites/colony.py",
     "v2ecoli/composites/departitioned.py",
     "v2ecoli/composites/reconciled.py",
 )


### PR DESCRIPTION
## Summary

- **`feat(composites)`** — adds a `@composite_generator(name="colony")` wrapper around `v2ecoli.colony.make_colony_document` so the multi-cell colony surfaces in workspace catalogs and dashboards alongside `baseline`, `departitioned`, and `reconciled`. Registers it in `composites/__init__.py` and `cache_version.INPUT_FILES` per AGENTS.md. New `tests/test_composites_colony.py` mirrors the three-test pattern from `test_composites_baseline.py` (registration + signature fast, document-shape sim-gated).
- **`docs(workspace-template)`** — seeds five droppable Investigation `spec.yaml` skeletons (`full-lifecycle`, `architectures-compare`, `multigeneration`, `colony`, `v1-v2-parity`) under `docs/workspace-template/investigations/`. Each is pre-wired to the v2ecoli composite generators + the seven Visualization Steps from #39. Intended for a sibling `v2ecoli-workspace` repo built from `pbg-template` — v2ecoli itself stays a clean simulation package.
- **`fix(ci)`** — `.github/workflows/ci.yml` edit (called out explicitly per AGENTS.md). The cache-restore step's `hashFiles` list had drifted: it referenced the deleted `v2ecoli/composite.py` and was missing the four `composites/*.py` files plus `core.py`. So the CI cache silently went stale on any composite change — adding `colony.py` to `INPUT_FILES` is the first to expose it (8 × `StaleCacheError` in `behavior-tests`). Fix mirrors `cache_version.INPUT_FILES` exactly and adds `cache_version.py` so future drifts auto-invalidate. Bumps key v1 → v2 to force one clean rebuild.

## Why

`#39` ported the legacy reports to `Visualization(Step)` subclasses, and `pbg-superpowers` already provides the Investigations dashboard. The missing pieces for v2ecoli were: (1) the colony architecture wasn't a `@composite_generator` (only `make_colony_document` existed), and (2) no ready-made `spec.yaml` files so a researcher could go from `git clone` → working Studies without hand-authoring orchestrator wiring.

## Open seams (flagged inline in each spec.yaml)

Three orchestrator-side conventions proposed in the specs but not yet verified against the running dashboard:

1. **`inputs:` port-binding block** on each viz — explicit `{source: run|run-meta|runs|variant-document|variant-documents|dataset, …}` mapping. The current schema doesn't define this; the orchestrator may auto-bind by port name. Will surface on first run.
2. **`${V2ECOLI_CACHE}` env-var interpolation** in `parameters.cache_dir`.
3. **`datasets:` block** (v1-v2-parity only) for pre-recorded external reference trajectories — doesn't fit the current `overlays:` shapes.

## Test plan

- [x] `pytest tests/test_composites_colony.py -m fast` — 2 pass, 1 sim-gated
- [x] `pytest tests/test_composites_*.py -m fast` — 8/8 pass (no regressions in baseline/departitioned/reconciled)
- [x] `compute_cache_version()` runs cleanly with the new INPUT_FILES (10 files)
- [x] CI: `fix(ci)` resolves the StaleCacheError seen in `behavior-tests` on the initial run
- [ ] Run the colony sim-gated test once a cache is built locally
- [ ] Bootstrap v2ecoli-workspace and exercise `/pbg-investigate full-lifecycle` end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)