### PR TITLE
fix(emitter): default sqlite_emitter to workspace .pbg/composite-runs.db

### DIFF
--- a/tests/test_sqlite_emitter_workspace_default.py
+++ b/tests/test_sqlite_emitter_workspace_default.py
@@ -1,0 +1,133 @@
+"""Unit tests for the ``sqlite_emitter()`` workspace-default behavior.
+
+Confirms:
+  - When called with no ``file_path``, the emitter override resolves to
+    ``<workspace_root>/.pbg/composite-runs.db`` (auto-detected by walking
+    up from cwd looking for ``workspace.yaml``).
+  - The ``simulations`` table grows ``study_slug`` + ``investigation_slug``
+    columns on first use, and the slugs passed to the context manager are
+    stamped onto the row.
+  - Explicit ``file_path`` + ``db_file`` still work (back-compat).
+
+These tests don't run a real composite — they exercise the helper around a
+synthetic SQLite DB so they're fast (no parca, no cell sim).
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+
+import pytest
+
+from v2ecoli.composites._helpers import (
+    _EMITTER_OVERRIDE,  # noqa: F401 — referenced via module attribute
+    set_emitter_override,
+    sqlite_emitter,
+)
+from v2ecoli.composites import _helpers as _h
+
+
+@pytest.mark.fast
+def test_workspace_default_resolves_to_pbg_composite_runs_db(tmp_path, monkeypatch):
+    """No file_path -> <workspace>/.pbg/composite-runs.db, with the slug columns."""
+    (tmp_path / 'workspace.yaml').write_text('name: test-ws\n')
+    monkeypatch.chdir(tmp_path)
+
+    with sqlite_emitter(
+        name='smoke-run',
+        study_slug='dnaa-01-expression-dynamics',
+        investigation_slug='dnaa-replication',
+    ) as cfg:
+        assert cfg['file_path'] == str(tmp_path / '.pbg')
+        assert cfg['db_file'] == 'composite-runs.db'
+        sim_id = cfg['simulation_id']
+
+    db = tmp_path / '.pbg' / 'composite-runs.db'
+    assert db.is_file(), '.pbg/composite-runs.db not created'
+    conn = sqlite3.connect(str(db))
+    try:
+        cols = {row[1] for row in conn.execute('PRAGMA table_info(simulations)')}
+        assert 'study_slug' in cols
+        assert 'investigation_slug' in cols
+        row = conn.execute(
+            'SELECT study_slug, investigation_slug '
+            'FROM simulations WHERE simulation_id = ?',
+            (sim_id,),
+        ).fetchone()
+        assert row == ('dnaa-01-expression-dynamics', 'dnaa-replication')
+    finally:
+        conn.close()
+
+
+@pytest.mark.fast
+def test_explicit_file_path_preserves_backcompat(tmp_path, monkeypatch):
+    """Passing file_path explicitly keeps the old per-study layout."""
+    study_dir = tmp_path / 'studies' / 'dnaa-01'
+    study_dir.mkdir(parents=True)
+    # Put us somewhere with no workspace.yaml to prove the default-resolver
+    # isn't triggered when file_path is supplied.
+    monkeypatch.chdir(tmp_path)
+
+    with sqlite_emitter(
+        file_path=str(study_dir),
+        db_file='runs.db',
+        name='legacy',
+    ) as cfg:
+        assert cfg['file_path'] == str(study_dir)
+        assert cfg['db_file'] == 'runs.db'
+
+    assert (study_dir / 'runs.db').is_file()
+
+
+@pytest.mark.fast
+def test_missing_workspace_raises(tmp_path, monkeypatch):
+    """No workspace.yaml in the cwd chain + no file_path -> clear error."""
+    # Park cwd somewhere with no workspace.yaml ancestor.
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(_h, '_find_workspace_root', lambda *_a, **_k: None)
+
+    with pytest.raises(RuntimeError, match='workspace.yaml'):
+        with sqlite_emitter(name='no-ws'):
+            pass
+
+
+@pytest.mark.fast
+def test_slugs_optional(tmp_path, monkeypatch):
+    """Omitting slugs leaves the columns NULL; no crash."""
+    (tmp_path / 'workspace.yaml').write_text('name: test-ws\n')
+    monkeypatch.chdir(tmp_path)
+    with sqlite_emitter(name='plain') as cfg:
+        sim_id = cfg['simulation_id']
+    db = tmp_path / '.pbg' / 'composite-runs.db'
+    assert db.is_file()
+    conn = sqlite3.connect(str(db))
+    try:
+        # The row is only inserted when slugs are present; without slugs
+        # the helpers don't touch the row at all (the emitter would insert
+        # it at runtime). Verify the columns at least exist on the table.
+        cols = {row[1] for row in conn.execute('PRAGMA table_info(simulations)')}
+        assert 'study_slug' in cols
+        assert 'investigation_slug' in cols
+        row = conn.execute(
+            'SELECT simulation_id FROM simulations WHERE simulation_id = ?',
+            (sim_id,),
+        ).fetchone()
+        # No row from us — we didn't stamp anything. That's fine.
+        assert row is None or row[0] == sim_id
+    finally:
+        conn.close()
+
+
+@pytest.mark.fast
+def test_override_is_cleared_on_exit(tmp_path, monkeypatch):
+    """Even on exception, the module-level emitter override is reset."""
+    (tmp_path / 'workspace.yaml').write_text('name: test-ws\n')
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(RuntimeError, match='boom'):
+        with sqlite_emitter(name='will-fail'):
+            assert _h._EMITTER_OVERRIDE is not None
+            raise RuntimeError('boom')
+    assert _h._EMITTER_OVERRIDE is None
+    # Cleanup — paranoia for parallel test runs.
+    set_emitter_override(None)

--- a/v2ecoli/composites/_helpers.py
+++ b/v2ecoli/composites/_helpers.py
@@ -140,31 +140,177 @@ def set_emitter_override(config: dict | None) -> None:
 
 
 import contextlib  # noqa: E402
+import os  # noqa: E402
+import sqlite3  # noqa: E402
+import uuid  # noqa: E402
+from pathlib import Path  # noqa: E402
+
+
+def _find_workspace_root(start: Path | None = None) -> Path | None:
+    """Walk up from ``start`` (default: cwd) looking for ``workspace.yaml``.
+
+    Returns the directory that contains ``workspace.yaml``, or ``None`` if
+    none is found before hitting the filesystem root. Cheap, no imports.
+    """
+    cur = Path(start or Path.cwd()).resolve()
+    for d in (cur, *cur.parents):
+        if (d / 'workspace.yaml').is_file():
+            return d
+    return None
+
+
+def _ensure_study_columns(db_path: str) -> None:
+    """Idempotently add study_slug / investigation_slug columns to ``simulations``.
+
+    Safe to call on a missing DB (creates the parent dir + an empty DB with
+    just the columns we add — the SQLiteEmitter's _init_history_db will
+    create the rest of the schema on its own init).
+    """
+    parent = os.path.dirname(db_path)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+    conn = sqlite3.connect(db_path, isolation_level=None)
+    try:
+        # Mirror the SQLiteEmitter's table layout — without recreating the
+        # full schema, we just need the `simulations` table to exist before
+        # we ALTER. If SQLiteEmitter has already initialized it, the CREATE
+        # is a no-op.
+        conn.execute('''
+            CREATE TABLE IF NOT EXISTS simulations (
+                simulation_id TEXT PRIMARY KEY,
+                name TEXT,
+                started_at TEXT NOT NULL,
+                completed_at TEXT,
+                elapsed_seconds REAL,
+                composite_config TEXT,
+                metadata TEXT,
+                emit_schema TEXT
+            )
+        ''')
+        existing = {row[1] for row in conn.execute(
+            'PRAGMA table_info(simulations)')}
+        if 'study_slug' not in existing:
+            conn.execute('ALTER TABLE simulations ADD COLUMN study_slug TEXT')
+        if 'investigation_slug' not in existing:
+            conn.execute(
+                'ALTER TABLE simulations ADD COLUMN investigation_slug TEXT')
+    finally:
+        conn.close()
+
+
+def _stamp_study_metadata(
+    db_path: str,
+    simulation_id: str,
+    study_slug: str | None,
+    investigation_slug: str | None,
+) -> None:
+    """Write study_slug + investigation_slug for ``simulation_id``.
+
+    Upserts a row keyed on ``simulation_id`` and leaves any existing
+    SQLiteEmitter-managed fields (name, emit_schema, ...) untouched. Use
+    after the SQLiteEmitter step has been constructed (which inserts the
+    initial row) — or before, in which case ``started_at`` defaults to
+    now-UTC and the emitter will overwrite it on its own insert.
+    """
+    if study_slug is None and investigation_slug is None:
+        return
+    import datetime
+    now_iso = datetime.datetime.now(datetime.timezone.utc).strftime(
+        '%Y-%m-%dT%H:%M:%SZ')
+    conn = sqlite3.connect(db_path, isolation_level=None)
+    try:
+        conn.execute(
+            'INSERT INTO simulations '
+            '(simulation_id, started_at, study_slug, investigation_slug) '
+            'VALUES (?, ?, ?, ?) '
+            'ON CONFLICT(simulation_id) DO UPDATE SET '
+            '  study_slug = COALESCE(excluded.study_slug, simulations.study_slug), '
+            '  investigation_slug = COALESCE(excluded.investigation_slug, simulations.investigation_slug)',
+            (simulation_id, now_iso, study_slug, investigation_slug),
+        )
+    finally:
+        conn.close()
+
 
 @contextlib.contextmanager
-def sqlite_emitter(*, file_path: str, db_file: str = 'runs.db',
+def sqlite_emitter(*, file_path: str | None = None,
+                   db_file: str | None = None,
                    name: str | None = None,
                    simulation_id: str | None = None,
-                   subsample: int = 1):
+                   subsample: int = 1,
+                   study_slug: str | None = None,
+                   investigation_slug: str | None = None):
     """Context manager: build composite with a SQLiteEmitter step.
 
