### PR TITLE
ci(perf): parallelize CI tests via pytest-xdist (~2× speedup)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,12 +40,17 @@ jobs:
         run: uv sync --extra dev || uv sync
 
       - name: Run fast tests (no .run() calls)
+        # -n auto: pytest-xdist parallelism (~4 workers on ubuntu-latest).
+        # --dist=loadfile keeps tests from the same file on one worker —
+        # any module-level fixtures (caches, registry setup) only pay
+        # the build cost once per file, not once per worker.
         run: >-
           uv run pytest
           -m "not slow and not sim"
           --ignore=tests/test_initialize.py
           --ignore=tests/test_kinetics_units.py
           --ignore=tests/test_unit_bridge.py
+          -n auto --dist=loadfile
           -v --tb=short
 
   behavior-tests:
@@ -98,10 +103,17 @@ jobs:
       - name: Run simulation-based behavior tests
         env:
           CI: 'true'
+        # -n auto: pytest-xdist parallelism. The 7 behavior tests are
+        # mostly independent full-composite runs that each spend ~2 min
+        # in the inner WCM; parallelizing across 4 workers should
+        # roughly halve the wall time (target ~7 min vs ~14 min serial).
+        # --dist=loadfile keeps a file's tests on one worker so any
+        # module-level ParCa-cache-warm fixture pays its cost once.
         run: >-
           uv run pytest
           -m "sim and not slow"
           --ignore=tests/test_initialize.py
           --ignore=tests/test_kinetics_units.py
           --ignore=tests/test_unit_bridge.py
+          -n auto --dist=loadfile
           -v --tb=short

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
 
 [project.optional-dependencies]
 # Test-only deps. `uv sync --extra dev` pulls these in.
-dev = ["pytest-timeout>=2.3"]
+dev = ["pytest-timeout>=2.3", "pytest-xdist>=3.6"]
 parquet = [
     "duckdb",
     "polars",

--- a/uv.lock
+++ b/uv.lock
@@ -785,6 +785,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "executing"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2934,6 +2943,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -3813,6 +3835,7 @@ dependencies = [
 [package.optional-dependencies]
 dev = [
     { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
 ]
 emitters = [
     { name = "duckdb" },
@@ -3852,6 +3875,7 @@ requires-dist = [
     { name = "process-bigraph", git = "https://github.com/vivarium-collective/process-bigraph.git?branch=main" },
     { name = "pymunk" },
     { name = "pytest-timeout", marker = "extra == 'dev'", specifier = ">=2.3" },
+    { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.6" },
     { name = "requests" },
     { name = "scipy" },
     { name = "spatio-flux", git = "https://github.com/vivarium-collective/spatio-flux.git?branch=main" },


### PR DESCRIPTION
## Summary
behavior-tests on `main` currently runs ~14 min serial in the inner pytest step (7 sim tests, each spinning up a full v2ecoli composite). GitHub-hosted `ubuntu-latest` runners give 4 cores, so the CPU is idle 75% of the time. This PR parallelizes both CI jobs with `pytest-xdist`.

Follow-up to #53.

## Change
- `pyproject.toml`: dev deps gain `pytest-xdist>=3.6`
- `uv.lock`: regenerated (adds `pytest-xdist` + `execnet`)
- `.github/workflows/ci.yml`: both `fast-tests` and `behavior-tests` gain `-n auto --dist=loadfile`

## Flags explained
- `-n auto` — distribute tests across all CPU cores (4 on ubuntu-latest)
- `--dist=loadfile` — keep a file's tests on one worker so any module-level fixtures (ParCa-cache warm-up, registry setup) only pay the build cost once per file, not once per worker

## Expected
| Job | Before | After (target) |
|---|---|---|
| fast-tests | 1m | ~30s |
| behavior-tests | 14m | ~7m |

Amdahl on the 4-worker / 7-test split caps behavior-tests at roughly 2×. fast-tests has less to gain (overhead dominates) but goes parallel for consistency.

## Risk
Tests share a read-only ParCa cache fixture and don't write to global state, so xdist should be safe. If a specific test turns out to be xdist-unsafe (process-bigraph singleton registry, file-write race, etc.), opt it out with `@pytest.mark.no_parallel` + a small ini config tweak — won't block this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)