### PR TITLE
fix(viz): use 'node' instead of 'any' in Visualization input type strings

### DIFF
--- a/v2ecoli/visualizations/benchmark.py
+++ b/v2ecoli/visualizations/benchmark.py
@@ -50,9 +50,9 @@ class BenchmarkVisualization(Visualization):
     """Render v2ecoli vs vEcoli side-by-side benchmark.
 
     Inputs:
-      - history_v2ecoli: list[map[any]] — trajectory rows from v2ecoli run
-      - history_vecoli:  list[map[any]] — trajectory rows from vEcoli run
-      - metadata:        map[any]       — run metadata (seed, duration, etc.)
+      - history_v2ecoli: list[map[node]] — trajectory rows from v2ecoli run
+      - history_vecoli:  list[map[node]] — trajectory rows from vEcoli run
+      - metadata:        map[node]       — run metadata (seed, duration, etc.)
     """
 
     config_schema = {
@@ -61,9 +61,9 @@ class BenchmarkVisualization(Visualization):
 
     def inputs(self) -> dict[str, Any]:
         return {
-            "history_v2ecoli": "list[map[any]]",
-            "history_vecoli":  "list[map[any]]",
-            "metadata":        "map[any]",
+            "history_v2ecoli": "list[map[node]]",
+            "history_vecoli":  "list[map[node]]",
+            "metadata":        "map[node]",
         }
 
     def update(self, state: dict[str, Any]) -> dict:

--- a/v2ecoli/visualizations/colony.py
+++ b/v2ecoli/visualizations/colony.py
@@ -71,8 +71,8 @@ class ColonyVisualization(Visualization):
 
     def inputs(self) -> dict[str, Any]:
         return {
-            "history":  "list[map[any]]",
-            "metadata": "map[any]",
+            "history":  "list[map[node]]",
+            "metadata": "map[node]",
         }
 
     def update(self, state: dict[str, Any]) -> dict:

--- a/v2ecoli/visualizations/compare.py
+++ b/v2ecoli/visualizations/compare.py
@@ -77,7 +77,7 @@ class CompareVisualization(Visualization):
 
     def inputs(self) -> dict[str, Any]:
         return {
-            "composite_specs": "list[map[any]]",
+            "composite_specs": "list[map[node]]",
         }
 
     def update(self, state: dict[str, Any]) -> dict:

--- a/v2ecoli/visualizations/multigeneration.py
+++ b/v2ecoli/visualizations/multigeneration.py
@@ -66,8 +66,8 @@ class MultigenerationVisualization(Visualization):
 
     def inputs(self) -> dict[str, Any]:
         return {
-            "history":  "list[map[any]]",
-            "metadata": "map[any]",
+            "history":  "list[map[node]]",
+            "metadata": "map[node]",
         }
 
     def update(self, state: dict[str, Any]) -> dict:

--- a/v2ecoli/visualizations/network.py
+++ b/v2ecoli/visualizations/network.py
@@ -27,7 +27,7 @@ class NetworkVisualization(Visualization):
 
     def inputs(self) -> dict[str, Any]:
         return {
-            "composite_spec": "map[any]",
+            "composite_spec": "map[node]",
         }
 
     def update(self, state: dict[str, Any]) -> dict:

--- a/v2ecoli/visualizations/v1_v2.py
+++ b/v2ecoli/visualizations/v1_v2.py
@@ -328,10 +328,10 @@ class V1V2Visualization(Visualization):
 
     def inputs(self) -> dict[str, Any]:
         return {
-            "history_v1":      "list[map[any]]",
-            "history_v2":      "list[map[any]]",
-            "history_v2ecoli": "list[map[any]]",
-            "metadata":        "map[any]",
+            "history_v1":      "list[map[node]]",
+            "history_v2":      "list[map[node]]",
+            "history_v2ecoli": "list[map[node]]",
+            "metadata":        "map[node]",
         }
 
     def update(self, state: dict[str, Any]) -> dict:

--- a/v2ecoli/visualizations/workflow.py
+++ b/v2ecoli/visualizations/workflow.py
@@ -514,8 +514,8 @@ class WorkflowVisualization(Visualization):
 
     def inputs(self) -> dict[str, Any]:
         return {
-            "history":  "list[map[any]]",
-            "metadata": "map[any]",
+            "history":  "list[map[node]]",
+            "metadata": "map[node]",
         }
 
     def update(self, state: dict[str, Any]) -> dict:


### PR DESCRIPTION
## Summary

bigraph-schema's type parser doesn't resolve ``any`` as a type parameter, so every Visualization class that declared ``inputs()`` with ``map[any]`` / ``list[map[any]]`` failed at Composite construction with:

```
unable to parse type "map[any]"

due to
cannot resolve types, not schemas: Node(_default=None) any
```

``node`` is the canonical bigraph-schema base type — exactly the wildcard we wanted. Replace ``map[any]`` → ``map[node]`` and ``list[map[any]]`` → ``list[map[node]]`` across all 7 v2ecoli ``Visualization`` classes:

| File | Ports |
|---|---|
| `workflow.py` | `history`, `metadata` |
| `multigeneration.py` | `history`, `metadata` |
| `colony.py` | `history`, `metadata` |
| `compare.py` | `composite_specs` |
| `network.py` | `composite_spec` |
| `v1_v2.py` | `history_v1`/`v2`/`v2ecoli`, `metadata` |
| `benchmark.py` | `history_v2ecoli`/`vecoli`, `metadata` |

## End-to-end verified

A fresh ``POST /api/study-run-baseline {study: full-lifecycle, steps: 5}`` against the dashboard now writes 8 HTML files under ``investigations/full-lifecycle/viz/``:

```
   610 absolute-mass-components.html  ← TimeSeriesPlot (unchanged)
   598 cell-mass.html                  ← TimeSeriesPlot
   600 cell-volume.html                ← TimeSeriesPlot
   625 growth-rate.html                ← TimeSeriesPlot
   600 mass-fold-change.html           ← TimeSeriesPlot
   598 mass-fractions.html             ← TimeSeriesPlot
 23731 topology.html                   ← NetworkVisualization (Cytoscape)
  7604 workflow.html                   ← WorkflowVisualization (full lifecycle report)
```

The two large files (workflow + topology) were error stubs (~150 B) before this PR; now they're fully-rendered HTML. The integrated `WorkflowVisualization` covers the chromosome state + replication forks + ppGpp dynamics panels that prompted the original feature request.

## Note

Behaviour-of-`map[any]`-vs-`map[node]`: in bigraph-schema's type system today, both are intended to mean "untyped leaf map values". `node` is what the parser actually accepts. If `any` is ever added as a sugar alias for `node`, this PR's choice will still parse — the change is forward-compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)