-    Usage:
-        with sqlite_emitter(file_path='studies/dnaa-01/', name='baseline'):
+    By default writes to ``<workspace_root>/.pbg/composite-runs.db`` — the
+    same workspace-shared DB the vivarium-dashboard's Simulations DB tab
+    aggregates from. Pass ``study_slug`` / ``investigation_slug`` to tag the
+    run; the slugs are stored as columns on the ``simulations`` row so the
+    dashboard can group / filter by them.
+
+    To keep using a per-study DB, pass ``file_path`` (and optionally
+    ``db_file``) explicitly — the old behavior is preserved.
+
+    Usage::
+
+        with sqlite_emitter(name='baseline-seed0',
+                            study_slug='dnaa-01-expression-dynamics',
+                            investigation_slug='dnaa-replication'):
             doc = baseline(cache_dir='out/cache')
             comp = Composite(doc, core=core)
-            comp.update({}, 60.0 * 60)   # 60 minutes
+            comp.update({}, 60.0 * 60)
     """
-    cfg = {'file_path': file_path, 'db_file': db_file}
+    # Resolve workspace-default DB path when caller didn't pin one.
+    if file_path is None:
+        ws_root = _find_workspace_root()
+        if ws_root is None:
+            raise RuntimeError(
+                'sqlite_emitter(): no file_path given and no workspace.yaml '
+                'found walking up from cwd; either run from inside a '
+                'workspace or pass file_path explicitly.')
+        file_path = str(ws_root / '.pbg')
+        if db_file is None:
+            db_file = 'composite-runs.db'
+    else:
+        if db_file is None:
+            db_file = 'runs.db'
+
+    # Pin the simulation_id upfront so we can stamp metadata around the
+    # emitter's own init insert.
+    if simulation_id is None:
+        simulation_id = str(uuid.uuid4())
+
+    cfg = {
+        'file_path': file_path,
+        'db_file': db_file,
+        'simulation_id': simulation_id,
+    }
     if name is not None:
         cfg['name'] = name
-    if simulation_id is not None:
-        cfg['simulation_id'] = simulation_id
     if subsample != 1:
         cfg['subsample'] = subsample
+
+    db_path = os.path.join(file_path, db_file)
+    # Ensure our extra columns exist on the simulations table BEFORE the
+    # SQLiteEmitter step runs its own _init_history_db (which is a no-op for
+    # already-existing tables). Then stamp the slugs. Safe to run unconditionally
+    # — the helpers are idempotent and tolerate a missing file.
+    _ensure_study_columns(db_path)
+    _stamp_study_metadata(db_path, simulation_id, study_slug, investigation_slug)
+
     set_emitter_override(cfg)
     try:
         yield cfg
     finally:
+        # Re-stamp in case the emitter's own insert ran after ours and we
+        # need to ensure the slugs survived. ON CONFLICT DO UPDATE preserves
+        # any non-NULL value, so this is a belt-and-suspenders no-op when
+        # things already stuck.
+        try:
+            _stamp_study_metadata(
+                db_path, simulation_id, study_slug, investigation_slug)
+        except sqlite3.OperationalError:
+            pass
         set_emitter_override(None)
 
 


### PR DESCRIPTION
## Summary

The vivarium-dashboard's Simulations DB tab aggregates runs from `<workspace>/.pbg/composite-runs.db` and every `studies/<name>/runs.db`. Study runs in the dnaa-replication investigation weren't showing up because the parallel-agent's callers were passing per-study `file_path`s — easy to misroute and noisy in the dashboard.

- Make the workspace-shared DB the default in `sqlite_emitter()` by walking up from `cwd` for `workspace.yaml`. Back-compat preserved: passing `file_path` keeps the old per-study layout.
- Add `study_slug` + `investigation_slug` kwargs on the context manager that get stamped on the `simulations` row as new TEXT columns (idempotent `PRAGMA table_info` / `ALTER TABLE` migration).
- Pin `simulation_id` upfront so we can write the slugs without racing the SQLiteEmitter's own row insert — `ON CONFLICT DO UPDATE` keeps each side from clobbering the other.

## Schema migration approach

`process_bigraph.emitter.SQLiteEmitter` owns the row insert for `simulations(simulation_id, name, started_at, emit_schema)` and there's no way to extend its config to carry our slugs. So the context manager:

1. Resolves the DB path (workspace default or caller-supplied).
2. Ensures `simulations.study_slug` + `simulations.investigation_slug` exist via `PRAGMA table_info` + `ALTER TABLE ADD COLUMN` (re-creates the table only if it's missing; otherwise no-op).
3. Pins `simulation_id` upfront, INSERTs a row carrying the slugs before yielding, and re-stamps on exit. The emitter's own `INSERT ... ON CONFLICT(simulation_id) DO UPDATE` only touches the columns it knows about, so the slug columns survive.

## Call sites to migrate (follow-up)

The relevant files live on the parallel `dnaa-replication-studies` branch (not on `main`), so this PR only changes the helper + tests to avoid stepping on that branch's working tree:

- `studies/dnaa-01-expression-dynamics/sims/run_baseline.py` — drop `file_path` / `db_file`, pass `study_slug='dnaa-01-expression-dynamics'`, `investigation_slug='dnaa-replication'`.
- `studies/dnaa-01-expression-dynamics/tests/conftest.py` — same.
- `investigations/dnaa-replication/overnight-2026-05-17/run_baseline_with_fc.py` — pass `investigation_slug='dnaa-replication'`.
- `v2ecoli/visualizations/dnaa_state.py` — repoint at the workspace-shared DB if it reads runs directly.

## Backfill

Skipped — the dashboard's `_discover_dbs` already aggregates `studies/<name>/runs.db`, so legacy rows still appear; they just won't have populated slug columns. New runs after the helper migration will populate them, and a follow-up `scripts/migrate-runs-db.py` can copy/tag old rows if desired.

## Test plan

- [x] `pytest -q tests/test_sqlite_emitter_workspace_default.py` — 5/5 passing
- [ ] Once the call sites land on `dnaa-replication-studies`, run `pytest -q studies/dnaa-01-expression-dynamics/tests/` and confirm a fresh run lands at `<workspace>/.pbg/composite-runs.db` with `study_slug` + `investigation_slug` set.
- [ ] Confirm the run shows up in the dashboard's Simulations DB tab with an Investigation column (paired vivarium-dashboard PR: `feat/sim-db-investigation-grouping`).