### PR TITLE
docs(readme): cut to the point

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,19 @@
 # v2ecoli
 
-**Pure process-bigraph E. coli whole-cell model**
+Pure [process-bigraph](https://github.com/vivarium-collective/process-bigraph)
+port of the Covert lab's whole-cell *E. coli* model
+([vEcoli](https://github.com/CovertLab/vEcoli)). 55 biological processes, no
+vivarium-core dependency, same biology to within 0.0% dry-mass drift at 60 s.
 
-v2ecoli is the next-generation whole-cell *E. coli* simulation built entirely on 
-[process-bigraph](https://github.com/vivarium-collective/process-bigraph) — 
-no vivarium-core dependency. It ports all 55 biological processes from 
-[vEcoli](https://github.com/CovertLab/vEcoli) with identical biological output 
-and comparable performance.
-
-The Parameter Calculator (ParCa) that turns the raw knowledge base into
-a fitted `sim_data` also lives in this repo, as the nine-Step composite
-at [`v2ecoli/processes/parca/`](v2ecoli/processes/parca/).  vEcoli is
-used only by the side-by-side comparison report — the runtime and the
-flat-file knowledge base are both vendored, so a fresh clone can run
-the full build → simulate → divide pipeline end-to-end without any
-external vEcoli checkout.
+The Parameter Calculator (ParCa) — the ~70 min knowledge-base build that
+fits `sim_data` — is decomposed into nine process-bigraph Steps and ships
+pre-computed at `models/parca/parca_state.pkl.gz`, so a fresh clone can
+simulate end-to-end without rebuilding.
 
 ## Install
 
-Requires [`uv`](https://docs.astral.sh/uv/) (recommended) and a C
-compiler (Xcode CLI tools on macOS, `build-essential` on Linux).
+Requires [`uv`](https://docs.astral.sh/uv/) and a C compiler (Xcode CLI
+tools on macOS, `build-essential` on Linux).
 
 ```bash
 git clone https://github.com/vivarium-collective/v2ecoli.git
@@ -27,259 +21,116 @@ cd v2ecoli
 uv sync
 ```
 
-`uv sync` provisions Python 3.12, installs all dependencies (vEcoli,
+`uv sync` provisions Python 3.12, installs every dependency (vEcoli,
 process-bigraph, bigraph-schema, multi-cell), and compiles the three
-vendored Cython extensions automatically.  The fitted `sim_data` ships
-pre-computed at [`models/parca/parca_state.pkl.gz`](models/parca/) so a
-fresh clone can simulate end-to-end without re-running ParCa
-(~70 min).  See [Re-running from scratch](#re-running-from-scratch) for
-that path.
+vendored Cython extensions.
 
-### Auto-discovery via bigraph-schema
-
-v2ecoli ships a lightweight discovery layer that follows the
-[bigraph-schema package-discovery convention](https://github.com/vivarium-collective/bigraph-schema).
-
-Once v2ecoli is pip-installed (editable or otherwise) in a venv that also
-has `bigraph-schema` and `process-bigraph`, the key biological processes
-auto-register whenever a consumer calls `allocate_core()` — no manual
-`core.register_link()` calls needed:
-
-```python
-from process_bigraph import allocate_core
-
-core = allocate_core()
-print([k for k in core.link_registry if 'DnaA' in k or 'ChromosomePartition' in k])
-# ['DnaABinder', 'v2ecoli.processes.chromosome_initiation.DnaABinder',
-#  'ChromosomePartition', 'v2ecoli.processes.chromosome_initiation.ChromosomePartition']
-```
-
-Discovery-safe classes (importable without the full vEcoli / Cython stack):
-
-| Class | Module | Description |
-|---|---|---|
-| `DnaABinder` | `v2ecoli.processes.chromosome_initiation` | DnaA-oriC binding dynamics (skeleton) |
-| `ChromosomePartition` | `v2ecoli.processes.chromosome_initiation` | Chromosome partitioning at division (skeleton) |
-
-The full vEcoli-backed processes (`ChromosomeReplication`, `Metabolism`, etc.)
-are also `process_bigraph.Step` subclasses and will be discovered if the
-complete v2ecoli dependency set is available in the consumer's environment.
-
-## Reports
-
-**[All reports](https://vivarium-collective.github.io/v2ecoli/)** —
-cell lifecycle, colony, architecture comparisons, ParCa pipeline, and
-composition-graph visualizations.
-
-## ParCa
-
-The Parameter Calculator (ParCa) is the build step that turns ~130
-TSVs of raw knowledge-base data (genes, RNAs, proteins, reactions,
-concentrations, DNA sites) into a fitted `SimulationDataEcoli` that
-the online model reads from.  In the Covert-lab vEcoli the ParCa is a
-single monolithic `fitSimData_1()` call; v2ecoli decomposes it into
-nine process-bigraph `Step`s with explicit, named ports, so each
-stage's inputs and outputs are wired through the composite's store
-rather than threaded through a deeply-mutated `sim_data` blob.
-
-### Pipeline
-
-| Step | What it does |
-|---|---|
-| 1. initialize | Bootstraps `SimulationDataEcoli` from the flat files; scatters tables across the 20 subsystem objects (Mass, Constants, Transcription, Translation, Metabolism, …). |
-| 2. input_adjustments | Hand-curated corrections to expression, degradation rates, translation efficiencies, and small-molecule targets. |
-| 3. basal_specs | Builds the reference cell spec (M9 + glucose, no TF perturbations) — the anchor every condition perturbs away from. |
-| 4. tf_condition_specs | Per-TF activation replay of step 3; produces one spec per (condition, TF) pair.  ~50 s in fast mode. |
-| 5. fit_condition | Solves for bulk distributions + translation supply rates that make the specs self-consistent.  **~70 min** — the dominant cost, and the reason the step-5 checkpoint is memoized. |
-| 6. promoter_binding | CVXPY fits of TF-promoter recruitment strengths and binding probabilities. |
-| 7. adjust_promoters | Ligand concentrations + RNAP recruitment adjusted to match step 6. |
-| 8. set_conditions | Materializes per-nutrient dicts the online simulation indexes by `condition`. |
-| 9. final_adjustments | ppGpp kinetics + amino-acid supply constants + mechanistic kcat/KM corrections. |
-
-The per-step port manifests ship in
-[`v2ecoli/processes/parca/steps/`](v2ecoli/processes/parca/steps/); the
-wire table is [`STORE_PATH`](v2ecoli/processes/parca/composite.py).
-A static [`models/parca.pbg`](models/parca.pbg) (~16 KB) captures the
-same 9-Step pipeline as a process-bigraph JSON document — addresses +
-port wiring, no fitted data — for tooling that wants to inspect the
-pipeline shape without importing v2ecoli.  Regenerated automatically
-by `python reports/workflow_report.py` alongside `models/baseline.pbg`.
-
-### Using the fitted `sim_data`
-
-A gzipped pickle of the final state ships at
-[`models/parca/parca_state.pkl.gz`](models/parca/README.md) (18 MB)
-so downstream code can skip the ~70-min build:
-
-```python
-from v2ecoli.processes.parca.data_loader import load_parca_state
-state = load_parca_state()
-
-transcription = state['process']['transcription']
-sim_data_root = state['sim_data_root']   # full SimulationDataEcoli
-```
-
-The loader transparently aliases legacy `v2parca.*` / `vparca.*`
-pickle module paths, so older artifacts deserialize cleanly.
-
-The `workflow.py` pipeline's `step_parca` hydrates this fixture by
-default (~2 s) and dills its `sim_data_root` into
-`out/workflow/simData.cPickle` for downstream `save_cache()`.  Pass
-`--parca-rerun` to re-execute the full 9-Step composite instead.
-
-### Re-running from scratch
+## Quick start
 
 ```bash
-# Full pipeline (~70 min in fast mode; --cpus defaults to os.cpu_count)
-v2ecoli-parca --mode fast
+# Single cell to division (~42 simulated min)
+python reports/workflow_report.py
 
-# Or resume from a cached step-5 checkpoint (~15 s)
-bash scripts/parca_rerun_from_step5.sh
+# Three-cell colony with N adder-grow-divide surrogates
+python reports/colony_report.py --duration 45 --n-adder 5
+
+# Baseline vs departitioned vs reconciled architectures
+python reports/compare_report.py
+
+# vEcoli ↔ v2ecoli benchmark
+python reports/benchmark_report.py
 ```
 
-The Cython extensions are built automatically by `uv sync`.  If you
-edit a `.pyx` file and want to rebuild without a full reinstall, run
-`bash scripts/parca_cython_build.sh`.
+Each script writes a self-contained HTML report under `out/` and opens it.
 
-### Reconstruction data
+## Published reports
 
-The flat-file knowledge base is vendored at
-[`v2ecoli/processes/parca/reconstruction/ecoli/flat/`](v2ecoli/processes/parca/reconstruction/ecoli/flat/)
-(133 files, ~12.9 MB).  Ten of these come from EcoCyc and can be
-refreshed from the BioCyc webservice:
-
-```bash
-python scripts/parca_update_biocyc.py
-```
-
-The remaining ~120 are Covert-lab-curated overlays (diffs, modifier
-files, manually-added entries, compartment definitions, …) that live
-only in this repo's history.  The comparison report surfaces both
-sets with per-file GitHub links and EcoCyc/Curated source badges.
-
-### Comparison report
-
-[`scripts/parca_compare.py`](scripts/parca_compare.py) generates a
-self-contained HTML report with per-step runtime, port manifests, and
-scalar/distribution/cell_specs diffs against the original vEcoli
-`fitSimData_1` (the only place v2ecoli pulls from the Covert-lab
-vEcoli tree).  The rendered output is published at
-[vivarium-collective.github.io/v2ecoli/parca_comparison_report.html](https://vivarium-collective.github.io/v2ecoli/parca_comparison_report.html).
-
-### Tests
-
-| File | What it covers |
-|---|---|
-| [`tests/test_parca_ports_and_wiring.py`](tests/test_parca_ports_and_wiring.py) | Static checks: every declared port is in `STORE_PATH`; tick sequencing is valid; composite builds with a mocked raw_data.  Fast. |
-| [`tests/test_parca_fixture_roundtrip.py`](tests/test_parca_fixture_roundtrip.py) | Loads `models/parca/parca_state.pkl.gz`, asserts 24 top-level keys + 9 subsystem classes. |
-| [`tests/test_parca_alignment_vs_vecoli.py`](tests/test_parca_alignment_vs_vecoli.py) | Scalar-drift gate vs vEcoli's step-1-4 intermediates.  Skips cleanly when reference pickles aren't present. |
-| [`tests/test_workflow_parca_integration.py`](tests/test_workflow_parca_integration.py) | `workflow.step_parca` fast-path hydration (< 15 s); path sanity (no `../vEcoli/` references); KB stats via merged `KnowledgeBaseEcoli`. |
-
-### Composition diagrams
-
-Interactive per-architecture network views: click a process to inspect its
-inputs/outputs, port schemas, config, docstring, and mathematical model
-(with role-specific math for requester/evolver halves of partitioned
-processes). Bipartite layout by default (stores on the left, processes on
-the right); switch to dagre/fcose/grid/etc. from the dropdown.
-
-- **[Baseline (partitioned)](https://vivarium-collective.github.io/v2ecoli/network_baseline.html)** 
-- **[Departitioned](https://vivarium-collective.github.io/v2ecoli/network_departitioned.html)** 
-- **[Reconciled](https://vivarium-collective.github.io/v2ecoli/network_reconciled.html)** 
-
-These are also embedded as iframes inside the Architecture Comparison
-report and generated by `python reports/compare_report.py` or, individually, by
-`python reports/network_report.py --model baseline|departitioned|reconciled`.
-
-## Architecture
-
-```
-multi-cell colony (pymunk 2D physics)
-  └─ cells/
-       ├─ surrogate_1 (AdderGrowDivide)   ← grey
-       ├─ surrogate_2 (AdderGrowDivide)   ← grey
-       ├─ ecoli_0 (EcoliWCM bridge)       ← colored
-       │    └─ internal Composite
-       │         ├─ 11 PartitionedProcesses (requester/allocator/evolver)
-       │         ├─ 4 non-partitioned Steps (metabolism, chromosome structure, ...)
-       │         ├─ 9 listener Steps
-       │         └─ infrastructure (global clock, unique update, emitter)
-       └─ ...
-```
-
-Each whole-cell E. coli is wrapped by `EcoliWCM`, a process-bigraph `Process` 
-that holds an internal `Composite` with a bridge mapping:
-
-| External port | Internal store |
-|---------------|----------------|
-| `local` (input) | `boundary.external` |
-| `mass` (output) | `listeners.mass.dry_mass` |
-| `length` (output) | computed from volume via capsule geometry |
-| `volume` (output) | `listeners.mass.volume` |
-
-When the internal model reaches division (~702 fg dry mass), the bridge 
-removes the mother cell and adds two daughter cells with fresh `EcoliWCM` 
-processes and phylogeny-mutated colors.
+[vivarium-collective.github.io/v2ecoli](https://vivarium-collective.github.io/v2ecoli/)
+— cell lifecycle, colony, architecture comparison, ParCa pipeline,
+multi-generation lineage, and per-architecture composition graphs
+(baseline / [departitioned](https://vivarium-collective.github.io/v2ecoli/network_departitioned.html)
+/ [reconciled](https://vivarium-collective.github.io/v2ecoli/network_reconciled.html)).
+Regenerated from the corresponding `reports/*.py` scripts.
 
 ## Performance
 
-| Metric | vEcoli (composite) | v2ecoli |
-|--------|-------------------|---------|
-| 60s simulation | 6.5s wall | 7.3s wall |
-| Speed | 9.2x realtime | 8.2x realtime |
-| Division time | ~42 min | ~42 min |
-| dry_mass at 60s | 384.5 fg | 384.6 fg |
-| Mass difference | — | 0.0% |
-| vivarium-core | required | **none** |
+| | vEcoli | v2ecoli |
+|---|---|---|
+| 60 s simulated wall | 6.5 s | 7.3 s |
+| Realtime factor | 9.2× | 8.2× |
+| Dry mass at 60 s | 384.5 fg | 384.6 fg |
+| Time to division | ~42 min | ~42 min |
+| vivarium-core | required | none |
 
-## Quick Start
+## Architecture
 
-```bash
-# Single cell simulation (runs to division)
-python3 reports/workflow_report.py
+Three architectures share the same 55 processes and 9 listeners; they
+differ in how they're scheduled.
 
-# Colony simulation (1 wc-ecoli + N surrogates)
-python3 reports/colony_report.py --duration 45 --n-adder 5
+| Architecture | Composite generator | What it is |
+|---|---|---|
+| baseline | `v2ecoli.composites.baseline` | Partitioned (requester/allocator/evolver) — vEcoli-parity |
+| departitioned | `v2ecoli.composites.departitioned` | Flat process layout, no allocator |
+| reconciled | `v2ecoli.composites.reconciled` | Hybrid — partitioned where required, flat elsewhere |
 
-# Baseline vs departitioned architecture comparison (42 min)
-python3 reports/compare_report.py
+Each whole cell is wrapped by `EcoliWCM`, a process-bigraph `Process`
+that holds an internal `Composite` and a bridge:
 
-# Benchmark comparison
-python3 reports/benchmark_report.py
+| External port | Internal store |
+|---|---|
+| `local` (in) | `boundary.external` |
+| `mass` (out) | `listeners.mass.dry_mass` |
+| `length` (out) | from `volume` via capsule geometry |
+| `volume` (out) | `listeners.mass.volume` |
 
-# Three-way comparison (vEcoli 1.0, vEcoli 2.0, v2ecoli)
-python3 reports/v1_v2_report.py --duration 2500
+At division (~702 fg dry mass) the bridge swaps the mother for two
+daughters with fresh `EcoliWCM`s and phylogeny-mutated colors.
+
+## ParCa
+
+ParCa is the build step that fits ~130 knowledge-base TSVs into a
+`SimulationDataEcoli` blob the runtime reads from. The original is one
+monolithic `fitSimData_1()`; v2ecoli decomposes it into nine
+process-bigraph Steps with explicit ports, wired through the composite's
+store. Stage 5 (`fit_condition`) is the ~70 min cost; everything else is
+seconds.
+
+- Pre-computed `sim_data`: `models/parca/parca_state.pkl.gz` (18 MB).
+- Re-run from scratch: `v2ecoli-parca --mode fast` (~70 min).
+- Resume from cached step-5 checkpoint: `bash scripts/parca_rerun_from_step5.sh`.
+- Refresh BioCyc-sourced flat files: `python scripts/parca_update_biocyc.py`.
+
+## Auto-discovery
+
+When v2ecoli is pip-installed alongside `bigraph-schema` and
+`process-bigraph`, all biological processes register themselves on
+`allocate_core()` — no manual `core.register_link()` calls:
+
+```python
+from process_bigraph import allocate_core
+core = allocate_core()
+# core.link_registry now contains v2ecoli.processes.* by both bare and
+# fully-qualified names.
 ```
 
 ## Dependencies
 
-- [process-bigraph](https://github.com/vivarium-collective/process-bigraph) — composable simulation framework
-- [bigraph-schema](https://github.com/vivarium-collective/bigraph-schema) — type system
-- [vEcoli](https://github.com/CovertLab/vEcoli) — ParCa parameter calculator (for config generation)
-- [multi-cell](https://github.com/vivarium-collective/pymunk-process) — 2D colony physics (pymunk)
+- [process-bigraph](https://github.com/vivarium-collective/process-bigraph) — simulation framework
+- [bigraph-schema](https://github.com/vivarium-collective/bigraph-schema) — type system + discovery
+- [vEcoli](https://github.com/CovertLab/vEcoli) — ParCa reference data
+- [multi-cell](https://github.com/vivarium-collective/pymunk-process) — 2D colony physics
 
-## Project Structure
+## Layout
 
 ```
 v2ecoli/
-├── v2ecoli/
-│   ├── __init__.py         # build_composite() entry point
-│   ├── composites/         # baseline, departitioned, reconciled architectures
-│   ├── bridge.py           # EcoliWCM: whole-cell model as Process with bridge
-│   ├── colony.py           # make_colony() for multi-cell simulations
-│   ├── processes/          # 15 biological processes (from vEcoli)
-│   ├── steps/              # infrastructure + 9 listeners
-│   ├── types/              # custom bigraph-schema types
-│   └── library/            # shared utilities
-├── reports/
-│   ├── workflow_report.py        # single cell lifecycle report
-│   ├── multigeneration_report.py # N-generation single lineage report
-│   ├── colony_report.py          # colony simulation report
-│   ├── compare_report.py         # baseline vs departitioned vs reconciled comparison
-│   ├── network_report.py         # per-architecture Cytoscape diagram
-│   ├── benchmark_report.py       # v2ecoli vs vEcoli benchmark
-│   └── v1_v2_report.py           # three-way engine comparison
-├── models/
-│   └── baseline.pbg        # serialized model document
-└── docs/                   # GitHub Pages reports
+  composites/    baseline · departitioned · reconciled · colony
+  processes/     15 biological processes + parca/ (9-step pipeline)
+  steps/         infrastructure + 9 listeners
+  visualizations/ Visualization Steps backing each report
+  bridge.py      EcoliWCM wrapper
+  colony.py      make_colony() multi-cell builder
+reports/         CLI orchestrators (one per published report)
+models/          pre-computed sim_data + serialized .pbg documents
+tests/           unit + integration + ParCa alignment
 ```


### PR DESCRIPTION
## Summary
- 285 → 136 lines. Drop AI-flavored long-form prose; lead with what a fresh reader actually needs.
- Kept: one-paragraph pitch with the 0.0% drift number, install/uv sync, four-script quick-start, link to published reports, perf table, three-architecture table, EcoliWCM bridge table, ParCa essentials (pickle location, rebuild commands), dependencies, tight layout tree.
- Cut or compressed: stage-by-stage ParCa narrative, auto-discovery sales pitch (kept as a 6-line note), composition-diagrams subsection, reconstruction-data prose, duplicated project-structure block.

## Follow-up (separate PRs)
- Move detailed ParCa stage table + tests-list into \`docs/PARCA.md\` so the README can link out without losing the content.
- Add \`docs/REPORTS.md\` once \"Study-style\" multi-composite orchestration lands, so the per-report wiring + viz lineage is documented in one place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)