### PR TITLE
Tier 1: clone_investigation.py + dnaa-replication-fresh demo

### DIFF
--- a/investigations/dnaa-replication-fresh/STATUS.md
+++ b/investigations/dnaa-replication-fresh/STATUS.md
@@ -1,0 +1,139 @@
+# DnaA / Replication Initiation — Investigation Status
+
+> Bird's-eye view of where each study stands. Updated 2026-05-17 with
+> overnight autonomous-run progress.
+
+## 2026-05-17 OVERNIGHT UPDATE
+
+★ **Headline:** (TE=20×, fc=0.7) — the first calibration that passes
+both dnaa-01 primary gate tests. DnaA median 707 in band [300, 800],
+Pearson r = -0.521 (≤ -0.3 autorepression threshold). Validates the
+joint (TE × fold_change) sweep approach.
+
+## 2026-05-17 ARCHITECTURE UPDATE — cascading recipe chain
+
+★★ **Each study now inherits its parent's validated baseline + mechanisms
+via a declarative recipe chain.** Recipes registered in
+`v2ecoli/composites/baseline_recipes.py`:
+
+```
+v2ecoli_baseline
+  └── dnaa_01g_calibrated                       (TE=20×, fc=0.7 — 3 bundle patches)
+       ├── dnaa_02_with_intrinsic_hydrolysis     (+ Boesen 0.046/min loop)
+       └── dnaa_02_with_extrinsic_target_rate    (+ k=4.6/min loop ★ PASSES BOTH GATES)
+            └── dnaa_03_with_box_binding          (+ cooperative binding TODO)
+                 └── dnaa_04_with_dnaa_initiation_trigger  (+ trigger swap TODO)
+                      ├── dnaa_05_full_nucleotide_cycle    (+ RIDA/DDAH/DARS TODO)
+                      └── dnaa_06_with_seqa_sequestration  (+ SeqA Step TODO)
+```
+
+Each study's `baseline.composite:` field in study.yaml now points at
+the matching recipe. End-to-end validation (probe_via_recipe.py with
+`dnaa_02_with_extrinsic_target_rate`): total DnaA = 707 ✓,
+ATP fraction = 0.232 ✓. **dnaa-02's gate is now `open`, not conditional.**
+Downstream studies cascade off this validated baseline.
+
+See `overnight-2026-05-17/REPORT.md` for the full report. 10 insights,
+9 new findings across 4 studies, 2 new spawned follow-up studies,
+1 drafted Step (IntrinsicHydrolysis), 19 new sims, 10 SVG charts.
+
+## Live study status
+
+> **Gate badge format** (post-ADDENDUM-P1b-2):
+> Each study gets THREE independent verdicts, scored separately. Columns:
+> **reg** = regression_compatibility, **bio** = biological_validation, **expl** = explanatory_gain.
+> Symbols: ✓ PASS · ✗ FAIL · ⏸ PENDING · — NOT_CLAIMED · ⛔ BLOCKED
+>
+> Per the biology review: a heuristic-match (regression_compatibility) test cannot count as biological_validation — the three classes must be reported independently, not collapsed.
+
+| # | Study | Phase | reg | bio | expl | Findings | Runs |
+|---|---|---|---|---|---|---|---|
+| 1  | [dnaa-01-expression-dynamics](../../studies/dnaa-01-expression-dynamics/study.yaml) | Decide | ✓ (via cascaded recipe) | ⏸ (perturbations + suite pending) | — | 10 | 5 |
+| 1f | [dnaa-01f-listener-fix](../../studies/dnaa-01f-apply-overwrite-fix-to-sibling-listeners-rna-synth-prob-repl/study.yaml) | Decide | ✓ | ✓ (mechanistic fix verified) | — | 0 | 1 |
+| 1f | [dnaa-01f-recalibrate-EG10235](../../studies/dnaa-01f-recalibrate-eg10235-translation-efficiency-in-parca/study.yaml) | Decide | ⏸ (F-03 model_implied) | ⏸ | — | 3 | 1 set |
+| 1g | [dnaa-01g-joint-te-fold-change-sweep](../../studies/dnaa-01g-joint-te-fold-change-sweep/study.yaml) | Design | ✓ (TE=20×, fc=0.7 model_implied) | ⏸ | — | 0 | 0 |
+| 1g | [dnaa-01g-parca-te-derivation-audit](../../studies/dnaa-01g-parca-te-derivation-audit/study.yaml) | Design | ⛔ blocked | ⛔ | — | 0 | 0 |
+| 2 | [dnaa-02-atp-hydrolysis](../../studies/dnaa-02-atp-hydrolysis/study.yaml) | Decide | ✓ (F-04 model_implied) | ⏸ (perturbations + expert Q dnaa-02-EQ-01) | — | 5 | 4 probes |
+| 3 | [dnaa-03-box-binding](../../studies/dnaa-03-box-binding/study.yaml) | Decide | ✗ (F-05: Hill n=2 fails) | ⏸ | — | 5 | 2 probes |
+| 4 | [dnaa-04-initiation-mechanism](../../studies/dnaa-04-initiation-mechanism/study.yaml) | Decide | ⛔ blocked (ADDENDUM P1b-1: oriC-only signal required) | ⛔ | ⛔ | 4 | 1 |
+| 5 | [dnaa-05-rida-ddah-dars](../../studies/dnaa-05-rida-ddah-dars/study.yaml) | Decide | ⏸ (no implementation yet) | ⏸ | ⏸ (promise of explanatory gain) | 2 | 0 |
+| 6 | [dnaa-06-seqa-sequestration](../../studies/dnaa-06-seqa-sequestration/study.yaml) | Decide | ⏸ | ⏸ | — | 3 | 0 |
+
+**Totals:** 10 studies · 34 findings · 54 sim-runs (48 in `dnaa-01-expression-dynamics/runs.db` + 6 in-memory probes).
+
+**Investigation status:** Every dnaa-* study has now been driven to Decide phase at least at the design level. The implementation work remaining is well-scoped per study (each has explicit `conclusion` + `next_action` blocks); no design questions remain blocking.
+
+**What's done & clear to move on from:** ALL studies in the investigation.
+**What's clear to start NEXT (implementation cycle, not investigation cycle):**
+1. Promote (TE=20×, fc=0.7) to permanent ParCa adjustment (dnaa-01f-recalibrate next_action).
+2. Wire the drafted IntrinsicHydrolysis Step into baseline.py (dnaa-02 F-04 next_action).
+3. Author DnaABinder.update() with cooperative-binding logic (dnaa-03 F-05 + dnaa-04 F-01 implementation).
+
+**Investigation conclusion:** All 6 original studies + 4 spawned follow-ups reached Decide phase with documented gate decisions, conditional pass paths, and concrete implementation next-steps. The biology is well-understood; the engineering is well-scoped.
+
+## Dependency DAG
+
+```
+dnaa-01-expression-dynamics       (root — implemented baselines, ready to run)
+  └── dnaa-02-atp-hydrolysis      (DnaA-ATP/ADP/apo split — first hard upstream)
+        ├── dnaa-03-box-binding   (307 chromosomal + 11 oriC + 4 dnaAp boxes)
+        │     └── dnaa-04-initiation-mechanism   (replace mass-threshold heuristic)
+        │           ├── dnaa-05-rida-ddah-dars   (RIDA + DDAH + DARS1 + DARS2)
+        │           └── dnaa-06-seqa-sequestration   (SeqA + GATC methylation)
+        └── dnaa-05-rida-ddah-dars   (also depends on dnaa-02 directly)
+```
+
+Open the DAG live in the dashboard: **Investigations** → **DnaA / Replication Initiation**.
+
+## What's runnable today (no new code)
+
+Only **dnaa-01** has implemented behavioral tests against the existing baseline. Run with:
+
+```
+pytest studies/dnaa-01-expression-dynamics/tests/test_with_synthetic_history.py -v
+```
+
+5 tests pass against synthetic in-memory history (BT-01..BT-04). The same evaluator will run against a real `runs.db` once the baseline is executed via the dashboard.
+
+## What needs to land first (recommended order)
+
+1. **gap-1** — `DnaaConcentrationListener` Step (XS effort). Unblocks dnaa-01's `derived-needed` observables.
+2. **gap-2** — `translation_efficiency_override` composite-level hook (S). Unblocks dnaa-01's `stop-dnaA-synthesis` variant + its 2 behavioral tests.
+3. **dnaa-02 upstream** — split DnaA bulk into ATP / ADP / apo species + intrinsic hydrolysis Step (M). Unblocks 4 of 5 dnaa-02 behaviors.
+4. **dnaa-03 upstream** — DnaA-box catalog + binding kinetics (L). The biggest single block in the chain; unblocks all of dnaa-03 + much of dnaa-04.
+
+Each gap's full implementation plan is in the corresponding study.yaml under `gaps:`.
+
+## Acceptance criteria (when does this investigation conclude?)
+
+Listed in `investigation.yaml.acceptance_criteria:`. Summary: 8 specific behavioral tests across 5 studies must all pass.
+
+| Study | Behavior | Why this gates investigation completion |
+|---|---|---|
+| dnaa-01 | dnaa-count-in-mass-spec-range | Foundational DnaA pool is right |
+| dnaa-01 | dnaa-concentration-stable-within-10pct | Foundational pool is stable |
+| dnaa-02 | dnaa-atp-fraction-in-physiological-range | DnaA-ATP fraction in [0.2, 0.5] (Boesen 2024) |
+| dnaa-03 | oric-stays-unoccupied-until-chromosome-saturates | Titration is real |
+| dnaa-04 | one-initiation-per-generation | Stable cell cycle |
+| dnaa-04 | initiation-mass-mean-matches-heuristic | Mechanism reproduces the heuristic baseline |
+| dnaa-05 | inter-initiation-cv-narrows-vs-intrinsic-only | Extrinsic conversion improves homeostasis |
+| dnaa-06 | wildtype-zero-reinitiation | SeqA prevents reinitiation |
+
+## Open questions
+
+Per-study `expert_questions:` lists the active questions for domain experts. Highlights:
+
+- dnaa-01: ask Katayama / Lobner-Olesen labs on dnaa autorepression strength + each DnaA box in dnaAp.
+- dnaa-02: apo-DnaA pool size assumption + ATP/ADP binding kinetics resolution.
+- dnaa-03: 307-box equivalence vs context-dependent cooperativity.
+- dnaa-04: cooperativity of DnaA-ATP filament at oriC + DnaA box dissociation mechanism on fork passage.
+- dnaa-05: quantitative scaling of RIDA per replication fork.
+- dnaa-06: SeqA-multimer cooperativity vs Hill-shaped on/off.
+
+## How to use this file
+
+- **Daily**: glance at the table to see what's blocked / runnable.
+- **PR-by-PR**: update the status column when a phase moves planned → running → ran → complete.
+- **Cross-study triage**: the Blocks column tells you the priority order — landing dnaa-01 first unblocks dnaa-02, etc.
+
+The dashboard auto-discovers this file as the investigation's README equivalent (planned dashboard feature: render this in the Investigations tab as a "Status" subtab).

--- a/investigations/dnaa-replication-fresh/biology-feedback-2026-05-17/ADDENDUM.md
+++ b/investigations/dnaa-replication-fresh/biology-feedback-2026-05-17/ADDENDUM.md
@@ -1,0 +1,295 @@
+# Addendum: items missed in the first PLAN pass
+
+The first pass at the biology-feedback (`PLAN.md`) captured the P1/P2/P3
+items at face value but missed several SUBSTANTIVE insights from the
+review's section 3 acceptance criteria + section 5 desired-behavior
+checklist. Documenting them here as P1b / P2b / P3b that extend the
+matrix in `PLAN.md`.
+
+## P1b — must fix (architectural)
+
+### P1b-1 ★ Active-initiation-signal constraint (dnaa-04 architectural change)
+
+> Section 3, DnaA-ATP decomposition acceptance: **"Initiation studies cannot
+> use total DnaA-ATP alone as the active initiation signal."**
+
+This is the deepest specific architectural finding in the entire review.
+The dnaa-04 implementation must read **`DnaA_box.DnaA_bound AND
+region_type == 'oriC'`** as the initiation trigger, not the total
+`bulk[MONOMER0-160]` count. My drafted swap-point design at
+`chromosome_replication.py:244` correctly mentions "n_DnaA_bound_at_oriC"
+but the **fallback** text says "use bulk[MONOMER0-160] count as a proxy"
+— that's explicitly forbidden. Remove the fallback wording.
+
+Required changes:
+- `studies/dnaa-04-initiation-mechanism/study.yaml` — strip "fallback to
+  total DnaA-ATP" from F-01 and from `gate_status_summary`. Make it clear
+  the trigger READS `oriC_bound` exclusively. Without dnaa-03's binding
+  mechanism + region_type catalog, dnaa-04 is **blocked**, not "ready
+  with degraded fallback."
+- `gate_status` for dnaa-04 changes from `ready` (cascaded via recipe
+  chain) back to `blocked` (on dnaa-03's cooperative binding + box
+  region_type catalog).
+- `v2ecoli/composites/baseline_recipes.py` —
+  `dnaa_04_with_dnaa_initiation_trigger` recipe must depend on the
+  dnaa-03 box catalog being populated, not just inherit from the
+  hydrolysis-bearing parent.
+
+### P1b-2 ★ Triple verdict in `conclusion_logic` (not collapsed)
+
+> Section 3, Target class split acceptance: **"A heuristic-match test
+> cannot count as biological validation. Final decisions show all three
+> outcomes independently."**
+
+`conclusion_logic` currently emits one verdict. It must emit three:
+
+```yaml
+conclusion_verdicts:
+  regression_compatibility:
+    result: PASS                  # PASS | FAIL | PENDING | NOT_APPLICABLE
+    basis: '(TE=20×, fc=0.7) matches Schmidt 2016 count'
+    contributing_tests: [dnaA-count-in-range, autorepression-correlation]
+  biological_validation:
+    result: PENDING
+    basis: 'no perturbation panel runs yet'
+    blocking_tests: [dnaA-overexpression, autorepression-ablation]
+  explanatory_gain:
+    result: NOT_CLAIMED
+    basis: 'study is calibration, not mechanism'
+```
+
+The dashboard's `gate_status` badge should split into 3 sub-badges per
+study. Currently one `🟢 open` collapses all three classes — misleading.
+
+### P1b-3 ★ `model_implied: true` tag on calibration-fit findings
+
+> Section 3, Reset mechanism cards acceptance: **"Hydrolysis-rate
+> requirements are labeled model-implied unless supported by direct
+> biology."**
+
+Generalize: any finding whose evidence is "the model matches literature
+because we fit a parameter to make it match" must be tagged
+`model_implied: true`. The tag prevents these from being read as
+measured biology.
+
+Findings to re-tag:
+
+| Finding | Add tag | Clarifying note |
+|---|---|---|
+| dnaa-01g recipe `dnaa_01g_calibrated` | `model_implied: true` | "TE=20×, fc=0.7 fit to dnaa-01 count target; not measured" |
+| dnaa-02 F-04 (k=4.6/min) | `model_implied: true` | "Compensates for v2ecoli's equilibrium reverse-rate; NOT an in-vivo measured rate" |
+| dnaa-02 F-05 (recipe-chain validation) | partially `model_implied` | "Mechanism architecture validated; specific rate is a fit" |
+| dnaa-03 F-05 (Hill n=5-10 prediction) | `model_implied: true` | "Predicted to reproduce two-step pattern; alternatives: HU/IHF/Fis accessory factors, SeqA sequestration" |
+
+### P1b-4 INSUFFICIENT_EVIDENCE enforcement
+
+> Section 3, Autorepression suite acceptance: **"Sparse mRNA data can
+> return insufficient evidence rather than false pass/fail."**
+
+`AUTOREPRESSION_TEST_RESULT` enum has the `INSUFFICIENT_EVIDENCE` value
+but `tests/_behaviors.py` doesn't return it. The current behavior is to
+return `r=N/A` and call it FAIL or to silently produce a pearson r with
+N=2 samples.
+
+Required changes:
+- `tests/_behaviors.py` pearson-correlation evaluator emits
+  `INSUFFICIENT_EVIDENCE` when `len(samples) < 30` OR when the input
+  signal has zero variance.
+- `tests/_behaviors.py` adds a generic `_insufficient(reason)` helper
+  used by every measure kind that can produce one.
+- Outcome aggregation in study.yaml `runs[].outcomes` accepts
+  `INSUFFICIENT_EVIDENCE` and propagates it to `conclusion_verdicts`
+  (NOT a fail, NOT a pass).
+
+## P2b — schema extensions
+
+### P2b-5 `decision_log[]` versioning
+
+> Section 3, Expert questions acceptance: **"Expert input changes
+> thresholds, mappings, or mechanism cards in a versioned way."**
+
+Append-only log entries on each `pass_if` threshold, each
+`measurement_mapping`, each `mechanism_card`:
+
+```yaml
+behavior_tests:
+- name: dnaA-count-in-range
+  pass_if: {op: in_range, low: 300, high: 800}
+  decision_log:
+  - timestamp: 2026-05-01T00:00Z
+    actor: 'initial setup (auto)'
+    field_changed: pass_if.high
+    old_value: 1000
+    new_value: 800
+    rationale: 'Schmidt 2016 updated mass-spec upper bound'
+  - timestamp: 2026-05-17T11:40Z
+    actor: 'biology review (external)'
+    field_changed: measurement_mapping.literature_observable.biological_pool
+    old_value: '(implicit: total)'
+    new_value: total                  # now explicit
+    rationale: 'feedback P1-2 — pool must be explicit before threshold can be used'
+```
+
+### P2b-6 `DnaAStateVisualization` extended to 8 pools
+
+> Section 3, DnaA-ATP decomposition specification: **"Report total, free,
+> DNA-bound, oriC-bound, non-oriC-bound, ADP-bound, and apo-DnaA pools."**
+
+The viz Step currently emits 3 pools + total. Missing splits:
+- `free` vs `DNA-bound` (requires dnaa-03 binding + the
+  `DnaA_box.DnaA_bound` state being populated)
+- `oriC-bound` vs `non-oriC-bound` (requires the `region_type` attribute
+  from P2-1 box-catalog extension)
+
+The Step should be extended NOW with placeholder series that draw zero
+until the supporting mechanism lands. Then when dnaa-03 wires in box
+binding, the viz starts showing real data without further Step changes.
+
+### P2b-7 Cross-study `biological_pool` consistency validator — **LANDED**
+
+When two studies reference the same biological measurement but with
+different `biological_pool` values, that's a quiet conflict the
+aggregator should flag.
+
+**Implementation** (commit on PR #56): `scripts/validate_study_biology.py`.
+Walks every `studies/*/study.yaml` and:
+
+1. Validates enum-typed fields against `BIOLOGY_TYPES` (the registered
+   bigraph-schema enums in `v2ecoli/types/biology.py`):
+   `target_class`, `biological_pool`, `molecular_pool`, `failure_cause`,
+   `region_type`, `affinity_class`, `nucleotide_preference`, `result`
+   (verdict_result / autorepression_test_result by context),
+   `narrative_confidence`, `autorepression_test_kind`,
+   `perturbation_kind`, `seqa_version`, `reset_mechanism_kind`.
+   Contextual rules use strict shape matching (`list_item` vs
+   `dict_value`) so e.g. `autorepression_test_suite[i].measure.kind`
+   is NOT wrongly checked against the autorepression-test-kind enum.
+2. Cross-study consistency: same `literature_observable.name` must map
+   to the same `biological_pool` across studies (ERROR if not); same
+   `model_observable.state_path` must map to the same `molecular_pool`
+   (ERROR if not); same `literature_observable.name` cited with
+   completely disjoint `source_ids` across studies emits a WARNING.
+
+Hooked into `scripts/lint-workspace.py` — failed enum or cross-study
+checks fail the workspace lint. Standalone usage:
+`python scripts/validate_study_biology.py [--json] [--strict]`.
+
+## P3b — process / reporting
+
+### P3b-8 `abstraction_level:` field per study and per test
+
+> Section 5 desired behavior: "what mechanism is being tested, **what
+> abstraction represents it**, ..."
+
+Each study declares its abstraction level explicitly so claims at
+abstraction N don't get extrapolated to N+1 inappropriately:
+
+```yaml
+abstraction_level:
+  name: 'lumped total-DnaA pool, quasi-steady-state'
+  resolves:
+  - 'total DnaA homeostasis'
+  - 'autorepression as a correlation signal'
+  does_not_resolve:
+  - 'per-form (ATP/ADP/apo) dynamics — that\'s dnaa-02'
+  - 'spatial DnaA distribution — that\'s dnaa-03+'
+  - 'cell-cycle timing — that\'s dnaa-04+'
+```
+
+Per-study abstraction-level declarations:
+
+- dnaa-01: "lumped total-DnaA pool, quasi-steady-state"
+- dnaa-02: "three-state nucleotide cycle (apo/ATP/ADP), well-mixed cytoplasm"
+- dnaa-03: "DnaA-box occupancy with per-class affinity, no cooperativity (v1)"
+- dnaa-04: "DnaA-occupancy-triggered initiation, mass-threshold removed"
+- dnaa-05: "extrinsic conversion via RIDA + DDAH + DARS"
+- dnaa-06 v0: "SeqA as fixed 10-min post-initiation timer"
+- dnaa-06 v1: "Dam re-methylation kinetics + SeqA"
+- dnaa-06 v2: "cooperative SeqA-Dam dynamics"
+
+### P3b-9 `narrative_confidence:` flag on mechanism cards
+
+> Section 1 framing: **"must not treat a staged textbook narrative as
+> more settled than the current evidence warrants."**
+
+Each mechanism card carries a textbook-consensus rating + the specific
+sub-claims that ARE contested:
+
+```yaml
+mechanism_cards:
+- name: dnaA_autorepression
+  textbook_consensus_strength: strong          # strong | moderate | contested | open
+  evidence_for_strength:
+  - {ref: Speck1999EMBO, evidence_type: in_vitro_binding}
+  - {ref: Saggioro2013BiochemJ, evidence_type: in_vivo_dosage_correction}
+  - {ref: Katayama2017Frontiers, evidence_type: review}
+  contested_aspects:
+  - aspect: 'Hill cooperativity coefficient for dnaAp1/dnaAp2 binding'
+    range_in_literature: '[1, 4]'
+    review_note: 'current evidence does not warrant claiming a specific value'
+  - aspect: 'Relative strength of dnaAp1 vs dnaAp2 binding'
+    review_note: 'dnaAp2 dominant in some studies, comparable in others'
+```
+
+### P3b-10 Structured `expert_decisions_needed[]` block
+
+> Section 5: "...what expert decision is needed."
+> Section 2 P3: "Convert uncertainties into answerable questions with
+> alternatives, impact if wrong, blocking status, requested response type."
+
+Already mentioned in PLAN.md P3-3 but not given a structured shape:
+
+```yaml
+expert_decisions_needed:
+- id: dnaa-01-EQ-01
+  question: 'Does Schmidt 2016 mass-spec 300-800 cellular DnaA include the chromosomally-bound DnaA population?'
+  alternatives: [yes, no, partially]
+  impact_if_wrong: 'The current 4.8× count gap (115 vs 300-800) may be an observable mismatch (different pool) rather than a miscalibration. If yes, dnaA-01 fails biological_validation for the wrong reason; if no, the gap is real and dnaa-01g calibration is justified.'
+  blocks:
+  - dnaa-01 conclusion_verdicts.biological_validation
+  - dnaa-02 calibration target derivation
+  requested_response: 'one paragraph from a mass-spec expert + DOI to extraction-protocol section of the 2016 paper'
+  status: open
+  asked_to: TBD
+  asked_at: TBD
+  answer: null
+```
+
+## Cross-cutting: updates to the bigraph-schema types
+
+These additions imply two enum extensions in `v2ecoli/types/biology.py`:
+
+```python
+VERDICT_RESULT = {
+    '_type': 'enum',
+    '_values': ['PASS', 'FAIL', 'PENDING', 'NOT_APPLICABLE', 'NOT_CLAIMED'],
+}
+
+NARRATIVE_CONFIDENCE = {
+    '_type': 'enum',
+    '_values': ['strong', 'moderate', 'contested', 'open'],
+}
+```
+
+(These can ship in the same PR as the per-study application of P1b-3
+`model_implied` tags.)
+
+## Updated execution order
+
+1. **Now (this iteration)**: Apply P1b-1 / P1b-2 / P1b-3 to dnaa-01,
+   dnaa-02, dnaa-04, dnaa-01g (the studies with actual outcomes to
+   re-classify). Add VERDICT_RESULT and NARRATIVE_CONFIDENCE enums.
+2. **Next iteration**: Roll out P1b-1..P1b-3 to remaining studies (-03, -05, -06).
+3. **Then**: P1b-4 INSUFFICIENT_EVIDENCE enforcement in tests/_behaviors.py.
+4. **Then**: P2b-5 decision_log[] versioning across all behavior_tests.
+5. **Then**: P2b-6 viz Step extension to 8 pools (requires dnaa-03 binding to land for real data).
+6. **Then**: P2b-7 cross-study consistency validator.
+7. **Then**: P3b items as polish.
+
+## What changes in the dashboard
+
+When the triple-verdict (P1b-2) lands, the dashboard's gate-status badge
+on each study card should split into three smaller badges:
+`reg ✓ · bio ⏸ · expl —`. The DAG SVG in `viz/08_investigation_dag.svg`
+should color each node's three sub-strips independently. Cleaner signal
+than the current single-emoji collapse.

--- a/investigations/dnaa-replication-fresh/biology-feedback-2026-05-17/PLAN.md
+++ b/investigations/dnaa-replication-fresh/biology-feedback-2026-05-17/PLAN.md
@@ -1,0 +1,304 @@
+# Plan: applying biology-review feedback to the dnaA investigation
+
+**Source:** `references/expert/dnaa_biology_feedback.pdf` (registered in `workspace.yaml.expert_docs[dnaa_biology_feedback]`)
+**Date:** 2026-05-17
+**Author:** External biology reviewer
+**Workspace:** v2ecoli
+
+## TL;DR of the feedback
+
+The decomposition (dnaa-01..06) is sound. The current biological-interpretation layer is not. Three changes are non-negotiable before any biological claim should stand:
+
+1. **Separate target classes.** Every gate test must declare one of `regression_compatibility` / `biological_validation` / `explanatory_gain`. A heuristic-match test cannot count as biological validation.
+2. **Map literature → model observable.** Every numeric threshold must carry a `measurement_mapping` (literature_observable + model_observable + transformation + caveats). No "DnaA in [300, 800]" without saying which pool and which transformation.
+3. **Perturbations validate mechanisms.** Wild-type baseline alone cannot close biological validation. Each study must declare a perturbation panel.
+
+Plus four more P1 items: explicit DnaA pool decomposition, autorepression test-SUITE (not just Pearson r), DnaA-ATP decomposition (free / DNA-bound / oriC-bound / non-oriC-bound), and uncertainty as actionable expert questions.
+
+## Where this changes our findings
+
+Specific findings that are now overclaimed and need re-labeling:
+
+| Finding | Current status | After review |
+|---|---|---|
+| dnaa-01 F-01: "DnaA count 115 vs literature [300, 800]" | `biological/contradicts` | **observable mismatch** — which pool is the literature 300-800? mass-spec → total cellular DnaA; v2ecoli's `monomer_counts[3861]` is ambiguous (apo? all-three-form sum?). Needs `measurement_mapping`. |
+| dnaa-01 F-02: "Autorepression Pearson r = -0.594 PASSES" | `biological/confirms` | Pearson is the WEAKEST autorepression test. PASS-by-r is insufficient evidence. Promote to "promoter-response test suite ran, 1 of 4 tests passed". |
+| dnaa-01g (TE=20×, fc=0.7) "both gates pass" | `gate_status: open` | downgrade to `regression_compatibility: PASS` and `biological_validation: PENDING perturbation panel`. The fc=0.7 number is heuristic regression; doesn't say WHY autorepression is over-strong in v2ecoli. |
+| dnaa-02 F-04/F-05: "k=4.6/min PASSES Boesen band" | `biological/novel` | **regression_compatibility** — the 100× ratio is what's needed to FIT the band given v2ecoli's equilibrium reverse-rate. Doesn't validate biology; could equally mean the equilibrium reverse-rate is mis-calibrated by 100×. |
+| dnaa-03 F-05: "Simple Hill model fails 2-step" | `biological/contradicts` | correct — but the next-step "cooperative Hill n=5-10" is itself a `regression_compatibility` target until tested with literature DnaA-ATP perturbations. |
+
+## TODO matrix (P1 → P3)
+
+### P1 — must fix, schema changes touch every study
+
+| # | TODO | Files touched | Owner |
+|---|---|---|---|
+| P1-1 | `target_class:` field on every `behavior_tests[]` entry | all 10 study.yaml | this task |
+| P1-2 | `measurement_mapping:` block on every numeric threshold | all 10 study.yaml (in `behavior_tests` + `findings.evidence`) | this task |
+| P1-3 | Replace Pearson-only autorepression test with `autorepression_tests[]` suite | dnaa-01, dnaa-01g, dnaa-02..06 readouts | this task + dnaa-01 |
+| P1-4 | Explicit DnaA pool decomposition in readouts: `total / free / DNA-bound / oriC-bound / non-oriC-bound / ATP-bound / ADP-bound / apo` | dnaa-01 readouts; dnaa-02 readouts (this is where the split lives); enforce across dnaa-03..06 | this task |
+| P1-5 | `perturbation_panel:` block on each study; tests that REQUIRE perturbation evidence get tagged `requires_perturbations: [...]` | dnaa-01..06 | this task |
+
+### P2 — next cycle
+
+| # | TODO | Notes |
+|---|---|---|
+| P2-1 | DnaA-box catalog expert curation: each box gets `{region_type, box_class, affinity, nucleotide_preference, cooperative_group, source, expert_review_status}` | dnaa-03's box catalog work — extend DNAA_BOX_ARRAY schema in `v2ecoli/library/schema_types.py` and the ParCa initial-conditions setup that populates it |
+| P2-2 | Version SeqA abstractions: `seqa_v0` (fixed 10-min timer), `seqa_v1` (methylation-state + Dam re-methylation kinetics), `seqa_v2` (cooperative SeqA-Dam) | dnaa-06 study; each version is its own recipe (see baseline_recipes.py) |
+| P2-3 | RIDA/DDAH/DARS as RESET MECHANISMS not "hydrolysis knobs" — each gets a mechanism card | dnaa-05 study |
+| P2-4 | Test-failure classifier: each FAIL labels `failure_cause: [missing_mechanism, miscalibration, observable_mismatch, insufficient_statistics]` | evaluator in `tests/_behaviors.py` |
+
+### P3 — improvements
+
+| # | TODO | Notes |
+|---|---|---|
+| P3-1 | Mechanism cards (`mechanism_cards/` per study) for expert-editable assumptions | small templated md file per assumption |
+| P3-2 | "What would change my mind" boxes on every major conclusion | add to `conclusion_logic` |
+| P3-3 | Expert references → answerable expert questions with `alternatives, impact_if_wrong, blocking_status, requested_response_type` | replace flat `expert_references` |
+
+## Schema additions to study.yaml
+
+These are the minimal additions; the per-study application below shows usage.
+
+```yaml
+behavior_tests:
+- name: dnaA-count-in-range
+  target_class: biological_validation    # NEW (P1-1)
+  classification: primary
+  description: ...
+  measurement_mapping:                   # NEW (P1-2)
+    literature_observable:
+      name: total cellular DnaA per cell
+      biological_pool: total DnaA across apo + ATP + ADP + DNA-bound complexes
+      condition: M9 + glucose, exponential growth, doubling ~30 min
+      statistic: median across population
+      source_ids: [Schmidt2016NatBiotechnol, Sekimizu1991JBacteriol]
+    model_observable:
+      listener_path: listeners.monomer_counts
+      state_path: bulk[PD03831[c]] + bulk[MONOMER0-160[c]] + bulk[MONOMER0-4565[c]]
+      molecular_pool: total DnaA (sum across three forms)
+      units: molecules/cell
+      includes_bound_species: true       # critical: clarifies whether DNA-bound is in pool
+    transformation:
+      formula: median(sum_three_forms over t in [duration/2, duration])
+      time_window: second_half
+      aggregation: median across seeds
+    caveats:
+      - 'v2ecoli does not yet model DnaA bound to RIDA replisome complexes; if literature 300-800 includes those, sum understates by ~10%'
+      - 'Schmidt 2016 mass-spec excludes DnaA bound during fixation washouts; ratio uncertain'
+  measure: {kind: median_window, ...}
+  expect: {op: in_range, range: [300, 800]}
+
+readouts:
+- name: dnaA_pool_total
+  pool_kind: total                # NEW (P1-4): one of total | free | ATP_bound | ADP_bound | apo | DNA_bound | oriC_bound | non_oriC_bound
+  store_path: bulk
+  expansion: ['PD03831[c]', 'MONOMER0-160[c]', 'MONOMER0-4565[c]']
+- name: dnaA_pool_ATP_bound
+  pool_kind: ATP_bound
+  store_path: bulk
+  index_by: 'MONOMER0-160[c]'
+
+autorepression_tests:                  # NEW (P1-3): replaces single Pearson
+- name: lagged_binding_mrna_cross_correlation
+  description: 'Cross-correlation between DnaA-TF binding(t-Δt) and dnaA mRNA(t) at Δt ∈ {0, 30, 60, 120}s; expects negative peak at biologically-plausible Δt.'
+- name: conditional_transcription_probability_given_promoter_bound
+- name: transcription_burst_rate_by_promoter_state
+- name: dnaA_gene_dosage_corrected_expression
+
+perturbation_panel:                  # NEW (P1-5)
+- name: dnaA-overexpression
+  type: expression_step
+  description: 'Double dnaA expression at t=300s; expect autorepression to attenuate transient.'
+  expected_response: 'mRNA drops within 60s; protein steady state increases <1.5×'
+- name: dnaA-knockdown
+  type: expression_step
+  description: 'Halve dnaA TE; expect promoter de-repression in <60s.'
+- name: autorepression-ablation
+  type: parameter_swap
+  description: 'Set fc=0; expect uncontrolled DnaA accumulation.'
+- name: ATP-cycle-ablation
+  type: pathway_swap
+  description: 'Disable IntrinsicHydrolysis Step; expect ATP-fraction → 1.0.'
+# ... per the feedback list: oriC affinity, titration sites, RIDA, DDAH, DARS, SeqA
+```
+
+## Per-study application
+
+| Study | Most critical P1 change |
+|---|---|
+| **dnaa-01** | F-01 needs full `measurement_mapping` for [300, 800]; F-02 must split out `autorepression_tests[]` and drop Pearson-only PASS claim |
+| **dnaa-01f-recalibrate** | Re-classify (TE=20×, fc=0.7) as `regression_compatibility` not biological validation; add perturbation panel |
+| **dnaa-01g-joint-te-fold-change-sweep** | Same — the win is regression, NOT biological validation |
+| **dnaa-02** | F-04/F-05 (k=4.6/min) re-labeled `regression_compatibility`; add `measurement_mapping` for the Boesen [0.20, 0.50] band including which-pool clarification |
+| **dnaa-03** | `DnaA_box` schema extension (P2-1) — region_type, box_class, affinity, nucleotide_preference, cooperative_group, source, expert_review_status |
+| **dnaa-04** | Initiation trigger test gets a perturbation panel: dnaA-overexpression, autorepression-ablation, ATP-cycle-ablation |
+| **dnaa-05** | RIDA/DDAH/DARS each get mechanism cards (P2-3); hydrolysis-rate becomes "model-implied" until per-pathway biology lands |
+| **dnaa-06** | SeqA versioning (P2-2) — three recipes: seqa_v0_fixed_timer, seqa_v1_methylation_state, seqa_v2_cooperative |
+
+## Execution order (this PR + next)
+
+1. **This task** (today): Apply P1-1..P1-5 to dnaa-01 as proof of pattern. Document the schema extensions inline.
+2. **Next task**: Roll out P1-1..P1-5 to dnaa-01g, dnaa-02, then dnaa-03..06.
+3. **Then**: P2-1 (DnaA-box schema) — drives dnaa-03 implementation.
+4. **Then**: P2-2 (SeqA versions) — three recipes in baseline_recipes.py.
+5. **Then**: P3 items as polish.
+
+## How this interacts with the recipe chain
+
+Good news — the cascading baseline_recipes.py infrastructure already supports versioning. SeqA v0/v1/v2 become three child recipes of `dnaa_04_with_dnaa_initiation_trigger`. Perturbation panels become loop_patches that flip a single parameter mid-sim.
+
+## How this interacts with the live Visualization Steps
+
+`DnaAStateVisualization` already exposes apo / ATP / ADP separately. P1-4 (explicit pool decomposition) is largely already presented in viz output — just needs the readout-schema metadata to match.
+
+`DnaABoxOccupancyVisualization` partitions by oriC-proximal vs chromosomal. P2-1 (box catalog) will let it partition by `region_type` (oriC / dnaAp / datA / DARS / titration) instead of distance-based heuristic.
+
+## ★ Deeper integration: lift these into bigraph-schema types
+
+These schema additions should NOT just be YAML keys in study.yaml — they should be **first-class bigraph-schema types** registered in `v2ecoli/types/__init__.py:ECOLI_TYPES`. Three immediate wins:
+
+1. **Type-checking at construction.** If `target_class` is a registered enum type, attempting to set an invalid value fails at composite-build time rather than silently slipping through to the evaluator.
+2. **Discoverability via the type registry.** The dashboard's Registry tab, the test runner, and the report generator can all introspect the registered types to (e.g.) find every observable tagged `biological_validation`, or list every site whose `region_type == 'oriC'`.
+3. **Composability.** A `DnaA_pool_kind` enum referenced from a Listener's output port and from a `behavior_tests.measure.pool_kind` field guarantees the names agree.
+
+### Concrete bigraph-schema additions
+
+Five new types to register in `v2ecoli/types/__init__.py`:
+
+```python
+# v2ecoli/types/biology.py  (new file)
+
+TARGET_CLASS = {
+    '_type': 'enum',
+    '_values': [
+        'regression_compatibility',
+        'biological_validation',
+        'explanatory_gain',
+    ],
+    '_description': 'How a behavior_test should be interpreted. Heuristic-match cannot count as biological validation. Per dnaa_biology_feedback (2026-05-17).',
+}
+
+DNAA_POOL_KIND = {
+    '_type': 'enum',
+    '_values': [
+        'total',           # apo + ATP-bound + ADP-bound + DNA-bound + complexed
+        'free',            # apo + ATP + ADP, not DNA-bound
+        'ATP_bound',       # MONOMER0-160 only
+        'ADP_bound',       # MONOMER0-4565 only
+        'apo',             # PD03831, neither nucleotide
+        'DNA_bound',       # bound to chromosomal boxes
+        'oriC_bound',      # subset of DNA_bound: at oriC sites
+        'non_oriC_bound',  # subset of DNA_bound: chromosomal + dnaAp + datA
+    ],
+    '_description': 'Which DnaA pool a count refers to. dnaA-count-in-range gate cannot fire without explicit pool selection. Per feedback P1-4.',
+}
+
+DNAA_BOX_REGION_TYPE = {
+    '_type': 'enum',
+    '_values': ['oriC', 'dnaAp', 'datA', 'DARS1', 'DARS2', 'chromosomal_titration', 'other'],
+    '_description': 'Per feedback P2-1 — oriC / dnaAp / datA / DARS / titration must not be conflated.',
+}
+
+DNAA_BOX_AFFINITY_CLASS = {
+    '_type': 'enum',
+    '_values': ['high', 'medium', 'low'],
+    '_description': 'Roth1998 + Hansen 2018 affinity classification. Maps to Kd ~1-5, ~20-100, ~100-500 (DnaA-ATP molecules per cell).',
+}
+
+FAILURE_CAUSE = {
+    '_type': 'enum',
+    '_values': [
+        'missing_mechanism',       # the biology required isn\'t in the model yet
+        'miscalibration',          # mechanism present, parameter wrong
+        'observable_mismatch',     # literature vs model measure different pools/conditions
+        'insufficient_statistics', # data exists but not enough samples
+    ],
+    '_description': 'Per feedback P2-4. Required field on any FAIL outcome.',
+}
+
+# Compound type — a measurement_mapping is a struct attached to a behavior_test:
+MEASUREMENT_MAPPING = {
+    '_type': 'tree[any]',  # bigraph-schema struct
+    '_inputs': {
+        'literature_observable': {
+            '_type': 'tree[any]',
+            'name': 'string',
+            'biological_pool': 'dnaa_pool_kind',  # ← references the enum above
+            'condition': 'string',
+            'statistic': 'string',
+            'source_ids': 'list[string]',
+        },
+        'model_observable': {
+            '_type': 'tree[any]',
+            'listener_path': 'string',
+            'state_path': 'string',
+            'molecular_pool': 'dnaa_pool_kind',
+            'units': 'string',
+            'includes_bound_species': 'boolean',
+        },
+        'transformation': {
+            '_type': 'tree[any]',
+            'formula': 'string',
+            'time_window': 'string',
+            'aggregation': 'string',
+        },
+        'caveats': 'list[string]',
+    },
+}
+
+# Extend the existing DNAA_BOX_ARRAY (P2-1):
+# Current: 'unique_array[coordinates:integer|domain_index:integer|DnaA_bound:boolean|...]'
+# Becomes:
+DNAA_BOX_ARRAY_RICH = (
+    'unique_array[coordinates:integer'
+    '|domain_index:integer'
+    '|DnaA_bound:boolean'
+    '|region_type:dnaa_box_region_type'        # ← NEW
+    '|affinity_class:dnaa_box_affinity_class'  # ← NEW
+    '|nucleotide_preference:string'            # ← NEW: ATP-only / ATP-preferred / either
+    '|cooperative_group:integer'               # ← NEW: index into cooperative-binding cluster
+    '|source:string'                            # ← NEW: roth1998 / hansen2018 / parca_pwm / ...
+    '|expert_review_status:string'             # ← NEW: confirmed / pending / disputed
+    '|_entryState:integer|...]'
+)
+```
+
+Then register them:
+```python
+# v2ecoli/types/__init__.py — extend ECOLI_TYPES
+from .biology import (
+    TARGET_CLASS, DNAA_POOL_KIND, DNAA_BOX_REGION_TYPE,
+    DNAA_BOX_AFFINITY_CLASS, FAILURE_CAUSE, MEASUREMENT_MAPPING,
+)
+ECOLI_TYPES['target_class'] = TARGET_CLASS
+ECOLI_TYPES['dnaa_pool_kind'] = DNAA_POOL_KIND
+ECOLI_TYPES['dnaa_box_region_type'] = DNAA_BOX_REGION_TYPE
+ECOLI_TYPES['dnaa_box_affinity_class'] = DNAA_BOX_AFFINITY_CLASS
+ECOLI_TYPES['failure_cause'] = FAILURE_CAUSE
+ECOLI_TYPES['measurement_mapping'] = MEASUREMENT_MAPPING
+```
+
+### Wins from doing this at the type level
+
+| Capability | Without bigraph-schema integration | With it |
+|---|---|---|
+| Invalid `target_class` value | Slips through to evaluator → silent miscategorization | Composite-build raises TypeError at registration time |
+| Listener output port for DnaA-ATP count | Just a number | A `{value: int, pool_kind: 'ATP_bound', units: 'molecules/cell'}` struct that the test runner unwraps with full schema knowledge |
+| DnaA-box query "all oriC boxes" | Have to read coordinates and infer | `boxes[where region_type == 'oriC']` — type-aware indexing |
+| Test runner classifying a FAIL | Free-text in the report | `failure_cause` enum on the result; aggregator groups failures by cause |
+| `DnaABoxOccupancyVisualization` color-by-class | Hard-coded distance heuristic | Reads `region_type` directly from the unique array; works for any box catalog |
+| Cross-study consistency | Each study.yaml could use slightly different pool names | Single registered type → mismatches fail fast |
+
+### Migration path
+
+1. **Now (P1)**: Add the enums + MEASUREMENT_MAPPING type to `v2ecoli/types/biology.py`. Register in ECOLI_TYPES. study.yamls reference them by name (string values still readable to humans).
+2. **Next (P2-1)**: Extend `DNAA_BOX_ARRAY` to `DNAA_BOX_ARRAY_RICH`. ParCa's initial-conditions populates `region_type` and `affinity_class` from the curated catalog. Existing dnaa-03 probe + viz Step start using these attributes.
+3. **Then (P2-2 / P2-3)**: Mechanism cards become structured types too — `SeqA_version: enum[v0_fixed_timer, v1_methylation_state, v2_cooperative]` and similar for RIDA/DDAH/DARS.
+4. **Then**: The test runner introspects type-registered metadata to render the report's per-class breakdown automatically (target_class buckets) and to surface failure_cause histograms.
+
+## What changes in this PR vs follow-ups
+
+- **This PR (current)**: register `dnaa_biology_feedback` expert doc, write this plan, apply P1-1..P1-5 to dnaa-01 as proof of pattern (with bigraph-schema type usage from the start).
+- **Next PR**: roll out P1 to dnaa-01g, dnaa-02, dnaa-03..06; create `v2ecoli/types/biology.py` if not done here.
+- **Then**: P2 items as separate PRs (DnaA-box schema extension is its own substantial implementation).

--- a/investigations/dnaa-replication-fresh/investigation.yaml
+++ b/investigations/dnaa-replication-fresh/investigation.yaml
@@ -1,0 +1,50 @@
+schema_version: 1
+name: dnaa-replication-fresh
+title: DnaA / Replication Initiation
+created: '2026-05-17'
+status: planning
+question: "Can a DnaA-driven mechanistic model of replication initiation in v2ecoli\nreproduce the observed once-per-generation\
+  \ timing, initiation-mass\nhomeostasis, and ATP-fraction oscillations while staying within \xB15% of\nthe mass-threshold\
+  \ heuristic baseline under slow non-overlapping growth?\n"
+hypothesis: "Yes. The six staged studies (expression \u2192 ATP/ADP cycle \u2192 DnaA-box\nbinding \u2192 mechanism-driven\
+  \ initiation \u2192 RIDA/DDAH/DARS extrinsic\nconversion \u2192 SeqA sequestration) compose into a model that recapitulates\n\
+  the textbook DnaA cycle. Each study's behavioral tests pass before the\nnext study in the chain is started; the final mechanism\
+  \ baseline matches\nthe heuristic's initiation-mass distribution within \xB15%.\n"
+description: "Multi-phase port of DnaA / replication initiation into v2ecoli, driven by\nthe molecular-info expert document\
+  \ and the multi-phase plan\n(references/expert/). Each study is a discrete, gated implementation\nphase; tests in each must\
+  \ pass before its dependents can run.\n\nStudies, in dependency order:\n\n1. dnaa-01-expression-dynamics    \u2014 steady\
+  \ DnaA expression + autorepression baseline.\n2. dnaa-02-atp-hydrolysis         \u2014 DnaA-ATP/ADP/apo nucleotide cycle,\
+  \ intrinsic hydrolysis.\n3. dnaa-03-box-binding            \u2014 307 chromosomal boxes + 11 oriC + 4 dnaAp boxes, titration.\n\
+  4. dnaa-04-initiation-mechanism   \u2014 replace mass-threshold heuristic with DnaA-driven initiation.\n5. dnaa-05-rida-ddah-dars\
+  \         \u2014 replisome-coupled hydrolysis + DARS reactivation.\n6. dnaa-06-seqa-sequestration     \u2014 post-initiation\
+  \ SeqA sequestration of oriC + dnaAp.\n\nSee investigations/<name>/STATUS.md for the per-phase implementation\nstatus and\
+  \ the cross-study test report (planned).\n"
+studies:
+- dnaa-fresh-01-expression-dynamics
+- dnaa-fresh-01f-recalibrate-eg10235-translation-efficiency-in-parca
+- dnaa-fresh-01f-apply-overwrite-fix-to-sibling-listeners-rna-synth-prob-repl
+- dnaa-fresh-02-atp-hydrolysis
+- dnaa-fresh-03-box-binding
+- dnaa-fresh-04-initiation-mechanism
+- dnaa-fresh-05-rida-ddah-dars
+- dnaa-fresh-06-seqa-sequestration
+expert_docs:
+- replication_initiation_molecular_info
+- chromosome_replication_plan
+acceptance_criteria:
+- study: dnaa-fresh-01-expression-dynamics
+  behavior: dnaa-count-in-mass-spec-range
+- study: dnaa-fresh-01-expression-dynamics
+  behavior: dnaa-concentration-stable-within-10pct
+- study: dnaa-fresh-02-atp-hydrolysis
+  behavior: dnaa-atp-fraction-in-physiological-range
+- study: dnaa-fresh-03-box-binding
+  behavior: oric-stays-unoccupied-until-chromosome-saturates
+- study: dnaa-fresh-04-initiation-mechanism
+  behavior: one-initiation-per-generation
+- study: dnaa-fresh-04-initiation-mechanism
+  behavior: initiation-mass-mean-matches-heuristic
+- study: dnaa-fresh-05-rida-ddah-dars
+  behavior: inter-initiation-cv-narrows-vs-intrinsic-only
+- study: dnaa-fresh-06-seqa-sequestration
+  behavior: wildtype-zero-reinitiation

--- a/investigations/dnaa-replication-fresh/overnight-2026-05-17/FRICTION.md
+++ b/investigations/dnaa-replication-fresh/overnight-2026-05-17/FRICTION.md
@@ -1,0 +1,221 @@
+# Investigation-Design Friction Log — 2026-05-17
+
+> Each friction point is something that slowed me down or made me less
+> effective driving the dnaA investigation forward. Each entry includes
+> a concrete improvement suggestion so the studies-infrastructure can
+> evolve to support deeper, faster work.
+
+## F-01: Spawned follow-up study.yaml is mostly empty templates
+
+**Where**: `studies/dnaa-01f-recalibrate-eg10235-translation-efficiency-in-parca/study.yaml`
+
+**What I hit**: The spawned study has `purpose.question` (good, copied
+from parent), but `model_change.notes: "Populate during Build phase"`,
+`pipeline_gate.proceed_condition: "TBD — define before Simulate"`, and
+`behavior_tests: []`. Every section asks me to invent context that
+already exists in the parent's finding evidence.
+
+**Concrete suggestion**: When the dashboard's "Seed new study" action
+fires, in addition to copying `purpose`, it should:
+1. Copy the parent finding's `evidence` block into `seeded_from.evidence`.
+2. Pre-populate `pipeline_gate.proceed_condition` from the parent's
+   `next_action` (or at minimum quote it as a starting point).
+3. Pre-populate `behavior_tests` with the parent's tests that
+   originally FAILED (these are exactly what the follow-up must make
+   pass). For dnaa-01f-recalibrate, that's `dnaA-count-in-range` +
+   `autorepression-correlation`.
+4. Pre-populate `model_change.modified_processes` with a "TBD"
+   placeholder per the finding's `mechanism` hint, but at least
+   point at the right file.
+
+**Why it matters**: Driving from a fresh `planned`-status study takes
+30+ minutes of re-reading the parent before any real model work
+starts. With the suggested seed, that drops to 5 minutes.
+
+## F-02: Test gate logic is implicit in conclusion_logic.if_primary_tests_pass
+
+**Where**: `study.yaml.conclusion_logic`
+
+**What I hit**: To decide whether dnaa-01 can pass its gate, I had to
+read the conclusion_logic block AND mentally match it against the
+findings list. There's no programmatic way to ask "is this study's
+gate passed yet?" — the dashboard infers it from running pytest, but
+the decision rules live in YAML prose.
+
+**Concrete suggestion**: Add a `gate_evaluator` field to study.yaml,
+e.g.:
+
+```yaml
+gate_evaluator:
+  expr: "outcomes['dnaA-count-in-range'].result == 'PASS' AND outcomes['autorepression-correlation'].result == 'PASS'"
+  result: blocked  # auto-set by evaluator after last run
+  blocked_by: ["dnaA-count-in-range", "autorepression-correlation"]
+```
+
+Then the dashboard can show a binary "gate open/closed" badge on
+each study card, and the next-study auto-status update can flip from
+`blocked` → `planned` when its prerequisite's gate opens.
+
+## F-03: Joint parameter sweeps require manual scripting
+
+**Where**: F-10 explicitly recommends a "TE × autorepression-fold-change
+3×3 grid". To implement this I'd have to write a new variant runner
+that takes TWO override params, then a new evaluator that aggregates
+by both axes.
+
+**Concrete suggestion**: Promote the variant-sweep pattern in
+study.yaml to a first-class declarative spec:
+
+```yaml
+simulation_set:
+  - kind: grid_sweep
+    name: te_x_foldchange_grid
+    base: baseline
+    axes:
+      - param: dnaa_te_multiplier
+        values: [10, 20, 30, 40, 50]
+      - param: dnaa_autorep_multiplier
+        values: [0.5, 1.0, 2.0, 5.0]
+    seeds: [0, 1, 2]
+    duration_min: 10
+```
+
+Then a generic runner expands this into N×M×S simulations + a generic
+evaluator that produces a per-axis heatmap visualization
+automatically. This pattern recurs in dnaa-02 (ATP/ADP/apo split
+hydrolysis-rate sensitivity) and dnaa-03 (DnaA-box K_d sensitivity).
+
+## F-04: Listeners hide multi-state pools behind a single index
+
+**Where**: `listeners.monomer_counts[3861]` — apparently the dnaA "count"
+— is the observable that the dnaA-count-in-range test reads.
+
+**What I hit**: At the bulk level, DnaA actually lives across THREE bulk
+species (PD03831 apo, MONOMER0-160 ATP-bound, MONOMER0-4565 ADP-bound),
+maintained by the `ecoli-equilibrium` process. The
+`listeners.monomer_counts[3861]` reading aggregates these (probably) so
+that `count_in_range = 115` describes total DnaA, not just apo. **But you
+can't tell from the listener API alone** — there's no metadata that says
+"this is a sum over an equilibrium pool". I had to write a probe that
+reads the live `bulk` vector directly to verify.
+
+**Concrete suggestion**: Add an `expansion` field to listener-config
+schemas:
+
+```python
+listener_schema(monomer_counts, expansion={
+    "PD03831[c]": ["MONOMER0-160[c]", "MONOMER0-4565[c]"],
+    # ... more equilibrium-coupled species
+})
+```
+
+…and the dashboard's Observables tab can render the breakdown so a
+biologist exploring "DnaA count" sees apo + ATP-bound + ADP-bound on
+a stacked-area chart automatically.
+
+## F-05: Equilibrium and metabolic-reaction databases are de-coupled from kinetic constraints
+
+**Where**: `metabolic_reactions.tsv` declares RXN0-7444 (DnaA-ATP intrinsic
+hydrolysis) catalyzed by CPLX0-10342, BUT `metabolism_kinetics.tsv` has
+no entry for it. The FBA solver therefore never selects this reaction.
+
+**What I hit**: I went looking for "why is DnaA-ADP always 0?" and traced
+through three databases (`metabolic_reactions.tsv` → `metabolism_kinetics.tsv`
+→ `disabled_kinetic_reactions.tsv`) before realizing the reaction is silently
+inactive because no rate constraint exists for it.
+
+**Concrete suggestion**: Add a validation step that runs after ParCa cache
+build, checking: for each reaction in `metabolic_reactions.tsv`, is there
+EITHER a kinetic constraint, OR an entry in `disabled_kinetic_reactions.tsv`
+explicitly excluding it? Unannotated reactions get silently ignored by
+the FBA solver, which is the worst kind of failure mode — they look
+"available" but never fire. A startup-time warning ("4 reactions declared
+but neither constrained nor disabled; behavior depends on FBA objective")
+would have saved me an hour.
+
+## F-06: study.yaml.runs[] is divorced from runs.db simulations
+
+**Where**: A study's `runs[]` array (with `simulation`, `seed`, `started_at`,
+`outcomes`) does NOT carry a run_id field. Meanwhile `runs.db` tracks
+simulations via UUID `simulation_id`. The dashboard's Runs tab shows the
+yaml entries; Simulations DB shows the DB rows — they're disjoint
+datasets, so a user can't trivially click "see this run's data".
+
+**Concrete suggestion**: When the evaluator writes outcomes back to
+study.yaml.runs[], it should also record the `run_id` from the most
+recent matching `simulations.name` row, so the two views can join. The
+Dashboard's Runs-tab "View" button would then have a real URL to navigate
+to (instead of the currently-404 /composite-explorer?run_id=...).
+
+## F-07: New variant runners proliferate; no canonical pattern
+
+**Where**: To run the joint (TE × fc) sweep I had to write a NEW runner
+(`run_baseline_with_fc.py`) instead of extending the existing
+`run_baseline.py`. The existing runner has `--dnaa_te_multiplier` but
+not `--dnaa_autorep_multiplier`. There's no clean way to add a new
+"pre-build patch" without copying the entire runner.
+
+**Concrete suggestion**: Refactor the runner around a `BundlePatcher`
+plugin pattern:
+
+```python
+class BundlePatcher:
+    def apply(self, bundle, args): ...
+
+REGISTRY = {
+    'dnaa_te_multiplier': lambda v: lambda b: scale_te(b, 3861, v),
+    'dnaa_autorep_multiplier': lambda v: lambda b: scale_deltaV_col(b, 12, v),
+    # ... add more
+}
+
+# In runner:
+for name, value in args.__dict__.items():
+    patcher = REGISTRY.get(name)
+    if patcher and value != 1.0:
+        patcher(value)(bundle)
+```
+
+Then any new variant adds one row to REGISTRY, no new runner needed.
+
+## F-08: Path-resolution bug pattern in seed scripts
+
+**Where**: Wrote `run_baseline_with_fc.py` using `Path(__file__).resolve().parents[2]`
+to locate V2ECOLI_DIR. Wrong — the file is at
+`investigations/dnaa-replication/overnight-2026-05-17/run_baseline_with_fc.py`,
+so parents[2] = `investigations/` (off by one). Got
+`FileNotFoundError: ...investigations/out/cache/initial_state.json`.
+
+**Concrete suggestion**: Provide a one-import helper:
+
+```python
+# In v2ecoli/library/paths.py
+def workspace_root() -> Path:
+    """Walk up from caller's file until you find workspace.yaml or .git/."""
+    p = Path(sys._getframe(1).f_code.co_filename).resolve().parent
+    while p != p.parent:
+        if (p / 'workspace.yaml').exists() or (p / '.git').exists():
+            return p
+        p = p.parent
+    raise RuntimeError('no workspace root found')
+```
+
+Then every script does `V2ECOLI_DIR = workspace_root()` and is location-independent.
+
+## F-09: deltaV [DnaA col] regulation graph is opaque
+
+**Where**: `delta_prob.deltaV[deltaJ==12]` has 10 entries — these are
+the 10 TUs DnaA regulates. The TU IDs are `TU0-1193[c]`, `TU0-14305[c]`,
+etc. — opaque locus IDs. Cross-referencing to gene names requires reading
+`rnas.tsv` and following `cistron_id` → `gene_symbol`.
+
+**What I hit**: Trying to verify whether dnaA self-autorepresses (a key
+biological assumption), I had to grep `rnas.tsv` for `EG10235_RNA`
+to find its cistron ID, then trace cistron→TU via cistron_to_rna_indexes
+machinery in transcription dataclass. Took 10 minutes that should have
+been 30 seconds.
+
+**Concrete suggestion**: `delta_prob` should carry a `regulation_map`
+field: `{TF_id: {regulated_TU_id: {target_gene: ..., effect: ...}}}`.
+At least at debug-time, exposing readable names with deltaV would make
+autorepression triage much faster.
+

--- a/investigations/dnaa-replication-fresh/overnight-2026-05-17/PROGRESS.md
+++ b/investigations/dnaa-replication-fresh/overnight-2026-05-17/PROGRESS.md
@@ -1,0 +1,371 @@
+# Overnight Investigation Progress — 2026-05-17
+
+> Live log of what was actually run, what passed/failed, and the biological
+> insights surfaced as the dnaA / replication-initiation investigation
+> drives forward through Phases 1→6.
+
+Started: 2026-05-17 04:00 (local)
+Operator: Claude (overnight autonomous run)
+
+## ★ Headline finding — the autorepression knob works
+
+**(TE=20×, fc=0.7) is the first v2ecoli calibration that passes BOTH
+of dnaa-01's primary gate tests:**
+- `dnaA-count-in-range`: median 707 DnaA/cell (in literature [300, 800])
+- `autorepression-correlation`: Pearson r = -0.521 (≤ -0.3 threshold)
+
+> Scaling the dnaA-specific entries of `delta_prob.deltaV` by 0.7
+> (weakening autorepression by 30%) combined with TE=20× resolves
+> F-10's "no single multiplier works" finding. **The fold_change
+> parameter is the missing second knob.** Phase 2 5-seed validation
+> in progress.
+
+## Insights (numbered)
+
+1. dnaA's TE sits at the 8.6th percentile of v2ecoli's proteome — biologically improbable for a master regulator.
+2. The DnaA-ATP/ADP/apo equilibrium machinery is ALREADY active in baseline; req-1 of dnaa-02 is partially done.
+3. DnaA-ATP fraction = 0.99 in baseline (Boesen 2024 target [0.2, 0.5]); intrinsic hydrolysis doesn't fire.
+4. DnaA-ADP pool = 0 throughout simulation; the conversion mechanism is broken.
+5. Metabolic reaction RXN0-7444 (DnaA-ATP hydrolysis) has NO kinetic constraint — silently inactive in FBA.
+6. TE→DnaA-count relationship is non-monotonic; phase transition between 20× and 25× TE causes autorepression saturation.
+7. 15× TE is the cleanest single-knob calibration (autorep PASS r=-0.533, count short by 18%).
+8. ★ (TE=20×, fc=0.7) passes both primary gate tests — joint sweep is the right approach.
+9. DnaA-box catalog ALREADY exists in chromosome_structure.py (DNAA_BOX_ARRAY); req-1 of dnaa-03 is largely done.
+10. dnaa-04's mass-threshold initiation trigger lives at exactly chromosome_replication.py:244 — swap point identified.
+
+## Starting state
+
+- **dnaa-01**: Decide, gated. 10 findings (F-01..F-10). Pipeline-gated on
+  the F-10 finding that no single TE multiplier passes both
+  `dnaA-count-in-range` AND `autorepression-correlation`.
+- **dnaa-01f-recalibrate-EG10235**: Design (planned, empty model_change).
+- **dnaa-01f-listener-fix**: Decide (ran, partial-success).
+- **dnaa-02..06**: Design (planned, all behaviors gated on upstream).
+
+## Plan for tonight
+
+Three workstreams, executed in order:
+
+1. **Investigate ParCa TE root cause (F-08 next_action #2)**. Is the
+   cached TE for EG10235 (7.23e-5) genuinely calibrated, or a bug?
+2. **Drive dnaa-01f-recalibrate through to Decide.** Either fix lands
+   `dnaA-count-in-range` cleanly without breaking autorepression
+   (gate opens for dnaa-02) OR document the tension precisely and spawn
+   the next layer of follow-up.
+3. **Push into dnaa-02 (DnaA-ATP/ADP/apo split)** as far as possible.
+   Real code: new bulk species + intrinsic-hydrolysis Step.
+
+## Step-by-step log
+
+### Step 0 — Setup (04:00–04:15)
+
+- Read F-01, F-08, F-09, F-10 in full.
+- Read existing TE sweep evaluator + run_baseline runner.
+- Located key indices: DNAA monomer = 3861, DNAA_TF = 12, dnaA cistron = 227.
+- Located fold_change machinery in `tf_binding` (`delta_prob.deltaV` sparse matrix).
+- Created tracking dir `investigations/dnaa-replication/overnight-2026-05-17/`.
+
+### Step 1 — Root-cause inspection of ParCa-cached TE for EG10235 (04:15–04:30)
+
+**Approach**: Loaded the ParCa cache bundle directly via
+`load_cache_bundle('out/cache')` and inspected the
+`translation_efficiencies` vector against the full proteome distribution
+(4309 monomers).
+
+**Key biological insight — Insight #1 of the night**:
+
+> DnaA (PD03831[c]) translation efficiency sits at the **8.6th percentile**
+> of v2ecoli's proteome (TE = 7.23e-5).
+
+| Quantile | TE value |
+|---|---|
+| 1st percentile | 2.07e-6 |
+| 10th percentile | 8.06e-5 |
+| **DnaA (idx 3861)** | **7.23e-5** |
+| 25th percentile | 1.73e-4 |
+| Median (50th) | 2.30e-4 |
+| 75th percentile | 2.30e-4 |
+| 90th percentile | 3.80e-4 |
+| 99th percentile | 6.73e-4 |
+| Max | 2.10e-3 |
+
+**Why this is striking**: DnaA is a *master regulator* — its per-cell
+count needs to track cell volume across generation times for proper
+initiation timing. Placing its translation efficiency at the bottom
+9% of the proteome is biologically improbable for an essential,
+abundance-regulated protein. The 8.6th-percentile band is dominated
+by low-expression, fate-determining proteins (e.g., MONOMER0-2860,
+G7747-MONOMER, EG11312-MONOMER at the 2e-6 floor) and inner-membrane
+machinery, not master regulators.
+
+**Implication**: The 50× TE multiplier that F-08 found by sweep is
+not a fix — it pushes DnaA's TE to ~3.6e-3, **above** the proteome
+max of 2.10e-3 (also unphysical). The right answer should sit
+somewhere in between, likely a ~3–5× nudge that places DnaA near
+the proteome median (~2.3e-4). The fact that 5× barely moved the
+DnaA count (115 → 129) means **autorepression buffers small TE
+nudges very effectively** — F-08's observation. The system needs
+a TE bump large enough to overwhelm autorepression's response, but
+small enough that the fold-change protein response stays sub-linear.
+
+**Next**: Run a focused multi-seed sweep at 3×, 5×, 10×, 15×, 20×,
+30× (6 points × 3 seeds = 18 sims, ~25 min wall) so we can locate
+the inflection precisely and pick the TE that lands DnaA in [300, 800]
+with minimum autorepression damage.
+
+### Step 2 — DnaA-ATP/ADP/apo probe (04:30–04:50)
+
+While the TE sweep ran in background, I probed v2ecoli's existing equilibrium
+machinery to test a hypothesis (was F-01's "115 DnaA/cell" an undercount
+because it only counted apo-DnaA?). Wrote a 27-line probe script that
+builds a baseline composite, runs it 5 min, then reads the bulk vector
+directly for the three DnaA forms.
+
+**Result (5-min sim, seed 0)**:
+
+| Species | Bulk idx | Initial | 5-min final |
+|---|---|---|---|
+| apo (PD03831) | 11565 | 124 | **1** |
+| DnaA-ATP (MONOMER0-160) | 10822 | 0 | **114** |
+| DnaA-ADP (MONOMER0-4565) | 11114 | 0 | **0** |
+| **TOTAL** | | **124** | **115** |
+
+**Three biological insights — Insights #2–4 of the night**:
+
+**Insight #2** — The DnaA-ATP/ADP equilibrium machinery is ALREADY active in
+v2ecoli's baseline composite. Within 5 simulated minutes, equilibrium drives
+essentially all apo-DnaA into the DnaA-ATP form (99.1% ATP-bound). This was
+not previously surfaced — STATUS.md and dnaa-02's gaps both said this needed
+to be built. **It exists.**
+
+**Insight #3** — DnaA-ATP fraction = 0.991 at steady state. **This violates
+Boesen 2024's target of [0.2, 0.5]**. v2ecoli's intrinsic-hydrolysis flux
+(reaction RXN0-7444: DnaA-ATP + H2O → DnaA-ADP + Pi, catalyzed by CPLX0-10342)
+is either not firing or far below its specified rate (Boesen: 0.046/min).
+This is dnaa-02's first concrete computational gap.
+
+**Insight #4** — DnaA-ADP pool = 0 at steady state. This means the conversion
+to ADP-bound form (which is the "post-initiation reset" state in the
+Katayama model) is broken. Without DnaA-ADP, RIDA/DDAH/DARS cannot do
+their replication-coupled work in dnaa-05. **This blocks dnaa-05's entire
+mechanism.**
+
+**Verification of F-01**: Total DnaA = 115 (apo + ATP + ADP) at 5 min,
+matching `monomer_counts[3861] = 113` at 10 min. So `monomer_counts` for
+PD03831 likely sums-across-complexes for display — F-01's calibration
+finding (115 << [300, 800]) is correct, not an undercount. Recalibration
+is still the right move.
+
+**Files written**:
+- `investigations/dnaa-replication/overnight-2026-05-17/probe_dnaa_total.py` (probe script)
+
+### Step 3 — TE sweep results, including 15×/25×/30× fill-in (04:50–05:00)
+
+Sweep completed: 19 new sims added to runs.db. Combined with the
+pre-existing F-10 data, we now have **5-seed coverage at 1×, 10×, 15×,
+20×, 25×, 30×, 50×** and 3-seed at 5× and 100×.
+
+Final aggregate table (pooled multi-seed extraction, second-half window):
+
+| TE× | seeds | DnaA median | mRNA mean | Pearson r | count gate | autorep gate |
+|---|---|---|---|---|---|---|
+| 1× | 5 | 115 | 0.000 | N/A (no variance) | FAIL | FAIL |
+| 5× | 3 | 129 | 0.000 | N/A | FAIL | FAIL |
+| 10× | 5 | 188 | 0.332 | -0.301 | FAIL | PASS (barely) |
+| **15×** | 5 | **247** | — | **-0.533** | FAIL | **PASS (strong)** |
+| 20× | 5 | 296 | 0.286 | -0.253 | FAIL (close) | FAIL (close) |
+| **25×** | 5 | **263** | — | **+0.780** | FAIL | FAIL (flipped!) |
+| **30×** | 5 | **159** | — | **+0.186** | FAIL | FAIL (collapsed) |
+| 50× | 5 | 497 | 0.306 | +0.613 | PASS | FAIL |
+| 100× | 3 | 108 | 0.063 | -0.093 | FAIL | FAIL |
+
+**Insight #6 — TE → DnaA is NON-MONOTONIC.** Look at the 20→25→30 row:
+DnaA *drops* from 296 → 263 → 159 even though TE *increases* by 50%.
+By 30× the system has crashed back BELOW baseline (159 vs 115 unfit
+expectation). 100× crashes even further (108).
+
+**Mechanistic interpretation**: above 20× TE, autorepression goes into
+*oscillatory / collapsed* regime. The Pearson r flips abruptly from
+-0.253 at 20× to +0.780 at 25× — the autorepression mechanism is
+saturable; once mRNA hits zero, no more suppression is possible, and
+the system enters a runaway production → collapse cycle. This is a
+classic too-strong-negative-feedback oscillator signature.
+
+> **F-10 framed this as "no single TE passes both gates."** With 5-seed
+> coverage in the 15-30× region, the picture is sharper: **the system
+> has a phase transition between 20× and 25× TE.** Above the
+> transition, the autorepression model architecture is fundamentally
+> incompatible with the count-in-range target. The right scientific
+> next step is to interrogate the autorepression fold_change parameter
+> itself, not just sweep TE in isolation.
+
+**Insight #7 — 15× is the cleanest single-knob calibration**, even
+though it underschoots count by 18%:
+- Strongest measured autorepression signal (r = -0.533, well below -0.3 pass band)
+- Closest TE to median proteome TE (1.08e-3, just above the 99th percentile of 6.7e-4 but not WAY above)
+- Stable across all 5 seeds (no oscillatory regime)
+- Implies a "1.5×" deficit on DnaA count which COULD be closed by
+  combining 15× TE with a 1.5× reduction in DnaA degradation rate
+  (separate follow-up).
+
+**Visualizations generated**:
+- `viz/01_te_sweep_count.svg` — bar chart with literature acceptance band
+- `viz/02_te_sweep_pearson.svg` — bar chart with autorepression pass band
+- `viz/03_te_sweep_combined.svg` — dual-axis: count bars + Pearson points
+- `viz/05_dnaa_states_timeseries.svg` — DnaA equilibration trajectory
+
+### Step 4 — Cross-study triage (05:00–05:20)
+
+Surveyed dnaa-02 through dnaa-06 to find existing infrastructure that
+the studies' implementation_requirements treat as "TBD" but is actually
+already partially present.
+
+**dnaa-02-atp-hydrolysis** (3 findings added):
+- F-01: DnaA-ATP/ADP/apo equilibrium machinery ALREADY ACTIVE in
+  baseline. req-1 (split bulk) is partially done.
+- F-02: DnaA-ATP fraction = 0.99 in baseline (Boesen target [0.2, 0.5]).
+- F-03: RXN0-7444 has no kinetic constraint → DnaA-ADP pool = 0.
+
+**dnaa-03-box-binding** (1 finding added):
+- F-01: DnaA-box catalog ALREADY EXISTS in chromosome_structure.py.
+  DNAA_BOX_ARRAY type tracks coordinates, domain_index, DnaA_bound.
+  ParCa initializes from sim_data.process.replication.motif_coordinates.
+  req-1 (catalog) is essentially done; per-box affinity attributes
+  and binding Step are the remaining work.
+
+**dnaa-04-initiation-mechanism** (2 findings added):
+- F-01: Current initiation trigger is the mass-threshold at
+  chromosome_replication.py:244. Exact insertion point + swap strategy
+  documented. Becomes a 1-day task once dnaa-03 lands.
+- F-02: `chromosome_initiation.py` has empty stubs (DnaABinder,
+  ChromosomePartition) explicitly designated for the binding+
+  initiation logic — work goes there, not in chromosome_structure.py.
+
+**dnaa-05 / dnaa-06**: deferred to subsequent overnight runs.
+
+### Step 5 — Proposed model code: IntrinsicHydrolysis Step (05:20–05:35)
+
+Drafted (NOT yet wired into baseline) at
+`investigations/dnaa-replication/overnight-2026-05-17/proposed_intrinsic_hydrolysis_step.py`.
+
+A stochastic first-order Step that converts DnaA-ATP → DnaA-ADP at
+Boesen 2024's intrinsic rate (k = 0.046/min). Reads bulk[MONOMER0-160],
+samples Poisson-rounded hydrolysis events, writes bulk delta. No
+metabolic-flux bookkeeping — relies on the cell's ATP/ADP pools being
+buffered by the rest of metabolism.
+
+**Why drafted but not wired**: Modifying baseline.py requires careful
+review for side-effects on the ~50 other processes. The Step file is
+complete and ready to drop into v2ecoli/processes/ in the morning.
+
+### Step 6 — fc-multiplier pilot for joint-sweep follow-up (05:35–05:55)
+
+Wrote `investigations/dnaa-replication/overnight-2026-05-17/run_baseline_with_fc.py`
+— a parallel runner with both `--dnaa_te_multiplier` AND
+`--dnaa_autorep_multiplier` flags.
+
+The autorep multiplier scales the deltaV entries in
+`delta_prob[:, 12]` (the 10 TUs DnaA regulates). fc=0.5 halves the
+per-bound-DnaA suppression; fc=2.0 doubles it.
+
+Pilot sweep launched: TE=20× × fc∈{0.3, 0.5, 0.7, 2.0} × seeds 0,1 + 
+TE=30× × fc=0.3 × seeds 0,1 = 10 sims (~13 min wall). If any
+(TE, fc) cell passes both gates, that's a real biological insight:
+**v2ecoli's autorepression can be gradeable through delta_prob scaling**,
+which validates the joint-sweep follow-up's hypothesis.
+
+Sims being named `baseline-te{N}x-fc{F}-seed{S}` in
+`studies/dnaa-01-expression-dynamics/runs.db`.
+
+### Step 7 — fc-multiplier pilot WIN (05:55–06:10)
+
+**Insight #8 — biggest scientific finding of the night**:
+
+> **(TE=20×, fc=0.7) passes BOTH primary gate tests.**
+> DnaA median = 707 (in literature band [300, 800]) ✓
+> Pearson r = -0.521 (≤ -0.3 autorepression threshold) ✓
+
+This is the first calibration we've found that satisfies both gates
+simultaneously, and it validates the joint-sweep hypothesis from
+F-10 of the parent and F-02 of dnaa-01f-recalibrate. **The fold_change
+multiplier IS the right second knob.** Scaling deltaV entries in
+delta_prob[:, 12] by 0.7 (weakening autorepression by 30%) combined
+with TE=20× (raising baseline translation 20×) puts v2ecoli's DnaA
+pool in physiological range while preserving the homeostatic feedback
+signature.
+
+Pilot sweep table (caveat: 2-seed samples for fc!=1):
+
+| Combo | seeds | DnaA med | Pearson r | count | autorep | both |
+|---|---|---|---|---|---|---|
+| 1× fc=1.0 | 5 | 115 | N/A | FAIL | FAIL | – |
+| 10× fc=1.0 | 5 | 188 | -0.301 | FAIL | PASS | – |
+| 15× fc=1.0 | 5 | 247 | -0.533 | FAIL | PASS | – |
+| 20× fc=1.0 | 5 | 296 | -0.253 | FAIL | FAIL | – |
+| **20× fc=0.7** | **2** | **707** | **-0.521** | **PASS** | **PASS** | **✓✓** |
+| 20× fc=0.5 | 2 | 933 | -0.395 | FAIL (high) | PASS | – |
+| 20× fc=0.3 | 2 | 401 | +0.168 | PASS | FAIL | – |
+| 50× fc=1.0 | 5 | 497 | +0.613 | PASS | FAIL | – |
+
+**Phase 2 validation launched** (~13 min):
+- TE=20×, fc=0.7 seeds 2,3,4 (top up to 5 seeds at the sweet spot)
+- TE=20×, fc∈{0.6, 0.8} seeds 0,1,2 (probe adjacent points)
+
+If 5-seed (20×, 0.7) holds, this becomes the recommended permanent
+v2ecoli calibration: add a TE multiplier of ×20 to
+translation_efficiencies_adjustments.tsv AND a one-line patch to
+ParCa's promoter_fitting.py (or a runtime config) that scales
+deltaV[deltaJ==12] by 0.7.
+
+### Step 8 — Phase-2 validation: ★ (TE=20×, fc=0.7) holds at 5 seeds (06:10–06:30)
+
+Validation sweep completed: 5 seeds at fc=0.7, 3 seeds each at fc∈{0.6, 0.8}.
+
+**Full joint-sweep aggregate after 29 fc-tagged sims**:
+
+| key (TE × fc) | seeds | DnaA med | Pearson r | count | autorep | both |
+|---|---|---|---|---|---|---|
+| 1×  fc=1.0 | 5 | 115 | N/A | FAIL | FAIL | – |
+| 5×  fc=1.0 | 3 | 129 | N/A | FAIL | FAIL | – |
+| 10× fc=1.0 | 5 | 188 | -0.301 | FAIL | PASS | – |
+| 15× fc=1.0 | 5 | 247 | -0.533 | FAIL | PASS | – |
+| 20× fc=1.0 | 5 | 296 | -0.253 | FAIL | FAIL | – |
+| 25× fc=1.0 | 5 | 263 | +0.780 | FAIL | FAIL | – |
+| 30× fc=1.0 | 5 | 159 | +0.186 | FAIL | FAIL | – |
+| 50× fc=1.0 | 5 | 497 | +0.613 | PASS | FAIL | – |
+| 100× fc=1.0 | 3 | 108 | -0.093 | FAIL | FAIL | – |
+| 20× fc=0.3 | 2 | 401 | +0.168 | PASS | FAIL | – |
+| 30× fc=0.3 | 2 | 737 | -0.201 | PASS | FAIL | – |
+| 20× fc=0.5 | 2 | 933 | -0.395 | FAIL (high) | PASS | – |
+| 20× fc=0.6 | 3 | 699 | +0.218 | PASS | FAIL | – |
+| **20× fc=0.7** | **5** | **707** | **-0.521** | **PASS** | **PASS** | **✓✓** |
+| **20× fc=0.8** | **3** | **707** | **-0.392** | **PASS** | **PASS** | **✓✓** |
+| 20× fc=2.0 | 2 | 365 | N/A | PASS | FAIL | – |
+
+**Insight #11 — there is a robust working region around (TE=20×, fc=0.7–0.8)**:
+
+- 5-seed (TE=20×, fc=0.7) gives identical median DnaA (707) to the 2-seed pilot — variance is small.
+- Pearson r holds at -0.521, well below the -0.3 threshold.
+- (TE=20×, fc=0.8) also passes both, suggesting the working region extends from 0.7–0.8 in fc.
+- fc=0.6 swings BACK to failure on autorepression (Pearson r flips positive). Looking at it: DnaA=699 (in band), but the per-bound-DnaA suppression is now too weak to maintain negative correlation. The window for fc is narrow: ~0.7±0.05.
+
+**Recommendation**: Adopt (TE=20×, fc=0.7) as the v2ecoli baseline
+calibration. Implementation requires two changes:
+
+(a) `v2ecoli/processes/parca/reconstruction/ecoli/flat/adjustments/translation_efficiencies_adjustments.tsv`:
+```
+"PD03831[c]"	20	"fit_sim_data_1.py"	"dnaA, master regulator; ribosome profiling underestimates per Schmidt 2016 mass-spec"
+```
+
+(b) `v2ecoli/processes/parca/promoter_fitting.py` (or a new adjustments
+file): scale `delta_prob.deltaV[deltaJ==12]` by 0.7 during ParCa's
+cache build. Alternatively, leave as a runtime patch in `baseline.py`
+similar to the runtime TE patch — but ParCa-baked is more permanent.
+
+After these two changes, every dnaa-01 baseline sim will pass both
+gate tests by default, dnaa-02 unblocks cleanly, and the downstream
+studies inherit a correctly-calibrated baseline.
+
+
+
+

--- a/scripts/clone_investigation.py
+++ b/scripts/clone_investigation.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""Clone an investigation into a fresh planning state.
+
+Copies an investigation directory and its constituent studies, renaming
+them via a prefix swap, and strips simulation results (run logs, dbs,
+charts, sims, tests) so the clone is the shape the dashboard would show
+*before* any runs.
+
+Designed as both a CLI and an importable library so the dashboard's
+``POST /api/investigation-clone`` endpoint and any wrapper skill can call
+``clone_investigation(...)`` directly.
+
+Example
+-------
+    python scripts/clone_investigation.py \\
+        --source dnaa-replication \\
+        --target dnaa-replication-fresh \\
+        --source-root /path/to/source/workspace \\
+        --target-root /path/to/target/workspace
+
+If ``--source-root`` / ``--target-root`` are omitted, both default to the
+current working directory (single-workspace clone).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+from dataclasses import dataclass, field
+from datetime import date
+from pathlib import Path
+
+import yaml
+
+
+# Subdirectories/files inside a study directory that are simulation
+# OUTPUT (not planning input). These are dropped during clone.
+_STUDY_STRIP_DIR_NAMES = {
+    "sims",
+    "tests",
+    "charts",
+    "viz",
+    "data",
+    "__pycache__",
+}
+_STUDY_STRIP_FILE_NAMES = {
+    "runs.db",
+    "runs.db-shm",
+    "runs.db-wal",
+}
+_STUDY_STRIP_FILE_GLOBS = (
+    "run-*.html",
+    "*.log",
+)
+
+# Inside an investigation subdirectory (biology-feedback-*, overnight-*,
+# etc.) only these explicit planning docs are preserved. REPORT.md,
+# probe_*.py, *.json result files, *.html, *.sh, sweep logs are dropped.
+_INVEST_SUBDIR_KEEP_NAMES = {
+    "PLAN.md",
+    "ADDENDUM.md",
+    "FRICTION.md",
+    "PROGRESS.md",
+}
+
+
+def _today_iso() -> str:
+    return date.today().isoformat()
+
+
+def _remap_study_name(old: str, source_prefix: str, target_prefix: str) -> str:
+    """Replace leading ``source_prefix-`` with ``target_prefix-``; otherwise return as-is."""
+    if old.startswith(source_prefix + "-"):
+        return target_prefix + "-" + old[len(source_prefix) + 1 :]
+    return old
+
+
+def _copy_investigation_dir(src_dir: Path, dst_dir: Path) -> None:
+    """Copy investigation directory contents, keeping only planning material.
+
+    Top level: keep ``investigation.yaml`` and any ``*.md`` (STATUS.md etc.).
+    Subdirs:   keep only the four explicit planning docs in
+               ``_INVEST_SUBDIR_KEEP_NAMES``. Empty subdirs are removed.
+    """
+    dst_dir.mkdir(parents=True, exist_ok=True)
+    for entry in src_dir.iterdir():
+        if entry.is_file():
+            if entry.name == "investigation.yaml" or entry.suffix == ".md":
+                shutil.copy2(entry, dst_dir / entry.name)
+        elif entry.is_dir():
+            sub_dst = dst_dir / entry.name
+            sub_dst.mkdir(parents=True, exist_ok=True)
+            for sub in entry.iterdir():
+                if sub.is_file() and sub.name in _INVEST_SUBDIR_KEEP_NAMES:
+                    shutil.copy2(sub, sub_dst / sub.name)
+            if not any(sub_dst.iterdir()):
+                sub_dst.rmdir()
+
+
+def _copy_study_dir(src_dir: Path, dst_dir: Path) -> None:
+    """Copy a study directory, stripping result subdirs and files."""
+    dst_dir.mkdir(parents=True, exist_ok=True)
+    for entry in src_dir.iterdir():
+        if entry.name in _STUDY_STRIP_DIR_NAMES or entry.name in _STUDY_STRIP_FILE_NAMES:
+            continue
+        if any(entry.match(g) for g in _STUDY_STRIP_FILE_GLOBS):
+            continue
+        if entry.is_file():
+            shutil.copy2(entry, dst_dir / entry.name)
+        elif entry.is_dir():
+            shutil.copytree(entry, dst_dir / entry.name, dirs_exist_ok=True)
+
+
+def _reset_investigation_yaml(
+    src_path: Path,
+    dst_path: Path,
+    new_name: str,
+    study_remap: dict[str, str],
+) -> None:
+    data = yaml.safe_load(src_path.read_text())
+    data["name"] = new_name
+    data["created"] = _today_iso()
+    data["status"] = "planning"
+    data["studies"] = [study_remap.get(s, s) for s in data.get("studies", [])]
+    for crit in data.get("acceptance_criteria", []) or []:
+        if isinstance(crit, dict) and crit.get("study") in study_remap:
+            crit["study"] = study_remap[crit["study"]]
+    dst_path.write_text(yaml.safe_dump(data, sort_keys=False, width=120))
+
+
+def _reset_study_yaml(
+    src_path: Path,
+    dst_path: Path,
+    new_name: str,
+    study_remap: dict[str, str],
+) -> None:
+    data = yaml.safe_load(src_path.read_text())
+    data["name"] = new_name
+    data["created"] = _today_iso()
+    data["status"] = "planning"
+    data.pop("last_run", None)
+    if "phase" in data:
+        data["phase"] = "Design"
+
+    pg = data.get("pipeline_gate")
+    if isinstance(pg, dict):
+        pg["prerequisites"] = [study_remap.get(s, s) for s in pg.get("prerequisites", []) or []]
+        pg["enables"] = [study_remap.get(s, s) for s in pg.get("enables", []) or []]
+        pg["gate_status"] = "blocked"
+        pg["gate_status_summary"] = (
+            "Not yet started — investigation cloned in fresh planning state."
+        )
+
+    for parent in data.get("parent_studies", []) or []:
+        if isinstance(parent, dict) and parent.get("study") in study_remap:
+            parent["study"] = study_remap[parent["study"]]
+
+    for sim in data.get("simulation_set", []) or []:
+        if isinstance(sim, dict):
+            sim["status"] = "gated"
+
+    data.pop("runs", None)
+    data.pop("findings", None)
+    data.pop("conclusion", None)
+
+    verdicts = data.get("conclusion_verdicts")
+    if isinstance(verdicts, dict):
+        for cat in verdicts.values():
+            if isinstance(cat, dict):
+                cat["result"] = "PENDING"
+                cat["basis"] = "No runs yet — investigation cloned in fresh planning state."
+                cat.pop("contributing_tests", None)
+
+    for ed in data.get("expert_decisions_needed", []) or []:
+        if isinstance(ed, dict):
+            ed["status"] = "open"
+
+    tests = data.get("tests")
+    if isinstance(tests, dict):
+        tests["last_results"] = None
+
+    dst_path.write_text(yaml.safe_dump(data, sort_keys=False, width=120))
+
+
+@dataclass
+class CloneSummary:
+    source: str
+    target: str
+    studies_remapped: dict[str, str] = field(default_factory=dict)
+    paths_written: list[str] = field(default_factory=list)
+
+
+def clone_investigation(
+    source_name: str,
+    target_name: str,
+    source_root: Path,
+    target_root: Path,
+    source_prefix: str | None = None,
+    target_prefix: str | None = None,
+) -> CloneSummary:
+    """Clone ``source_name`` to ``target_name`` as a fresh planning copy.
+
+    Parameters
+    ----------
+    source_name, target_name:
+        Investigation names (directory names under ``investigations/``).
+    source_root, target_root:
+        Workspace roots. May be the same path.
+    source_prefix, target_prefix:
+        Prefix to swap on study names. Defaults to the first dash-segment
+        of the corresponding investigation name. Studies whose names do
+        not start with ``source_prefix-`` are treated as external
+        references and left untouched.
+    """
+    src_invest = source_root / "investigations" / source_name
+    dst_invest = target_root / "investigations" / target_name
+
+    if not src_invest.is_dir():
+        raise FileNotFoundError(f"source investigation not found: {src_invest}")
+    if dst_invest.exists():
+        raise FileExistsError(f"target investigation already exists: {dst_invest}")
+
+    invest_yaml = yaml.safe_load((src_invest / "investigation.yaml").read_text())
+
+    sp = source_prefix or source_name.split("-")[0]
+    tp = target_prefix or target_name.split("-")[0]
+
+    listed_studies = list(invest_yaml.get("studies") or [])
+    study_remap: dict[str, str] = {
+        s: _remap_study_name(s, sp, tp) for s in listed_studies if s.startswith(sp + "-")
+    }
+
+    summary = CloneSummary(
+        source=source_name,
+        target=target_name,
+        studies_remapped=study_remap,
+    )
+
+    _copy_investigation_dir(src_invest, dst_invest)
+    _reset_investigation_yaml(
+        src_invest / "investigation.yaml",
+        dst_invest / "investigation.yaml",
+        new_name=target_name,
+        study_remap=study_remap,
+    )
+    summary.paths_written.append(str(dst_invest))
+
+    for old_study, new_study in study_remap.items():
+        src_study_dir = source_root / "studies" / old_study
+        dst_study_dir = target_root / "studies" / new_study
+        if not src_study_dir.is_dir():
+            print(f"warning: source study missing, skipping: {src_study_dir}", file=sys.stderr)
+            continue
+        if dst_study_dir.exists():
+            raise FileExistsError(f"target study already exists: {dst_study_dir}")
+        _copy_study_dir(src_study_dir, dst_study_dir)
+        study_yaml_dst = dst_study_dir / "study.yaml"
+        if study_yaml_dst.exists():
+            _reset_study_yaml(
+                src_study_dir / "study.yaml",
+                study_yaml_dst,
+                new_name=new_study,
+                study_remap=study_remap,
+            )
+        summary.paths_written.append(str(dst_study_dir))
+
+    return summary
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.split("\n\n", 1)[0])
+    parser.add_argument("--source", required=True, help="Source investigation name")
+    parser.add_argument("--target", required=True, help="Target investigation name")
+    parser.add_argument(
+        "--source-root", type=Path, default=Path.cwd(),
+        help="Workspace root containing the source (default: cwd)",
+    )
+    parser.add_argument(
+        "--target-root", type=Path, default=Path.cwd(),
+        help="Workspace root for the target (default: cwd)",
+    )
+    parser.add_argument(
+        "--source-prefix", default=None,
+        help="Study-name prefix to strip (default: first dash-segment of --source)",
+    )
+    parser.add_argument(
+        "--target-prefix", default=None,
+        help="Study-name prefix to apply (default: first dash-segment of --target)",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON summary on stdout")
+    args = parser.parse_args(argv)
+
+    try:
+        summary = clone_investigation(
+            source_name=args.source,
+            target_name=args.target,
+            source_root=args.source_root.resolve(),
+            target_root=args.target_root.resolve(),
+            source_prefix=args.source_prefix,
+            target_prefix=args.target_prefix,
+        )
+    except (FileNotFoundError, FileExistsError) as exc:
+        print(f"clone failed: {exc}", file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(json.dumps({
+            "source": summary.source,
+            "target": summary.target,
+            "studies_remapped": summary.studies_remapped,
+            "paths_written": summary.paths_written,
+        }, indent=2))
+    else:
+        print(f"cloned investigation {summary.source!r} -> {summary.target!r}")
+        for old, new in summary.studies_remapped.items():
+            print(f"  study  {old}  ->  {new}")
+        print(f"  {len(summary.paths_written)} paths written under {args.target_root}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/studies/dnaa-fresh-01-expression-dynamics/study.yaml
+++ b/studies/dnaa-fresh-01-expression-dynamics/study.yaml
@@ -1,0 +1,907 @@
+schema_version: 3
+name: dnaa-fresh-01-expression-dynamics
+created: '2026-05-17'
+status: planning
+phase: Design
+baseline:
+- name: baseline-steady-state
+  composite: v2ecoli.composites.baseline.baseline
+  params:
+    seed: 0
+    cache_dir: out/cache
+purpose:
+  question: 'Does the v2ecoli baseline produce a steady, realistic DnaA pool with
+
+    working autorepression at the dnaA promoter?
+
+    '
+  mechanism: "Uses the EXISTING v2ecoli transcript_initiation + tf_binding chain\ndriven by the dnaA \u2192 EG10235_RNA fold\
+    \ change. No new processes added\nin this study \u2014 it certifies the layer-1 (total-pool) baseline that\ndownstream\
+    \ studies build on.\n"
+  expected_outcome: 'Steady DnaA monomer count within an order of magnitude of the
+
+    Sekimizu / Schmidt / Mori mass-spec value (300-800/cell, target band);
+
+    concentration coefficient-of-variation < 10% over the second half
+
+    of one doubling time; bound DnaA at promoters anti-correlated with
+
+    dnaA tx-init events.
+
+    '
+pipeline_gate:
+  prerequisites: []
+  enables:
+  - dnaa-fresh-02-atp-hydrolysis
+  - dnaa-fresh-03-box-binding
+  gate_status: blocked
+  gate_status_summary: "Not yet started \u2014 investigation cloned in fresh planning state."
+  proceed_condition: 'All primary tests pass; the supporting autorepression-correlation
+
+    test passes; calibration discrepancies (if any) are annotated and
+
+    expert-reviewed.
+
+    '
+  blocks_until_resolved: "If the DnaA-count primary test fails because v2ecoli's simulated\ncount is far outside the literature\
+    \ band, downstream studies should\nNOT start \u2014 dnaa-02's hydrolysis rates etc. are tuned against a\nrealistic baseline\
+    \ pool. Resolution choices: (a) recalibrate\ntranslation_efficiency for dnaA, (b) widen the test band with\nexpert sign-off,\
+    \ (c) reinterpret the test concept (free pool vs\ntotal).\n"
+simulation_set:
+- name: baseline-steady-state
+  base_model: v2ecoli.composites.baseline.baseline
+  perturbation: null
+  condition: M9-minimal-glucose
+  duration_min: 60
+  seeds:
+  - 0
+  - 1
+  - 2
+  - 3
+  - 4
+  readouts:
+  - dnaA_protein_count
+  - dnaA_mrna_count
+  - dnaA_tx_init_events
+  - dnaA_bound_to_promoters
+  - dnaa_atp_complex_bulk
+  applies_tests:
+  - dnaA-count-in-range
+  - dnaA-concentration-stable
+  - autorepression-correlation
+  status: gated
+- name: stop-dnaA-synthesis
+  base_model: v2ecoli.composites.baseline.baseline
+  perturbation:
+    translation_efficiency_override:
+      EG10235: 0.0
+  condition: M9-minimal-glucose
+  duration_min: 60
+  seeds:
+  - 0
+  - 1
+  - 2
+  readouts:
+  - dnaA_protein_count
+  applies_tests:
+  - stop-synthesis-30pct-drop
+  - stop-synthesis-monotonic
+  status: gated
+  blocked_by_requirements:
+  - req-2-translation-override-hook
+- name: gene-dosage-distal-promoter
+  base_model: v2ecoli.composites.baseline.baseline
+  perturbation:
+    dnaA_locus_relative_to_oric: 0.5
+  condition: M9-minimal-glucose
+  duration_min: 120
+  seeds:
+  - 0
+  - 1
+  - 2
+  - 3
+  - 4
+  - 5
+  readouts:
+  - dnaA_tx_init_events
+  - dnaA_protein_count
+  applies_tests:
+  - post-initiation-tx-spike
+  status: gated
+  blocked_by_requirements:
+  - req-4-locus-relocation
+  - req-5-initiation-event-detector
+- name: autorepression-strength-sweep
+  base_model: v2ecoli.composites.baseline.baseline
+  perturbation:
+    dnaap_autorepression_multiplier:
+    - 0.1
+    - 1.0
+    - 3.0
+  condition: M9-minimal-glucose
+  duration_min: 60
+  seeds:
+  - 0
+  - 1
+  - 2
+  readouts:
+  - dnaA_protein_count
+  - dnaA_bound_to_promoters
+  applies_tests: []
+  status: gated
+  blocked_by_requirements:
+  - req-3-autorepression-multiplier
+model_change:
+  base_model: v2ecoli.composites.baseline.baseline
+  new_processes: []
+  new_state_variables: []
+  new_parameters: []
+  modified_processes: []
+  new_listeners:
+  - name: DnaaConcentrationListener
+    emits:
+    - agents.<id>.listeners.dnaa.protein_uM
+    - agents.<id>.listeners.dnaa.mrna_uM
+    status: optional
+    requirement_id: req-1-concentration-listener
+  notes: 'All identifiers and listeners used here ALREADY exist in v2ecoli''s
+
+    baseline composite (verified 2026-05-16; see investigation
+
+    walkthrough notes). This study is a no-code-change certification.
+
+    '
+key_assumptions:
+- Steady-state slow growth (M9-glucose, doubling time ~60 min).
+- Total DnaA pool is the right concept for this study; ATP/ADP/apo split is dnaa-02's job.
+- "Autorepression at dnaAp goes through tf_binding's existing dnaA\u2192EG10235_RNA fold change."
+- Cell-birth-to-division covers one doubling; pre-existing v2ecoli initial state seeds 124 DnaA monomers.
+readouts:
+- name: dnaA_protein_count
+  description: "Aggregate DnaA monomer count via monomer_counts_listener\n(re-aggregates bulk + complexation_stoich; \u2248\
+    \ total DnaA in\nthe cell). Index 3861 in monomer_ids = \"PD03831[c]\" = DnaA\n(467 aa, matches Schmidt 2016 protein length).\n"
+  store_path: agents.0.listeners.monomer_counts.monomerCounts
+  index_by:
+    type: monomer_id
+    value: PD03831[c]
+  units: molecules/cell
+  status: available
+- name: dnaA_mrna_count
+  description: 'Aggregate dnaA mRNA count via RNA_counts_listener.
+
+    EG10235_RNA is the transcript ID; idx = mRNA_TU_ids.index("EG10235_RNA").
+
+    '
+  store_path: agents.0.listeners.rna_counts.mRNA_counts
+  index_by:
+    type: rna_id
+    value: EG10235_RNA
+  units: molecules/cell
+  status: available
+- name: dnaA_tx_init_events
+  description: 'Per-step transcription-initiation events on EG10235_RNA from
+
+    rnap_data listener. Sums to the total init events when reduced.
+
+    '
+  store_path: agents.0.listeners.rnap_data.rna_init_event
+  index_by:
+    type: tu_id
+    value: EG10235_RNA
+  units: events/step
+  status: available
+- name: dnaA_bound_to_promoters
+  description: "DnaA molecules currently bound at promoters, via\nrna_synth_prob.n_bound_TF_per_TU (n_TU \xD7 n_TF matrix);\
+    \ sum over TUs\nalong the DnaA-TF axis. Coarse autorepression proxy \u2014 broader than\njust dnaAp.\n"
+  store_path: agents.0.listeners.rna_synth_prob.n_bound_TF_per_TU
+  index_by:
+    type: tf_axis_id
+    value: PD03831[c]
+  units: molecules
+  status: derived-needed
+  blocked_by_requirements:
+  - req-6-tf-axis-aggregation
+- name: dnaa_atp_complex_bulk
+  description: 'Bulk count of MONOMER0-160[c] (the DnaA-ATP complex form in
+
+    molecule_ids.py). Currently populated to ~100 at end of single
+
+    cell sim. Will become a primary readout in dnaa-02 once the
+
+    nucleotide-state split is in place.
+
+    '
+  store_path: agents.0.bulk
+  index_by:
+    type: bulk_id
+    value: MONOMER0-160[c]
+  units: molecules/cell
+  status: available
+- name: dnaA_protein_concentration
+  description: "Volume-normalised DnaA in uM. Requires the DnaaConcentrationListener\nStep (req-1) \u2014 without it, the\
+    \ test falls back to count-based CV.\n"
+  store_path: agents.0.listeners.dnaa.protein_uM
+  units: uM
+  status: derived-needed
+  blocked_by_requirements:
+  - req-1-concentration-listener
+behavior_tests:
+- name: dnaA-count-in-range
+  classification: primary
+  target_class: biological_validation
+  measurement_mapping:
+    literature_observable:
+      name: total cellular DnaA per cell
+      biological_pool: total
+      condition: M9 + glucose, exponential growth, doubling ~30 min
+      statistic: median across population
+      source_ids:
+      - Schmidt2016NatBiotechnol
+      - Sekimizu1991JBacteriol
+      - Mori2021MolSysBiol
+      - Liu2020NatMicrobiol
+    model_observable:
+      listener_path: listeners.monomer_counts
+      state_path: bulk[PD03831[c]] + bulk[MONOMER0-160[c]] + bulk[MONOMER0-4565[c]]
+      molecular_pool: total
+      units: molecules/cell
+      includes_bound_species: false
+    transformation:
+      formula: median(sum_three_forms over t in [duration/2, duration])
+      time_window: second_half
+      aggregation: median across seeds
+    caveats:
+    - v2ecoli does not yet sum chromosomally DNA-bound DnaA into monomer_counts[3861]. If Schmidt 2016 mass-spec includes
+      that fraction, the model count understates by an unknown amount (literature suggests ~10-30% during S phase).
+    - "Schmidt 2016 mass-spec excludes DnaA bound during fixation washouts \u2014 extraction efficiency uncertain."
+    - "Sekimizu 1991 used radioactive label decay (DnaA half-life proxy) \u2014 assumes no replisome-bound subpopulation."
+  failure_cause_candidates:
+  - observable_mismatch
+  - miscalibration
+  requires_perturbations:
+  - dnaA-overexpression
+  - dnaA-knockdown
+  - autorepression-ablation
+  description: 'Median DnaA monomer count over the second half of the run lies
+
+    within the literature band [300, 800] reported by Sekimizu 1991,
+
+    Schmidt 2016, Mori 2021, and Liu 2020.
+
+    '
+  measure:
+    kind: monomer_count
+    id: PD03831[c]
+    reduce: median
+    window: second_half
+  pass_if:
+    op: in_range
+    low: 300
+    high: 800
+  units: molecules/cell
+  requires_simulation: baseline-steady-state
+  calibration_anchor:
+    v2ecoli_observed: 115
+    literature_target: 550
+    divergence_alarm_factor: 10
+    divergence_observed: 4.8
+    notes: "Two-stage finding from the 2026-05-16 walkthrough:\n\nSTAGE 1 \u2014 Infrastructure bug (discovered + fixed):\n\
+      First 10-min run emitted monomer_counts[DnaA] = 51,781 (and ALL top\nmonomers in the tens-of-millions). Root cause:\
+      \ the\nmonomer_counts_listener's output type was declared as a plain\n`array[N,integer]` without an `overwrite[]` wrapper,\
+      \ so each timestep\nADDED to the previous value instead of replacing it. Fixed by\nwrapping the output type. Re-run\
+      \ gave physiological values.\n(Sibling listeners rna_synth_prob / replication_data have the same\npattern and likely\
+      \ the same bug \u2014 flagged for follow-up.)\n\nSTAGE 2 \u2014 Real calibration finding:\nWith the bug fixed, v2ecoli\
+      \ emits a stable median DnaA = 115 per\ncell over the second-half window. Literature target is [300, 800]\n(Sekimizu\
+      \ / Schmidt / Mori / Liu). So v2ecoli is ~5\xD7 too LOW, not\n300\xD7 too high. This is a tractable calibration question,\
+      \ not a\nconcept mismatch. Likely causes \u2014 to evaluate with expert:\n  (a) translation_efficiency for EG10235 is\
+      \ set too low in\n      ParCa-cache for slow-growth media;\n  (b) DnaA half-life / degradation rate is too short;\n\
+      \  (c) The literature numbers include chromosome-bound DnaA (DnaA\n      boxes, replisome) which v2ecoli stores in `unique`\
+      \ and would\n      need to be summed back in \u2014 but the listener already accounts\n      for unique-molecule subunit\
+      \ contributions, so this is unlikely\n      to explain a 5\xD7 gap.\nRecommend re-checking ParCa's translation_efficiency\
+      \ for EG10235\nbefore kicking off dnaa-02.\n"
+  cites:
+  - Sekimizu1991JBacteriol
+  - Schmidt2016NatBiotechnol
+  - Mori2021MolSysBiol
+  - Liu2020NatMicrobiol
+  - Boesen2024PNAS
+- name: dnaA-concentration-stable
+  classification: primary
+  description: "DnaA count (proxy for concentration when uM listener unavailable)\nhas rolling 5-step CV \u2264 10% over the\
+    \ second half. Confirms the\nhomeostatic loop reached steady state.\n"
+  measure:
+    kind: monomer_count
+    id: PD03831[c]
+    reduce: series
+    window: second_half
+  pass_if:
+    op: rolling_cv_at_most
+    window_steps: 5
+    threshold: 0.1
+  units: fraction
+  requires_simulation: baseline-steady-state
+  cites:
+  - Hansen2018DnaATale
+  - Hansen1999JBacteriol
+  - Hansen2021FrontMolBiosci
+- name: autorepression-correlation
+  classification: supporting
+  target_class: regression_compatibility
+  measurement_mapping:
+    literature_observable:
+      name: dnaA autorepression strength
+      biological_pool: ATP_bound
+      condition: M9 + glucose, exponential growth
+      statistic: negative correlation between bound-DnaA and dnaA transcription rate
+      source_ids:
+      - Speck1999EMBO
+      - Saggioro2013BiochemJ
+      - Katayama2017Frontiers
+      - Hansen2018DnaATale
+    model_observable:
+      listener_path: listeners.rna_synth_prob.n_bound_TF_per_TU + listeners.rna_counts.mRNA_cistron_counts
+      state_path: sum(n_bound_TF_per_TU[:, 12]) at t  vs  mRNA_cistron_counts[227] at t
+      molecular_pool: ATP_bound
+      units: dimensionless (Pearson r)
+      includes_bound_species: true
+    transformation:
+      formula: pooled_pearson_r(x=sum_binding_col_12, y=mRNA_cistron_227, samples=second_half_across_5_seeds)
+      time_window: second_half
+      aggregation: pooled across seeds
+    caveats:
+    - Pearson r is symmetric in time \u2014 does NOT discriminate causation from co-incidence.
+    - Same-time correlation misses transcription-binding lag (~30-120s in vivo).
+    - Cell-wide init events (rna_init_event sum) was the original Y axis; switched to mRNA_cistron_counts[227] because dnaA
+      init events are too sparse (~0/step in 10-min window).
+    - A PASS here is necessary but not sufficient for autorepression validation \u2014 see autorepression_test_suite.
+  description: 'When DnaA bound-to-promoters is high, cell-wide transcription init
+
+    events should bias down \u2014 autorepression signature. Coarse first-pass
+
+    test: Pearson r \u2264 -0.3 across the second-half window.
+
+
+    X axis: DnaA-specific TF binding (sum over TUs in column 12 of
+
+    listeners.rna_synth_prob.n_bound_TF_per_TU; idx 12 = MONOMER0-160
+
+    = DnaA-ATP in tf_binding.tf_ids).
+
+
+    Y axis: cell-wide transcription init events. Note this is a coarse
+
+    proxy \u2014 true autorepression targets the dnaA promoter (EG10235_RNA
+
+    TU) specifically. Refining Y to slice on EG10235_RNA''s TU index
+
+    needs a sim_data lookup not currently available to the evaluator.
+
+    '
+  measure:
+    kind: xy_correlation
+    x:
+      kind: tf_axis_sum
+      path: listeners.rna_synth_prob.n_bound_TF_per_TU
+      tf_index: 12
+    y:
+      kind: listener_index
+      path: listeners.rna_counts.mRNA_cistron_counts
+      index: 227
+    window: second_half
+  pass_if:
+    op: pearson_at_most
+    threshold: -0.3
+  units: dimensionless r
+  requires_simulation: baseline-steady-state
+  prerequisites:
+  - run with --heavy_tf_listener so n_bound_TF_per_TU is populated
+  cites:
+  - Speck1999EMBO
+  - Saggioro2013BiochemJ
+  - Katayama2017Frontiers
+- name: stop-synthesis-30pct-drop
+  classification: diagnostic
+  description: "With translation_efficiency[EG10235] = 0, DnaA count at end of\none doubling time \u2264 70% of initial count.\
+    \ Confirms the dilution\n+ turnover balance.\n"
+  measure:
+    kind: monomer_count
+    id: PD03831[c]
+    reduce: first_and_last
+    window: full
+  pass_if:
+    op: ratio_at_most
+    ratio: 0.7
+  units: ratio (last/first)
+  requires_simulation: stop-dnaA-synthesis
+  cites:
+  - Li2014Cell
+  - Hansen1999JBacteriol
+- name: stop-synthesis-monotonic
+  classification: diagnostic
+  description: "Stop-synthesis run shows monotonic DnaA decrease (allow \u22645% rebound\nfor noise). Confirms there's no\
+    \ compensatory production mechanism.\n"
+  measure:
+    kind: monomer_count
+    id: PD03831[c]
+    reduce: series
+    window: full
+  pass_if:
+    op: monotonic_decreasing
+    allow_rebound_pct: 5
+  units: monotonic check
+  requires_simulation: stop-dnaA-synthesis
+- name: post-initiation-tx-spike
+  classification: diagnostic
+  description: "Within 10 min after replication-initiation, dnaA transcription rate\nrises \u226550% (gene-dosage effect when\
+    \ EG10235 is duplicated).\n"
+  measure:
+    kind: listener_sum
+    path: listeners.rnap_data.rna_init_event
+    reduce: pre_post_event_ratio
+    window: post_initiation_10min
+  pass_if:
+    op: ratio_at_least
+    ratio: 1.5
+  units: ratio (post/pre)
+  requires_simulation: gene-dosage-distal-promoter
+  blocked_by_requirements:
+  - req-5-initiation-event-detector
+  cites:
+  - Speck1999EMBO
+  - Hansen2018DnaATale
+autorepression_test_suite:
+- name: lagged_binding_mrna_cross_correlation
+  kind: lagged_binding_mrna_cross_correlation
+  description: "Cross-correlation between DnaA-TF binding(t-\u0394t) and dnaA mRNA(t) at\n\u0394t \u2208 {0, 30, 60, 120}s.\
+    \ Biologically valid autorepression should show\na NEGATIVE peak at \u0394t \u2248 30-90s (transcription-binding response\
+    \ delay).\n"
+  measure:
+    kind: cross_correlation
+    x_signal: sum(listeners.rna_synth_prob.n_bound_TF_per_TU[:, 12])
+    y_signal: listeners.rna_counts.mRNA_cistron_counts[227]
+    lags_s:
+    - 0
+    - 30
+    - 60
+    - 120
+  pass_if:
+    op: negative_peak_at_lag_within
+    lag_range_s:
+    - 30
+    - 120
+    min_magnitude: 0.3
+  status: not_implemented_yet
+- name: conditional_transcription_probability_given_promoter_bound
+  kind: conditional_transcription_probability_given_promoter_bound
+  description: 'P(rna_init_event[EG10235] = 1 | dnaAp promoter bound) vs
+
+    P(rna_init_event[EG10235] = 1 | dnaAp promoter unbound).
+
+    Ratio < 1.0 = autorepression active.
+
+    '
+  measure:
+    kind: conditional_probability_ratio
+    condition_on: listeners.rna_synth_prob.n_bound_TF_per_TU[dnaAp_TUs, 12] > 0
+    event: listeners.rnap_data.rna_init_event[EG10235_TUs] > 0
+  pass_if:
+    op: less_than
+    value: 1.0
+  status: not_implemented_yet
+  requires_data: "dnaAp_TUs index list \u2014 currently unresolved (P3 expert question)"
+- name: transcription_burst_rate_by_promoter_state
+  kind: transcription_burst_rate_by_promoter_state
+  description: 'Burst rate when bound vs unbound, computed via inter-event interval
+
+    distribution. Bound state should have longer inter-event intervals.
+
+    '
+  status: not_implemented_yet
+- name: dnaA_gene_dosage_corrected_expression
+  kind: dnaA_gene_dosage_corrected_expression
+  description: 'Correct for gene dosage (chromosomal-locus replication doubles dnaA
+
+    gene copies mid-cycle). Per-copy expression should drop when DnaA
+
+    is high. Without this correction, dosage swamps the autorepression
+
+    signal.
+
+    '
+  status: not_implemented_yet
+  requires_data: per-cell-cycle replication-fork position relative to dnaA locus
+perturbation_panel:
+- name: dnaA-overexpression
+  kind: expression_step
+  description: "Double dnaA TE at t=300s of a 600s sim. Expected: dnaA mRNA drops\nwithin 60s (autorepression kicks in), DnaA-ATP\
+    \ steady-state rises\n<1.5\xD7 (not 2\xD7 \u2014 autorepression attenuates).\n"
+  expected_response:
+    metric: change in mRNA[EG10235] within 60s of perturbation
+    direction: decrease
+    magnitude_estimate: ~30-50%
+  status: not_run
+- name: dnaA-knockdown
+  kind: expression_step
+  description: 'Halve dnaA TE at t=300s. Expected: dnaAp promoter de-repression
+
+    within 60s (mRNA bursts higher), eventual recovery toward new lower
+
+    steady state.
+
+    '
+  expected_response:
+    metric: change in mRNA[EG10235] within 60s
+    direction: increase
+  status: not_run
+- name: autorepression-ablation
+  kind: parameter_swap
+  description: "Set fc multiplier = 0 (zero out delta_prob.deltaV[:, 12] entries).\nExpected: uncontrolled DnaA accumulation;\
+    \ CV of DnaA count grows\nover time; cell loses homeostatic regulation. This is the \"what would\nchange my mind\" control\
+    \ \u2014 if DnaA pool stays stable WITHOUT\nautorepression, the autorepression-tests above are testing the wrong\nthing.\n"
+  expected_response:
+    metric: rolling CV of DnaA count over 10 min
+    direction: increase
+    magnitude_estimate: '> 0.5 (vs <0.01 baseline)'
+  status: not_run
+- name: ATP-cycle-ablation
+  kind: pathway_swap
+  description: "Disable the IntrinsicHydrolysis Step. Expected: DnaA-ATP fraction\n\u2192 1.0 (no sink for the ATP form).\
+    \ Confirms F-04 of dnaa-02 in the\nreverse direction.\n"
+  expected_response:
+    metric: median DnaA-ATP / total over second half
+    direction: increase
+    target_value: 1.0
+  status: not_run
+- name: titration-site-removal
+  kind: site_mutation
+  description: "Remove the ~445 non-oriC chromosomal DnaA-boxes (P2-1 dependent \u2014\nrequires DnaA_box catalog with region_type\
+    \ attribute). Expected:\noriC saturates earlier (smaller titration buffer), initiation\ntiming shifts earlier in the cell\
+    \ cycle.\n"
+  expected_response:
+    metric: inter-initiation interval (when initiation mechanism is wired in dnaa-04)
+    direction: decrease
+  status: blocked_until_dnaa_03_box_catalog
+mechanism_cards: []
+abstraction_level:
+  name: lumped total-DnaA pool, quasi-steady-state
+  resolves:
+  - total DnaA homeostasis (CV)
+  - autorepression as a same-time correlation signal
+  - "TE \u2192 pool-size calibration sensitivity"
+  does_not_resolve:
+  - "per-form (apo / ATP / ADP) dynamics \u2014 that is dnaa-02"
+  - "spatial DnaA distribution (oriC vs chromosomal binding) \u2014 that is dnaa-03"
+  - "cell-cycle initiation timing \u2014 that is dnaa-04"
+  - "RIDA / DDAH / DARS reset dynamics \u2014 that is dnaa-05"
+  - "SeqA sequestration window \u2014 that is dnaa-06"
+conclusion_verdicts:
+  regression_compatibility:
+    result: PENDING
+    basis: "No runs yet \u2014 investigation cloned in fresh planning state."
+    caveat: The recipe parameters are model_implied (fits, not measured biology).
+  biological_validation:
+    result: PENDING
+    basis: "No runs yet \u2014 investigation cloned in fresh planning state."
+    blocking_evidence_needed:
+    - perturbation_panel runs (dnaA-overexpression, dnaA-knockdown, autorepression-ablation, ATP-cycle-ablation, titration-site-removal)
+    - autorepression_test_suite runs (4 tests beyond Pearson r)
+    - 'measurement_mapping resolution: does Schmidt 2016 mass-spec include DNA-bound DnaA?'
+  explanatory_gain:
+    result: PENDING
+    basis: "No runs yet \u2014 investigation cloned in fresh planning state."
+expert_decisions_needed:
+- id: dnaa-01-EQ-01
+  question: Does the Schmidt 2016 mass-spec 300-800 cellular DnaA per cell INCLUDE chromosomally-bound DnaA (i.e., DnaA bound
+    at oriC, dnaAp, datA, chromosomal titration sites), or is it the soluble cytoplasmic fraction only?
+  alternatives:
+  - "Total cellular (includes bound): then v2ecoli's 115 is a 4.8\xD7 shortfall regardless of binding"
+  - 'Soluble only: then v2ecoli (without dnaa-03 binding yet) reports the wrong pool; gap may shrink'
+  - 'Partial / extraction-protocol-dependent: bracket the uncertainty by including both bounds'
+  impact_if_wrong: "Mis-attribution of the 4.8\xD7 count gap. If \"soluble only\", a chunk of the gap is observable_mismatch\
+    \ (P2-4 failure_cause) rather than miscalibration. dnaa-01g recipe (TE=20\xD7, fc=0.7) may be over-correcting by a factor\
+    \ of 1.1-1.3."
+  blocks:
+  - dnaa-01 conclusion_verdicts.biological_validation
+  - dnaa-02 calibration target derivation
+  - dnaa-01g-parca-te-derivation-audit reference target
+  requested_response: One paragraph from a mass-spec expert citing the 2016 paper extraction-protocol section + DOI
+  status: open
+  asked_to: TBD
+- id: dnaa-01-EQ-02
+  question: What Hill cooperativity coefficient governs DnaA binding to its OWN promoter (dnaAp1 + dnaAp2)? Literature ranges
+    from n=1 (independent) to n=4 (strong cooperative).
+  alternatives:
+  - "n \u2264 2 (mild cooperativity): Pearson autorepression r should saturate at ~-0.5 to -0.7"
+  - 'n = 3-4 (strong cooperativity): r could reach -0.8 or below; current r=-0.594 PASS may be coincidental'
+  - "Per-promoter different: dnaAp1 n=1, dnaAp2 n>1 \u2014 needs the autorepression_test_suite's dnaAp1_response + dnaAp2_response\
+    \ tests to discriminate"
+  impact_if_wrong: "Sets the bar for \"PASS\" on autorepression-correlation. Currently we treat r \u2264 -0.3 as PASS; the\
+    \ right threshold depends on n."
+  blocks:
+  - dnaa-01 autorepression_test_suite calibration
+  requested_response: Literature recommendation + DOI; ideally a specific value or narrow range
+  status: open
+  asked_to: TBD
+- id: dnaa-01-EQ-03
+  question: Is the ParCa-cached translation_efficiency for dnaA (7.23e-5, 8.6th-percentile of proteome) biologically correct,
+    or an artifact of ribosome-profiling extraction conditions / cistron-vs-monomer indexing?
+  alternatives:
+  - "Correct: dnaA is genuinely translated at very low efficiency, and our 20\xD7 multiplier compensates for a real biological\
+    \ feature (?why?)"
+  - 'Artifact: ribosome profiling under-counts dnaA due to a methodological issue, and the multiplier reflects the correction'
+  - 'Indexing bug: ParCa uses the wrong column / cistron during the TE derivation'
+  impact_if_wrong: "Whether the TE=20\xD7 recipe is a band-aid (artifact) or a documented physiological setting (correct).\
+    \ Affects whether dnaa-01g-parca-te-derivation-audit is necessary."
+  blocks:
+  - dnaa-01g-parca-te-derivation-audit
+  - permanent promotion of TE multiplier to translation_efficiencies_adjustments.tsv
+  requested_response: ParCa author + ribosome-profiling reviewer; pointer to the EG10235 row in original Li 2014 / Schmidt
+    2016 data
+  status: open
+  asked_to: TBD
+conclusion_logic:
+  if_primary_tests_pass:
+    implementation_status: v2ecoli baseline is functional at the layer-1 (total DnaA pool) abstraction.
+    biological_validation: "v2ecoli reproduces a STABLE DnaA pool \u2014 does NOT validate that\nthe per-cell count matches\
+      \ mass-spec measurements. That's a\nseparate calibration pass (compare median(dnaA_protein_count)\nto Schmidt2016's\
+      \ reported absolute count).\n"
+    pipeline_unblocks:
+    - dnaa-02 (DnaA-ATP/ADP/apo nucleotide-state split) becomes safe to start.
+    - Calibration_anchor.v2ecoli_observed gets locked in as the baseline reference for dnaa-02.
+  if_primary_tests_fail:
+    diagnose:
+    - "If dnaA-count-in-range fails: check calibration_anchor.divergence_alarm_factor \u2014 likely concept mismatch (monomer_counts\
+      \ vs bulk vs complex form)."
+    - 'If dnaA-concentration-stable fails: check whether translation rate + dilution balance reached steady state in the time
+      window (try multi-generation).'
+    - 'If autorepression-correlation fails: tf_binding wiring may be broken or fold-change too weak.'
+    block_downstream: dnaa-02..06 should not start until primary failures are resolved.
+limitations:
+- Single doubling time; multi-generation drift not validated (see dnaa-04 mechanism for that).
+- Total DnaA pool only; no ATP/ADP/apo split (dnaa-02).
+- Slow non-overlapping growth on M9; rich-media + fast growth not validated here.
+- dnaAp-specific box-by-box occupancy NOT validated (dnaa-03 covers the box catalog).
+- "Absolute DnaA count vs literature is a calibration question, not a test outcome \u2014 see calibration_anchor on dnaA-count-in-range."
+- Coarse autorepression proxy sums TF binding across ALL DnaA TF targets, not just dnaAp.
+implementation_requirements:
+- id: req-1-concentration-listener
+  kind: listener
+  title: DnaaConcentrationListener Step
+  effort: S
+  description: 'A Step that reads bulk[PD03831[c]] + (mRNA count via rna_counts) +
+
+    cell_volume and emits at listeners.dnaa.{protein_uM, mrna_uM}.
+
+    Converts via Avogadro + volume.
+
+    '
+  steps:
+  - Create v2ecoli/steps/dnaa_concentration_listener.py.
+  - Wire into baseline composite layer after transcript / translation.
+  - 'Unit test: assert dnaA_protein_uM > 0 after one timestep.'
+  unblocks:
+  - readouts.dnaA_protein_concentration
+  - dnaA-concentration-stable test in uM units (preferred)
+- id: req-2-translation-override-hook
+  kind: parameter_hook
+  title: translation_efficiency_override composite parameter
+  effort: S
+  description: 'Composite-level param `translation_efficiency_override: dict[gene_id, float]`
+
+    that patches sim_data.process.translation.translation_efficiency
+
+    before instantiating polypeptide_initiation.
+
+    '
+  steps:
+  - Add param to v2ecoli/composites/baseline.py.
+  - In build_composite body, deepcopy sim_data and patch.
+  - 'Behavior test: variant stop-dnaA-synthesis drives DnaA to <30% over one doubling.'
+  unblocks:
+  - simulation_set.stop-dnaA-synthesis
+  - tests.stop-synthesis-30pct-drop
+  - tests.stop-synthesis-monotonic
+- id: req-3-autorepression-multiplier
+  kind: parameter_hook
+  title: dnaap_autorepression_multiplier composite parameter
+  effort: M
+  description: "Composite-level param that scales the dnaA \u2192 EG10235_RNA fold change\nby a multiplier. Either by patching\
+    \ fold_changes.tsv values in sim_data\nat composite-build time, or via an intercepting Step.\n"
+  steps:
+  - Locate fold_changes.tsv (dnaA, EG10235_RNA) row.
+  - Patch sim_data at build time.
+  - "Sanity: 0.1\xD7 \u2192 low DnaA; 3\xD7 \u2192 high DnaA."
+  unblocks:
+  - simulation_set.autorepression-strength-sweep
+- id: req-4-locus-relocation
+  kind: parameter_hook
+  title: dnaA_locus_relative_to_oric override
+  effort: L
+  description: 'Composite-level override of the EG10235 chromosomal coordinate.
+
+    Complex because chromosome_replication models gene-dosage by fork
+
+    position; needs care to keep replication mechanics consistent.
+
+    '
+  steps:
+  - Audit chromosome_replication.py for the gene-dosage tracking.
+  - Override sim_data.process.replication.gene_data['EG10235']['coordinate'].
+  - 'Validation: replication still terminates correctly.'
+  defer_until: dnaa-04 (which already touches replication mechanism)
+  unblocks:
+  - simulation_set.gene-dosage-distal-promoter
+- id: req-5-initiation-event-detector
+  kind: listener
+  title: replication_initiation_event listener
+  effort: M
+  description: 'A listener that emits a per-step boolean (or a timestamped event)
+
+    when chromosome_initiation fires. Used by tests that need to slice
+
+    a window around the event (e.g., post-initiation gene-dosage spike).
+
+    '
+  defer_until: dnaa-04 (initiation mechanism rebuild)
+  unblocks:
+  - tests.post-initiation-tx-spike
+- id: req-6-tf-axis-aggregation
+  kind: listener
+  title: TF-axis sum on n_bound_TF_per_TU
+  effort: XS
+  status: done
+  description: 'n_bound_TF_per_TU is (n_TU x n_TF). For dnaa-01''s autorepression
+
+    correlation we want a 1-D series: sum over TUs along the DnaA TF
+
+    axis. Implemented as the `tf_axis_sum` measure kind in
+
+    studies/dnaa-01-expression-dynamics/tests/_behaviors.py (2026-05-16).
+
+    Requires `emit_n_bound_TF_per_TU=True` on tf_binding, which the
+
+    runner opts into via `--heavy_tf_listener`.
+
+    '
+  steps:
+  - 'DONE: looked up DnaA''s TF axis index in tf_binding.tf_ids -> idx 12 (MONOMER0-160 = DnaA-ATP).'
+  - 'DONE: added tf_axis_sum measure kind to _behaviors.py.'
+  - 'DONE: updated autorepression-correlation test to use tf_axis_sum with tf_index: 12.'
+  unblocks:
+  - readouts.dnaA_bound_to_promoters
+  - tests.autorepression-correlation
+bibliography:
+  expert:
+  - replication_initiation_molecular_info
+  - chromosome_replication_plan
+  bib_keys:
+  - Boesen2024PNAS
+  - Hansen2018DnaATale
+  - Katayama2017Frontiers
+  - Speck1999EMBO
+  - Saggioro2013BiochemJ
+  - Sekimizu1991JBacteriol
+  - Schmidt2016NatBiotechnol
+  - Li2014Cell
+  - Mori2021MolSysBiol
+  - Liu2020NatMicrobiol
+  - Hansen1999JBacteriol
+  - Hansen2021FrontMolBiosci
+follow_up_studies:
+- title: Apply overwrite[] fix to sibling listeners (rna_synth_prob, replication_data)
+  kind: infrastructure_fix
+  effort: S
+  why: 'The monomer_counts_listener bug pattern (plain array[] output without
+
+    overwrite[] wrapper) likely exists in rna_synth_prob_listener and
+
+    replication_data_listener. This explains why n_bound_TF_per_TU stays
+
+    empty in the emit, which blocks autorepression-correlation here AND
+
+    dnaa-03''s DnaA-box-occupancy readouts.
+
+    '
+  unblocks:
+  - tests.autorepression-correlation in dnaa-01
+  - dnaa-03's box-occupancy readouts
+  acceptance:
+  - After fix, listeners.rna_synth_prob.n_bound_TF_per_TU is populated each tick
+  - After fix, listeners.replication_data.* fields update each tick
+- title: Recalibrate EG10235 translation_efficiency in ParCa
+  kind: calibration_task
+  effort: M
+  why: "With the listener bug fixed, v2ecoli's median DnaA pool is ~115/cell.\nLiterature (Sekimizu, Schmidt, Mori) reports\
+    \ 300-800. v2ecoli is ~5\xD7\ntoo low. Most likely cause: translation_efficiency for EG10235 in the\nParCa cache. Other\
+    \ candidates worth ruling out: DnaA degradation rate;\nwhether literature numbers include chromosome-bound DnaA that the\n\
+    listener might not be summing back in.\n"
+  unblocks:
+  - tests.dnaA-count-in-range in dnaa-01 (passing the gate)
+  - all of dnaa-02..06 (a realistic DnaA pool is the baseline they depend on)
+  acceptance:
+  - dnaa-01 re-run produces median DnaA in [300, 800]
+  - bulk[MONOMER0-160[c]] (DnaA-ATP) reaches the expected 200-500 free pool fraction
+- title: dnaa-02-atp-hydrolysis
+  kind: existing
+  status: blocked
+  why: "Pre-stated pipeline_gate.proceed_condition not met \u2014 primary test\ndnaA-count-in-range failed. dnaa-02 builds\
+    \ on the layer-1 (total\npool) baseline that dnaa-01 was meant to certify; starting it now\nwould tune nucleotide-state\
+    \ rates against an unrealistic pool size.\n"
+  unblocks_when: dnaa-01's calibration is resolved (above)
+- title: 'Expert question for the dashboard: which DnaA pool does the literature target match?'
+  kind: expert_question
+  effort: XS
+  why: 'Literature numbers [300, 800] may refer to: (a) free DnaA in cytosol,
+
+    (b) total cellular DnaA including bound, (c) DnaA-ATP form only.
+
+    Different choice changes which v2ecoli readout to compare. Worth
+
+    confirming before tuning translation_efficiency to the wrong target.
+
+    '
+  unblocks:
+  - The interpretation of dnaA-count-in-range
+  forward_to: replication_initiation_molecular_info expert
+- title: Investigate why tf_binding leaves n_bound_TF_per_TU empty
+  kind: infrastructure_fix
+  effort: M
+  status: done
+  why: 'Discovered while running follow-up #0 (listener overwrite[] sweep):
+
+    fixing the listener output schema did NOT populate
+
+    listeners.rna_synth_prob.n_bound_TF_per_TU.
+
+    '
+  hypothesized_mechanism: 'Three candidates; root cause was (a).
+
+    '
+  resolved: 'Hypothesis (a) confirmed: tf_binding''s config has a feature flag
+
+    `emit_n_bound_TF_per_TU` that defaults to False because the
+
+    (n_TU x n_TF) matrix is ~900KB/tick. Flipping the flag populates
+
+    the field. Implementation: studies/dnaa-01-expression-dynamics/
+
+    sims/run_baseline.py grew a --heavy_tf_listener arg that monkey-
+
+    patches the cached config before composite build. Confirmed in
+
+    the baseline-heavy-tf run (601 steps; shape (3277, 23)).
+
+    '
+  unblocks:
+  - tests.autorepression-correlation in dnaa-01 (the supporting primary test)
+  - readouts.dnaA_bound_to_promoters in dnaa-01
+  - dnaa-03's DnaA-box-occupancy readouts (n_bound_TF_per_TU is the source)
+  acceptance:
+  - 'DONE: listeners.rna_synth_prob.n_bound_TF_per_TU has shape (3277, 23) each tick after t=1.'
+  - 'DONE: autorepression-correlation now produces r=+0.197 (real result, not insufficient-variance).'
+- title: Investigate v2ecoli's lack of dnaA autorepression signature
+  kind: new
+  effort: L
+  status: open
+  why: "With tf_binding's heavy listener populated AND DnaA-specific TF-axis\nslicing in place (req-6, done), the autorepression-correlation\
+    \ test\nyields Pearson r = +0.197 \u2014 weak POSITIVE correlation, not the\nstrong negative predicted by literature (Speck\
+    \ 1999, Saggioro 2013).\nThis is a real biology gap, not an infrastructure issue.\n"
+  hypothesized_mechanism: "Three candidates, in priority order:\n(1) The Y axis is still too coarse \u2014 summing all 3277\
+    \ TU init events\n    instead of slicing to the dnaA promoter's TU index. dnaA init\n    events are a tiny fraction of\
+    \ cell-wide events, so cell-wide Y\n    is dominated by other transcription.\n(2) The autorepression model in v2ecoli\
+    \ (tf_binding's dnaA\u2192EG10235\n    fold change) may not be strong enough to register over the noise.\n(3) The 10-minute\
+    \ window may be too short \u2014 autorepression operates\n    on cell-cycle timescales (~60 min). Try multi-generation\
+    \ runs.\n"
+  unblocks:
+  - autorepression-correlation may flip PASS once Y is dnaA-specific
+  - Validates / falsifies v2ecoli's autorepression model
+  acceptance:
+  - Y axis sliced to dnaA TU index (needs sim_data mRNA_TU_ids lookup)
+  - "Re-evaluate; if still positive, escalate to expert review of fold_changes.tsv parameter for dnaA\u2192EG10235"
+parent_studies: []
+tests:
+  auto_discover: true
+  data_source: latest_run
+  pytest_args: []
+  last_results: null
+conclusions: ''

--- a/studies/dnaa-fresh-01f-apply-overwrite-fix-to-sibling-listeners-rna-synth-prob-repl/study.yaml
+++ b/studies/dnaa-fresh-01f-apply-overwrite-fix-to-sibling-listeners-rna-synth-prob-repl/study.yaml
@@ -1,0 +1,287 @@
+schema_version: 3
+name: dnaa-fresh-01f-apply-overwrite-fix-to-sibling-listeners-rna-synth-prob-repl
+created: '2026-05-17'
+status: planning
+phase: Design
+seeded_from:
+  parent: dnaa-01-expression-dynamics
+  followup_idx: 0
+  followup_title: Apply overwrite[] fix to sibling listeners (rna_synth_prob, replication_data)
+  kind: infrastructure_fix
+baseline:
+- name: baseline-postfix
+  composite: v2ecoli.composites.baseline.baseline
+  params:
+    seed: 0
+    cache_dir: out/cache
+purpose:
+  question: 'Does applying the overwrite[] wrapper fix to rna_synth_prob_listener
+
+    and replication_data_listener (the sibling listeners suspected to
+
+    share monomer_counts_listener''s accumulation bug) populate
+
+    n_bound_TF_per_TU and unblock dnaa-01''s autorepression-correlation
+
+    test?
+
+    '
+  mechanism: "Wrap every plain `array[\u2026]` output field in those listeners with\n`overwrite[array[\u2026]]` so per-tick\
+    \ emissions REPLACE the previous\nvalue instead of accumulating element-wise (the bigraph-schema\ndefault array merge\
+    \ combinator).\n"
+  expected_outcome: "Per parent's follow_up_studies[0].acceptance:\n  1. listeners.rna_synth_prob.n_bound_TF_per_TU is populated\
+    \ each tick.\n  2. listeners.replication_data.* fields update each tick.\nIf both hold, autorepression-correlation should\
+    \ compute a non-zero\nPearson r against listeners.rnap_data.rna_init_event.\n"
+pipeline_gate:
+  prerequisites:
+  - dnaa-fresh-01-expression-dynamics
+  enables:
+  - dnaa-fresh-01-expression-dynamics
+  gate_status: blocked
+  gate_status_summary: "Not yet started \u2014 investigation cloned in fresh planning state."
+  proceed_condition: 'All listener output fields stop accumulating; subsequent re-run of
+
+    dnaa-01 produces an updated outcome row for autorepression-correlation.
+
+    '
+simulation_set:
+- name: baseline-postfix
+  base_model: v2ecoli.composites.baseline.baseline
+  perturbation: null
+  condition: M9-minimal-glucose
+  duration_min: 10
+  seeds:
+  - 0
+  readouts:
+  - rna_init_event_per_step
+  - n_bound_TF_per_TU_length
+  - dnaA_monomer_count
+  applies_tests:
+  - listeners-stop-accumulating
+  - n_bound_TF_per_TU-populates
+  status: gated
+model_change:
+  base_model: v2ecoli.composites.baseline.baseline
+  scope: 7 listener files in v2ecoli/steps/listeners/
+  fields_wrapped: 43
+  files:
+  - v2ecoli/steps/listeners/monomer_counts.py
+  - v2ecoli/steps/listeners/rna_synth_prob.py
+  - v2ecoli/steps/listeners/replication_data.py
+  - v2ecoli/steps/listeners/rnap_data.py
+  - v2ecoli/steps/listeners/rna_counts.py
+  - v2ecoli/steps/listeners/ribosome_data.py
+  - v2ecoli/steps/listeners/mass_listener.py
+  - v2ecoli/steps/listeners/dna_supercoiling.py
+  notes: "Mechanical sed-style refactor: every `'_type': 'array[\u2026]'` becomes\n`'_type': 'overwrite[array[\u2026]]'`.\
+    \ No new processes or parameters.\nScope widened from the original target (just 2 files) once we saw\nthe same pattern\
+    \ in 5 more.\n"
+key_assumptions:
+- Bigraph-schema's plain `array` combinator is element-wise addition (verified empirically).
+- "Wrapping in `overwrite[\u2026]` switches the combinator to last-write-wins."
+- Listener fields that are pure outputs (the listener writes them every tick) are the affected ones; fields the listener reads
+  from upstream processes are not affected by this fix.
+readouts:
+- name: rna_init_event_per_step
+  store_path: agents.0.listeners.rnap_data.rna_init_event
+  reducer: sum
+  units: events/step
+  status: available
+- name: n_bound_TF_per_TU_length
+  store_path: agents.0.listeners.rna_synth_prob.n_bound_TF_per_TU
+  reducer: length
+  units: int (count of TUs)
+  status: available
+behavior_tests:
+- name: listeners-stop-accumulating
+  classification: primary
+  description: 'rnap_data.rna_init_event sum over the second-half window should be
+
+    a stable per-step quantity (median 40-80 events/step), not a value
+
+    that grows linearly with timestep number.
+
+    '
+  measure:
+    kind: listener_sum
+    path: listeners.rnap_data.rna_init_event
+    reduce: median
+    window: second_half
+  pass_if:
+    op: in_range
+    low: 20
+    high: 200
+  units: events/step
+  requires_simulation: baseline-postfix
+- name: n_bound_TF_per_TU-populates
+  classification: primary
+  description: "listeners.rna_synth_prob.n_bound_TF_per_TU should have length > 0\nafter the fix \u2014 non-trivial 2D shape\
+    \ (n_TU \xD7 n_TF). If it stays\nempty, the listener-output fix is necessary but not sufficient \u2014\nthe upstream process\
+    \ (tf_binding) isn't writing the field.\n"
+  measure:
+    kind: listener_path
+    path: listeners.rna_synth_prob.n_bound_TF_per_TU
+    reduce: median
+    window: second_half
+  pass_if:
+    op: in_range
+    low: 1
+    high: 1e9
+  units: length
+  requires_simulation: baseline-postfix
+conclusion_logic:
+  if_primary_tests_pass:
+    implementation_status: All listener output fields stop accumulating + n_bound_TF_per_TU populates.
+    biological_validation: 'The infrastructure fix is sufficient to unblock dnaa-01''s
+
+      autorepression-correlation test. Re-run dnaa-01 to verify the
+
+      test now computes a non-zero Pearson r.
+
+      '
+    pipeline_unblocks:
+    - "Re-run dnaa-01 \u2192 autorepression-correlation should produce a result (PASS or FAIL on biology, not on infrastructure)."
+    - All future studies that read these listeners get correct per-tick values.
+  if_primary_tests_fail:
+    diagnose:
+    - "If listeners-stop-accumulating FAILS \u2014 the overwrite[] wrapper didn't take effect (cache, wrong file, schema not\
+      \ registered)."
+    - "If n_bound_TF_per_TU-populates FAILS \u2014 the listener output fix is NECESSARY but NOT SUFFICIENT. The field is populated\
+      \ by tf_binding (an upstream process), not by this listener. Need a separate follow-up to investigate tf_binding's output\
+      \ wiring."
+    block_downstream: 'If only the n_bound_TF_per_TU test fails, the broader fix still
+
+      ships (it cures the accumulation bug for every other listener).
+
+      dnaa-01 stays gated on a SEPARATE follow-up targeting tf_binding.
+
+      '
+limitations:
+- "Only validates listener OUTPUT merge semantics, not upstream PROCESS writes \u2014 a process step that fails to write a\
+  \ field will still leave that field empty regardless of this fix."
+- No regression test in the v2ecoli test suite asserts overwrite[] semantics on listener outputs; future plain-array[] additions
+  could reintroduce the bug.
+follow_up_studies:
+- title: Investigate why tf_binding leaves n_bound_TF_per_TU empty
+  kind: new
+  effort: M
+  status: open
+  why: 'Direct consequence of THIS study''s n_bound_TF_per_TU-populates FAIL.
+
+    The field stays empty across the run even with the listener output
+
+    fix in place. That means it''s fed by an upstream process (tf_binding
+
+    or a partitioned-allocator step), not produced by rna_synth_prob_
+
+    listener. Until we identify where the write SHOULD happen and why
+
+    it doesn''t, dnaa-01''s autorepression-correlation cannot evaluate.
+
+    '
+  hypothesized_mechanism: "Three candidate root causes, in priority order:\n  (1) tf_binding never writes n_bound_TF_per_TU\
+    \ in this composite\n      config \u2014 its outputs() schema declares the field but its\n      update() returns a dict\
+    \ that omits it. Fix: grep tf_binding.py\n      for 'n_bound_TF_per_TU' and verify the return statement.\n  (2) tf_binding\
+    \ writes a SCALAR or 1D array at the wrong path,\n      and the listener guard (length != n_TU) silently rejects it.\n\
+    \      Fix: log the field's shape per tick from tf_binding's update().\n  (3) The (n_TU \xD7 n_TF) 2D shape is computed\
+    \ at init but never\n      resized as promoters get added \u2014 the field is \"populated\"\n      but with shape (0,\
+    \ 0).\n"
+  unblocks:
+  - tests.autorepression-correlation in dnaa-01 (primary supporting test)
+  - readouts.dnaA_bound_to_promoters in dnaa-01
+  - dnaa-03's DnaA-box-occupancy readouts (same store path is the source)
+  acceptance:
+  - At least one timestep in a baseline run has len(n_bound_TF_per_TU) == n_TU
+  - autorepression-correlation produces a non-zero Pearson r (PASS or FAIL on biology, not infrastructure)
+- title: Re-run dnaa-01 against its existing tests now that listeners are fixed
+  kind: existing
+  status: done
+  effort: XS
+  why: 'The listener fix changes what dnaa-01''s tests see. Two of dnaa-01''s
+
+    behavior_tests read listener data that was previously corrupted:
+
+    dnaA-concentration-stable (reads listeners.monomer_counts) and
+
+    autorepression-correlation (reads listeners.rna_synth_prob.
+
+    n_bound_TF_per_TU + listeners.rnap_data.rna_init_event). A re-run
+
+    is the only way to know if the fix changes their outcomes.
+
+    '
+  unblocks:
+  - 'dnaa-01.runs[]: gets a fresh row reflecting post-fix listener values'
+  - dnaa-01's pipeline_gate.proceed_condition becomes evaluable again
+  acceptance:
+  - dnaa-01.runs[] has a new entry tagged 'baseline-postfix' with current outcomes
+  - "If autorepression-correlation flips PASS \u2192 unblock dnaa-02. Otherwise \u2192 spawn the tf_binding follow-up (above)."
+- title: "Add workspace lint rule rejecting plain array[\u2026] in listener outputs"
+  kind: infrastructure_fix
+  effort: S
+  status: open
+  why: "Recurrence-prevention. The bug we just fixed is easy to re-introduce\nby copy/pasting from older listener code. A\
+    \ lint check that fails CI\nwhen any `'_type': 'array[` (or f-string equivalent) appears in a\nlistener output schema\
+    \ without an `overwrite[\u2026]` wrapper would catch\nthis at PR time forever.\n"
+  hypothesized_mechanism: 'Extend scripts/lint-workspace.py to walk v2ecoli/steps/listeners/
+
+    *.py with a regex that flags plain-array outputs. False positive
+
+    rate should be near zero (the pattern is narrow).
+
+    '
+  unblocks:
+  - 'CI gate: future PRs cannot reintroduce the accumulation bug'
+  acceptance:
+  - scripts/lint-workspace.py exits non-zero when a listener output omits overwrite[]
+  - The rule is documented in docs/ so contributors know about it
+- title: Audit departitioned + reconciled composites for the same listener bug
+  kind: infrastructure_fix
+  effort: S
+  status: open
+  why: 'The baseline composite is just one of three v2ecoli architectures.
+
+    departitioned + reconciled use a subset of the same listener steps
+
+    via _helpers._get_special_step, but they may also instantiate
+
+    additional listener implementations OR override schema in ways that
+
+    bypass the overwrite[] fix. Worth a quick audit so the next study
+
+    using one of those architectures doesn''t hit the same bug.
+
+    '
+  hypothesized_mechanism: 'Read v2ecoli/composites/{departitioned,reconciled}.py for any
+
+    listener instantiation; spot-check their output schemas; run the
+
+    same accumulation-vs-instantaneous check via a smoke sim.
+
+    '
+  unblocks:
+  - Confidence that fix is workspace-wide, not just baseline
+  acceptance:
+  - "All listener output schemas in all three architectures use overwrite[\u2026]"
+  - Smoke sim per architecture confirms listener values don't accumulate
+implementation_requirements:
+- id: req-1-regression-test-on-listener-outputs
+  kind: test
+  title: "Workspace lint rule rejecting plain array[\u2026] in listener outputs"
+  effort: S
+  description: "Add a scripts/lint-workspace.py check that scans v2ecoli/steps/\nlisteners/*.py for `_type': 'array[` (or\
+    \ f-string equivalent) NOT\nwrapped in `overwrite[\u2026]`. Fails the lint if any are found.\n"
+  unblocks:
+  - 'Prevents regression: future listener fields that copy/paste from old patterns will fail lint.'
+bibliography:
+  expert:
+  - replication_initiation_molecular_info
+  - chromosome_replication_plan
+  bib_keys: []
+parent_studies:
+- dnaa-01-expression-dynamics
+tests:
+  auto_discover: true
+  data_source: latest_run
+  pytest_args: []
+  last_results: null

--- a/studies/dnaa-fresh-01f-recalibrate-eg10235-translation-efficiency-in-parca/study.yaml
+++ b/studies/dnaa-fresh-01f-recalibrate-eg10235-translation-efficiency-in-parca/study.yaml
@@ -1,0 +1,263 @@
+schema_version: 3
+name: dnaa-fresh-01f-recalibrate-eg10235-translation-efficiency-in-parca
+created: '2026-05-17'
+status: planning
+phase: Design
+seeded_from:
+  parent: dnaa-01-expression-dynamics
+  followup_idx: 1
+  followup_title: Recalibrate EG10235 translation_efficiency in ParCa
+  kind: calibration_task
+baseline:
+- name: baseline
+  composite: v2ecoli.composites.baseline.baseline
+  params:
+    seed: 0
+    cache_dir: out/cache
+purpose:
+  question: "With the listener bug fixed, v2ecoli's median DnaA pool is ~115/cell.\nLiterature (Sekimizu, Schmidt, Mori) reports\
+    \ 300-800. v2ecoli is ~5\xD7\ntoo low. F-08 found 50\xD7 TE puts DnaA at 497 (in band) but breaks\nautorepression. F-10's\
+    \ TE-sweep showed no single multiplier passes\nboth gates. This study finds the optimal single-knob TE multiplier\nAND\
+    \ surfaces a deeper architectural finding about the autorepression\nmechanism.\n"
+  mechanism: "Direct sweep of translation_efficiencies[3861] (EG10235 / dnaA\nmonomer) at integer multiples of the ParCa-cached\
+    \ value (7.23e-5).\n5 seeds per multiplier \xD7 10 min sim. Pool across seeds for\nautorepression Pearson r.\n"
+  expected_outcome: "Satisfies parent's follow_up_studies[1] acceptance criteria:\n  - dnaa-01 re-run produces median DnaA\
+    \ in [300, 800]\n  - bulk[MONOMER0-160[c]] (DnaA-ATP) reaches expected 200-500 free pool\n"
+pipeline_gate:
+  prerequisites:
+  - dnaa-fresh-01-expression-dynamics
+  enables:
+  - dnaa-fresh-02-atp-hydrolysis
+  gate_status: blocked
+  gate_status_summary: "Not yet started \u2014 investigation cloned in fresh planning state."
+  proceed_condition: 'EITHER (a) a single-knob TE adjustment lands both primary gate tests
+
+    PASS at 5 seeds; OR (b) we have a documented architectural finding
+
+    that no single TE multiplier passes both, and have spawned the next
+
+    follow-up to investigate the autorepression fold_change as a second
+
+    knob.
+
+    '
+simulation_set:
+- name: "baseline (1\xD7) \u2014 control"
+  variant_of: baseline
+  seeds:
+  - 0
+  - 1
+  - 2
+  - 3
+  - 4
+  status: gated
+- name: te10x-sweep
+  variant_of: baseline
+  override:
+    dnaa_te_multiplier: 10.0
+  seeds:
+  - 0
+  - 1
+  - 2
+  - 3
+  - 4
+  status: gated
+- name: te15x-sweep
+  variant_of: baseline
+  override:
+    dnaa_te_multiplier: 15.0
+  seeds:
+  - 0
+  - 1
+  - 2
+  - 3
+  - 4
+  status: gated
+- name: te20x-sweep
+  variant_of: baseline
+  override:
+    dnaa_te_multiplier: 20.0
+  seeds:
+  - 0
+  - 1
+  - 2
+  - 3
+  - 4
+  status: gated
+- name: te25x-sweep
+  variant_of: baseline
+  override:
+    dnaa_te_multiplier: 25.0
+  seeds:
+  - 0
+  - 1
+  - 2
+  - 3
+  - 4
+  status: gated
+- name: te30x-sweep
+  variant_of: baseline
+  override:
+    dnaa_te_multiplier: 30.0
+  seeds:
+  - 0
+  - 1
+  - 2
+  - 3
+  - 4
+  status: gated
+- name: te50x-sweep
+  variant_of: baseline
+  override:
+    dnaa_te_multiplier: 50.0
+  seeds:
+  - 0
+  - 1
+  - 2
+  - 3
+  - 4
+  status: gated
+- name: te100x-sweep
+  variant_of: baseline
+  override:
+    dnaa_te_multiplier: 100.0
+  seeds:
+  - 0
+  - 1
+  - 2
+  status: gated
+model_change:
+  base_model: v2ecoli.composites.baseline.baseline
+  new_processes: []
+  new_state_variables: []
+  new_parameters:
+  - name: dnaa_te_multiplier
+    type: float
+    default: 1.0
+    description: 'Pre-build patch to ecoli-polypeptide-initiation.translation_efficiencies[3861].
+
+      Already present in run_baseline.py since F-08 of the parent study.
+
+      '
+  modified_processes: []
+  notes: "No new processes. Single existing runtime parameter used to scale the\ncached TE. By design \u2014 this study's\
+    \ job is to find the right scalar,\nnot to add new mechanism.\n"
+key_assumptions:
+- 'Inherited: dnaa-01 re-run produces median DnaA in [300, 800] (Schmidt 2016)'
+- 'Inherited: bulk[MONOMER0-160[c]] (DnaA-ATP) reaches expected 200-500 free pool fraction'
+- Multi-seed pooling (5 seeds) is sufficient for stable autorepression Pearson r at 10-min duration (verified in F-02 of parent).
+readouts:
+- name: dnaA_count
+  store_path: listeners.monomer_counts
+  index_by: 3861
+- name: dnaA_TF_binding_sum
+  store_path: listeners.rna_synth_prob.n_bound_TF_per_TU
+  index_by: '[:, 12]'
+- name: dnaA_mRNA_count
+  store_path: listeners.rna_counts.mRNA_cistron_counts
+  index_by: 227
+behavior_tests:
+- name: dnaA-count-in-range
+  classification: primary
+  description: Median DnaA per cell (second-half window) in [300, 800] per Schmidt 2016 mass-spec.
+  measure:
+    kind: median_window
+    field: dnaA_count
+    window: second_half
+  expect:
+    op: in_range
+    range:
+    - 300
+    - 800
+  cites:
+  - Schmidt2016NatBiotechnol
+  - Sekimizu1991JBacteriol
+- name: autorepression-correlation
+  classification: primary
+  description: "Pearson r(DnaA-TF binding, dnaA-mRNA) \u2264 -0.3, pooled 5 seeds \xD7 second-half."
+  measure:
+    kind: pearson
+    x: dnaA_TF_binding_sum
+    y: dnaA_mRNA_count
+    pool: across_seeds
+  expect:
+    op: less_or_equal
+    value: -0.3
+  cites:
+  - Speck1999EMBO
+  - Saggioro2013BiochemJ
+  - Katayama2017Frontiers
+conclusion_logic:
+  if_primary_tests_pass:
+    implementation_status: 'Promote winning multiplier to permanent adjustment in
+
+      v2ecoli/processes/parca/reconstruction/ecoli/flat/adjustments/translation_efficiencies_adjustments.tsv.
+
+      '
+    biological_validation: DnaA matches Schmidt 2016 AND autorepression preserved. dnaa-01 gate opens; dnaa-02 unblocks.
+    pipeline_unblocks:
+    - dnaa-02-atp-hydrolysis
+  if_primary_tests_fail:
+    diagnose:
+    - "Determine if non-monotonicity (DnaA count drops 296 \u2192 263 \u2192 159 across 20\xD7/25\xD7/30\xD7) is autorepression-model\
+      \ saturation."
+    - "Pearson r sign-flip from -0.253 at 20\xD7 to +0.780 at 25\xD7 = phase transition."
+    - Inspect fold_change parameter for dnaA in delta_prob.deltaV (sparse from ParCa).
+    block_downstream: dnaa-02 conditionally proceeds; spawn fold_change follow-up.
+limitations:
+- "Single-knob scan only. The TE \xD7 autorepression-fold-change joint sweep recommended in F-10 spawned as a separate follow-up."
+- Underlying ParCa raw-data fitting not re-verified. The 8.6th-percentile TE position may itself reflect a raw-source choice.
+- 10-min sims only. Cell-cycle phenomena (doubling-time variants) not tested.
+implementation_requirements:
+- Run with --heavy_tf_listener (enables n_bound_TF_per_TU emission for autorepression Pearson r).
+bibliography:
+  expert:
+  - replication_initiation_molecular_info
+  - chromosome_replication_plan
+  bib_keys:
+  - Schmidt2016NatBiotechnol
+  - Sekimizu1991JBacteriol
+  - Boesen2024MolMicrobiol
+  - Speck1999EMBO
+  - Saggioro2013BiochemJ
+  - Katayama2017Frontiers
+parent_studies:
+- dnaa-01-expression-dynamics
+follow_up_studies:
+- title: "Joint TE \xD7 autorepression-fold-change sweep"
+  kind: new
+  effort: M
+  status: planned
+  why: "F-02 shows TE alone has a saturable autorepression response with a\nphase transition at 20-25\xD7. The right move\
+    \ is to co-vary autorepression\nstrength (fold_change) and TE on a 2D grid.\n"
+  hypothesized_mechanism: "Reducing dnaA's fold_change (deltaV entries in delta_prob[:, 12])\nweakens per-bound-DnaA suppression.\
+    \ Combined with mid-TE (~20\xD7), this\ncould produce a calibration where DnaA reaches literature range\nwithout triggering\
+    \ saturation-driven oscillation.\n"
+  unblocks:
+  - dnaa-02-atp-hydrolysis (will pass cleanly if this works)
+  acceptance:
+  - Joint sweep produces at least one (TE, fold_change) pair PASSING both gate tests at 5 seeds.
+- title: ParCa TE derivation audit for low-mRNA-count genes
+  kind: new
+  effort: L
+  status: planned
+  why: "F-01 shows dnaA's cached TE (7.23e-5) sits at 8.6th percentile of\nproteome \u2014 biologically improbable. Determine\
+    \ which raw input source\n(ribosome profiling vs mass-spec) should govern the dnaA TE estimate.\n"
+  hypothesized_mechanism: 'ParCa step_08/step_09 derives TE from steady-state mass-balance. For
+
+    low-mRNA-count genes (dnaA mean mRNA ~0/cell), the ratio is
+
+    numerically unstable. Switching dnaA to use Schmidt 2016 mass-spec
+
+    count + Li 2014 half-life directly may be more accurate.
+
+    '
+  unblocks:
+  - permanent TE adjustment in translation_efficiencies_adjustments.tsv
+  acceptance:
+  - Documented root cause of 8.6th-percentile TE; either fix or rule out.
+tests:
+  auto_discover: true
+  data_source: latest_run
+  pytest_args: []
+  last_results: null

--- a/studies/dnaa-fresh-02-atp-hydrolysis/study.yaml
+++ b/studies/dnaa-fresh-02-atp-hydrolysis/study.yaml
@@ -1,0 +1,431 @@
+schema_version: 3
+name: dnaa-fresh-02-atp-hydrolysis
+created: '2026-05-17'
+status: planning
+phase: Design
+baseline:
+- name: baseline-nucleotide-cycle
+  composite: v2ecoli.composites.baseline_recipes.dnaa_02_with_intrinsic_hydrolysis
+  params:
+    seed: 0
+    cache_dir: out/cache
+- name: baseline-extrinsic-target
+  composite: v2ecoli.composites.baseline_recipes.dnaa_02_with_extrinsic_target_rate
+  params:
+    seed: 0
+    cache_dir: out/cache
+visualizations:
+- name: dnaa_state
+  address: local:DnaAStateVisualization
+  config:
+    title: "dnaa-02 \u2014 DnaA state (apo/ATP/ADP) trajectory"
+    sample_every: 10
+- name: dnaa_box_occupancy
+  address: local:DnaABoxOccupancyVisualization
+  config:
+    title: "dnaa-02 \u2014 DnaA-box occupancy (end-state landscape)"
+    sample_every: 10
+purpose:
+  question: "Does an exponential intrinsic DnaA-ATP \u2192 DnaA-ADP hydrolysis\n(k \u2248 0.046/min; Sekimizu 1987) paired\
+    \ with tight ATP/ADP binding\nproduce the physiological DnaA-ATP / total-DnaA fraction band of\n0.2-0.5 (Boesen 2024)?\n"
+  mechanism: "Split the single DnaA species into three bulk forms (DnaA-apo,\nDnaA-ATP, DnaA-ADP). Add a first-order hydrolysis\
+    \ Step\nDnaA-ATP \u2192 DnaA-ADP with rate parameter. Optionally clamp the\nDnaA-ATP fraction to the [0.2, 0.5] band so\
+    \ downstream studies\n(dnaa-03, dnaa-04) can proceed before the full RIDA/DDAH/DARS\nnetwork in dnaa-05 lands.\n"
+  expected_outcome: "Intrinsic-only baseline equilibrates near the low end of the\nphysiological band (~0.2). no-hydrolysis\
+    \ variant drifts to ~1.0;\n10\xD7 variant drops below 0.1. apo fraction < 5%.\n"
+pipeline_gate:
+  prerequisites:
+  - dnaa-fresh-01-expression-dynamics
+  enables:
+  - dnaa-fresh-03-box-binding
+  - dnaa-fresh-05-rida-ddah-dars
+  gate_status: blocked
+  gate_status_summary: "Not yet started \u2014 investigation cloned in fresh planning state."
+  proceed_condition: 'apo-dnaA-fraction-is-small + dnaa-atp-fraction-in-physiological-range
+
+    pass (or the clamp is enabled and acknowledged by the expert as a
+
+    temporary scaffold).
+
+    '
+simulation_set:
+- name: baseline-nucleotide-cycle
+  base_model: v2ecoli.composites.baseline.baseline
+  perturbation: null
+  condition: M9-minimal-glucose
+  duration_min: 60
+  seeds:
+  - 0
+  - 1
+  - 2
+  readouts:
+  - dnaA_atp_fraction
+  - dnaA_apo_count
+  - atp_pool
+  - adp_pool
+  applies_tests:
+  - apo-dnaa-fraction-is-small
+  - dnaa-atp-fraction-in-physiological-range
+  - atp-pool-much-greater-than-adp
+  status: gated
+  blocked_by_requirements:
+  - req-1-nucleotide-split
+  - req-2-intrinsic-hydrolysis-step
+  - req-3-atp-fraction-listener
+- name: no-intrinsic-hydrolysis
+  base_model: v2ecoli.composites.baseline.baseline
+  perturbation:
+    dnaA_intrinsic_hydrolysis_rate_per_min: 0.0
+  condition: M9-minimal-glucose
+  duration_min: 60
+  seeds:
+  - 0
+  - 1
+  - 2
+  readouts:
+  - dnaA_atp_fraction
+  applies_tests:
+  - no-hydrolysis-accumulates-atp-form
+  status: gated
+  blocked_by_requirements:
+  - req-1-nucleotide-split
+  - req-2-intrinsic-hydrolysis-step
+- name: fast-intrinsic-hydrolysis
+  base_model: v2ecoli.composites.baseline.baseline
+  perturbation:
+    dnaA_intrinsic_hydrolysis_rate_per_min: 0.46
+  condition: M9-minimal-glucose
+  duration_min: 60
+  seeds:
+  - 0
+  - 1
+  - 2
+  readouts:
+  - dnaA_atp_fraction
+  applies_tests:
+  - fast-hydrolysis-suppresses-atp-form
+  status: gated
+  blocked_by_requirements:
+  - req-1-nucleotide-split
+  - req-2-intrinsic-hydrolysis-step
+model_change:
+  base_model: v2ecoli.composites.baseline.baseline
+  new_state_variables:
+  - id: DnaA_apo
+    kind: bulk
+    units: molecules/cell
+  - id: DnaA_ATP
+    kind: bulk
+    units: molecules/cell
+  - id: DnaA_ADP
+    kind: bulk
+    units: molecules/cell
+  new_processes:
+  - name: DnaaIntrinsicHydrolysis
+    kind: Step
+    fires_per: timestep
+    requirement_id: req-2-intrinsic-hydrolysis-step
+  new_parameters:
+  - name: dnaA_intrinsic_hydrolysis_rate_per_min
+    default: 0.046
+    units: per_min
+  - name: dnaA_atp_fraction_clamp
+    default: null
+    type: '[low, high] | null'
+  new_listeners:
+  - name: dnaA_atp_fraction
+    emits:
+    - agents.<id>.listeners.dnaA_cycle.atp_fraction
+    requirement_id: req-3-atp-fraction-listener
+  modified_processes:
+  - 'Initial-state seeder: split MONOMER0-160[c] equivalent across the three new species at equilibrium fraction.'
+key_assumptions:
+- DnaA binding to ATP and ADP is tight (Kd ~30 nM ATP, ~100 nM ADP; Sekimizu 1987).
+- Intrinsic hydrolysis is first-order and slow (~0.046/min; 50% in 15 min).
+- At physiological [ATP] = 6-7 mM, apo-DnaA is a small minority.
+- DNA-binding does NOT modify the intrinsic hydrolysis rate (per Sekimizu 1987 in vitro).
+readouts:
+- name: dnaA_atp_fraction
+  description: DnaA-ATP / (DnaA-apo + DnaA-ATP + DnaA-ADP) over time.
+  store_path: agents.0.listeners.dnaA_cycle.atp_fraction
+  units: fraction
+  status: derived-needed
+  blocked_by_requirements:
+  - req-1-nucleotide-split
+  - req-3-atp-fraction-listener
+- name: dnaA_apo_count
+  store_path: agents.0.bulk
+  index_by:
+    type: bulk_id
+    value: DnaA_apo
+  units: molecules/cell
+  status: aspirational
+  blocked_by_requirements:
+  - req-1-nucleotide-split
+- name: atp_pool
+  store_path: agents.0.bulk
+  index_by:
+    type: bulk_id
+    value: ATP[c]
+  units: molecules/cell
+  status: available
+- name: adp_pool
+  store_path: agents.0.bulk
+  index_by:
+    type: bulk_id
+    value: ADP[c]
+  units: molecules/cell
+  status: available
+behavior_tests:
+- name: apo-dnaa-fraction-is-small
+  classification: primary
+  description: "apo-DnaA / total \u2264 5% at steady state (nucleotide is tightly bound)."
+  measure:
+    kind: ratio_of_sums
+    numerator:
+      kind: bulk_count
+      id: DnaA_apo
+      reduce: median
+    denominator:
+      kind: bulk_count_sum
+      ids:
+      - DnaA_apo
+      - DnaA_ATP
+      - DnaA_ADP
+      reduce: median
+    window: second_half
+  pass_if:
+    op: at_most
+    value: 0.05
+  units: fraction
+  requires_simulation: baseline-nucleotide-cycle
+  cites:
+  - Sekimizu1987Cell
+  - Kawakami2006MolMicrobiol
+- name: dnaa-atp-fraction-in-physiological-range
+  classification: primary
+  description: DnaA-ATP / total in [0.2, 0.5] (Boesen 2024 PNAS Delta4 cells).
+  measure:
+    kind: ratio_of_sums
+    numerator:
+      kind: bulk_count
+      id: DnaA_ATP
+      reduce: median
+    denominator:
+      kind: bulk_count_sum
+      ids:
+      - DnaA_apo
+      - DnaA_ATP
+      - DnaA_ADP
+      reduce: median
+    window: second_half
+  pass_if:
+    op: in_range
+    low: 0.2
+    high: 0.5
+  units: fraction
+  requires_simulation: baseline-nucleotide-cycle
+  cites:
+  - Boesen2024PNAS
+- name: atp-pool-much-greater-than-adp
+  classification: supporting
+  description: Background metabolism keeps ATP/ADP > 10 at steady state.
+  measure:
+    kind: ratio_of_bulks
+    numerator:
+      id: ATP[c]
+    denominator:
+      id: ADP[c]
+    reduce: median
+    window: second_half
+  pass_if:
+    op: at_least
+    value: 10.0
+  units: ratio
+  requires_simulation: baseline-nucleotide-cycle
+  cites:
+  - Boesen2024PNAS
+- name: no-hydrolysis-accumulates-atp-form
+  classification: diagnostic
+  description: With hydrolysis rate = 0, DnaA-ATP fraction monotonically rises.
+  measure:
+    kind: ratio_of_sums
+    numerator:
+      kind: bulk_count
+      id: DnaA_ATP
+      reduce: series
+    denominator:
+      kind: bulk_count_sum
+      ids:
+      - DnaA_apo
+      - DnaA_ATP
+      - DnaA_ADP
+      reduce: series
+    window: full
+  pass_if:
+    op: monotonic_increasing
+    allow_dip_pct: 5
+  units: fraction
+  requires_simulation: no-intrinsic-hydrolysis
+  cites:
+  - Sekimizu1987Cell
+- name: fast-hydrolysis-suppresses-atp-form
+  classification: diagnostic
+  description: "10\xD7 hydrolysis pushes DnaA-ATP fraction below 0.1."
+  measure:
+    kind: ratio_of_sums
+    numerator:
+      kind: bulk_count
+      id: DnaA_ATP
+      reduce: median
+    denominator:
+      kind: bulk_count_sum
+      ids:
+      - DnaA_apo
+      - DnaA_ATP
+      - DnaA_ADP
+      reduce: median
+    window: second_half
+  pass_if:
+    op: at_most
+    value: 0.1
+  units: fraction
+  requires_simulation: fast-intrinsic-hydrolysis
+  cites:
+  - Sekimizu1987Cell
+  - Kawakami2006MolMicrobiol
+conclusion_logic:
+  if_primary_tests_pass:
+    implementation_status: Three-state DnaA nucleotide cycle works at the intrinsic-only level.
+    biological_validation: "Confirms Sekimizu 1987's intrinsic rate alone CAN produce a\nphysiological ATP-fraction band \u2014\
+      \ but doesn't validate the\ncell-cycle oscillation (that's dnaa-05's territory).\n"
+    pipeline_unblocks:
+    - dnaa-03-box-binding (box affinity depends on nucleotide form)
+    - dnaa-05-rida-ddah-dars (extrinsic conversion overlays this)
+  if_primary_tests_fail:
+    diagnose:
+    - 'If DnaA-ATP fraction is too high: hydrolysis rate is too low or DNA binding is shielding ATP form.'
+    - 'If DnaA-ATP fraction is too low: hydrolysis rate too high or ATP-binding kinetics wrong.'
+    - 'If apo fraction is large: ATP-binding Kd too weak in the implementation.'
+    block_downstream: dnaa-03 onward need a valid intrinsic baseline.
+conclusion_verdicts:
+  regression_compatibility:
+    result: PENDING
+    basis: "No runs yet \u2014 investigation cloned in fresh planning state."
+  biological_validation:
+    result: PENDING
+    basis: "No runs yet \u2014 investigation cloned in fresh planning state."
+    blocking_evidence_needed:
+    - "IntrinsicHydrolysis Step perturbation (knockout \u2192 ATP fraction \u2192 1.0)"
+    - ATP-cycle-ablation panel from dnaa-01
+    - Direct measurement of in-vivo total DnaA hydrolysis flux
+  explanatory_gain:
+    result: PENDING
+    basis: "No runs yet \u2014 investigation cloned in fresh planning state."
+expert_decisions_needed:
+- id: dnaa-02-EQ-01
+  question: "Is the v2ecoli equilibrium reverse-rate (MONOMER0-160_RXN rate constant 2.9e-8) correctly calibrated, or does\
+    \ the 100\xD7 gap between intrinsic Boesen rate and required v2ecoli flux indicate the equilibrium reverse-rate is the\
+    \ actual problem?"
+  alternatives:
+  - "Equilibrium reverse-rate is correct \u2192 RIDA + DDAH + DARS together really must deliver ~99\xD7 the intrinsic rate\
+    \ in vivo (dnaa-05 work)."
+  - "Equilibrium reverse-rate is over-estimated by ~10-100\xD7 \u2192 less extrinsic flux required \u2192 simpler dnaa-05."
+  - "Both are partially wrong \u2192 calibrate jointly."
+  impact_if_wrong: "Mis-attribution of ~100\xD7 hydrolysis-flux requirement to extrinsic pathways vs equilibrium calibration.\
+    \ Affects dnaa-05 design entirely."
+  blocks:
+  - dnaa-02 conclusion_verdicts.biological_validation
+  - dnaa-05 implementation
+  requested_response: Authority + DOI for the MONOMER0-160_RXN forward/reverse rate constants in ParCa; cross-reference Boesen
+    2024 + Sekimizu 1987 for in-vivo total flux measurements.
+  status: open
+  asked_to: TBD
+limitations:
+- Intrinsic hydrolysis only; the cell-cycle oscillation requires dnaa-05's RIDA + DDAH + DARS.
+- Single doubling time; multi-generation drift not validated.
+- Assumes physiological [ATP]/[ADP] from baseline metabolism is correct (validated by atp-pool-much-greater-than-adp).
+- "Does not validate which DnaA species binds which DnaA-box class \u2014 that's dnaa-03."
+implementation_requirements:
+- id: req-1-nucleotide-split
+  kind: state_variables
+  title: Split DnaA bulk into ATP / ADP / apo species
+  effort: M
+  description: 'The existing v2ecoli model has DnaA as a single bulk entry
+
+    (PD03831[c]) + a complex form (MONOMER0-160[c] = "DnaA_ATP_complex").
+
+    Need three explicit species (DnaA_apo, DnaA_ATP, DnaA_ADP) with
+
+    proper initial-state seeding at equilibrium fraction.
+
+    '
+  steps:
+  - Add 3 bulk ids in v2ecoli/library/sim_data.py.
+  - 'Initial-state seeder: distribute existing total DnaA across the three species at equilibrium fraction (~30% ATP-bound
+    under physiological [ATP]).'
+  - "Audit every reference to MONOMER0-160[c] / PD03831[c] \u2014 either keep as the SUM or rewire to the new species explicitly."
+  - "Behavioral check: sum(DnaA_apo + DnaA_ATP + DnaA_ADP) \u2248 historical PD03831[c] count."
+  unblocks:
+  - all dnaa-02 behavior_tests
+  - dnaa-03 box binding (form-specific)
+  - dnaa-05 atp_fraction observable
+- id: req-2-intrinsic-hydrolysis-step
+  kind: step
+  title: "DnaA-ATP \u2192 DnaA-ADP hydrolysis Step"
+  effort: S
+  description: First-order Step with rate parameter; transfers count each timestep.
+  steps:
+  - Create v2ecoli/steps/dnaa_intrinsic_hydrolysis.py.
+  - 'Composite param dnaA_intrinsic_hydrolysis_rate_per_min: float = 0.046.'
+  - Wire into baseline composite after nucleotide-binding equilibrium.
+  - "Test: no-hydrolysis variant \u2192 atp_fraction monotonic increasing."
+  unblocks:
+  - no-hydrolysis-accumulates-atp-form
+  - fast-hydrolysis-suppresses-atp-form
+- id: req-3-atp-fraction-listener
+  kind: listener
+  title: dnaA_atp_fraction listener
+  effort: XS
+  description: Step emitting agents.<id>.listeners.dnaA_cycle.atp_fraction = ATP / total each timestep.
+  unblocks:
+  - readouts.dnaA_atp_fraction
+  - apo-dnaa-fraction-is-small, dnaa-atp-fraction-in-physiological-range
+- id: req-4-atp-fraction-clamp
+  kind: step
+  title: Optional ATP-fraction clamp
+  effort: XS
+  description: 'Optional Step that, when enabled, redistributes ATP/ADP each
+
+    timestep to keep ATP/total in a user-specified band. Lets
+
+    dnaa-03 and dnaa-04 run before dnaa-05''s RIDA / DARS / DDAH
+
+    network lands.
+
+    '
+  steps:
+  - 'Composite param dnaA_atp_fraction_clamp: [low, high] | None = None.'
+  - Step runs AFTER hydrolysis; rebalances if outside band.
+  - 'Validation: clamped run keeps atp_fraction in the band.'
+  unblocks:
+  - dnaa-03 / dnaa-04 can proceed before dnaa-05 lands
+bibliography:
+  expert:
+  - replication_initiation_molecular_info
+  bib_keys:
+  - Sekimizu1987Cell
+  - Kawakami2006MolMicrobiol
+  - Boesen2024PNAS
+  - Hansen2018DnaATale
+  - Katayama2017Frontiers
+parent_studies:
+- study: dnaa-fresh-01-expression-dynamics
+  condition: tests-passed-or-conditional
+- study: dnaa-fresh-01f-recalibrate-eg10235-translation-efficiency-in-parca
+  condition: insights-recorded
+tests:
+  auto_discover: true
+  data_source: latest_run
+  pytest_args: []
+  last_results: null

--- a/studies/dnaa-fresh-03-box-binding/study.yaml
+++ b/studies/dnaa-fresh-03-box-binding/study.yaml
@@ -1,0 +1,454 @@
+schema_version: 3
+name: dnaa-fresh-03-box-binding
+created: '2026-05-17'
+status: planning
+phase: Design
+baseline:
+- name: baseline-box-binding
+  composite: v2ecoli.composites.baseline_recipes.dnaa_03_with_box_binding
+  params:
+    seed: 0
+    cache_dir: out/cache
+visualizations:
+- name: dnaa_box_occupancy
+  address: local:DnaABoxOccupancyVisualization
+  config:
+    title: "dnaa-03 \u2014 DnaA-box binding state trajectory + end-landscape"
+    sample_every: 10
+- name: dnaa_state
+  address: local:DnaAStateVisualization
+  config:
+    title: "dnaa-03 \u2014 DnaA pool feeding the box-binding mechanism"
+    sample_every: 10
+purpose:
+  question: 'Does explicit DnaA binding to the 322 catalogued sites (307 chromosomal
+
+    + 11 oriC + 4 dnaAp) reproduce the textbook two-step oriC occupancy
+
+    pattern and the post-titration rise in free DnaA?
+
+    '
+  mechanism: 'Add a DnaA-box catalog (positions + affinity class + nucleotide-form
+
+    preference) to chromosome_structure. Add a binding Process that
+
+    updates DnaA_bound + the bound-nucleotide annotation each timestep
+
+    using affinity-class-specific KDs (1 nM high, 100 nM low).
+
+    '
+  expected_outcome: 'Chromosomal occupancy rises monotonically; oriC stays <20% bound
+
+    until chromosomal sites are >90% occupied; free DnaA rises sharply
+
+    after titration; oriC fills in two steps (high then low).
+
+    '
+pipeline_gate:
+  prerequisites:
+  - dnaa-fresh-02-atp-hydrolysis
+  enables:
+  - dnaa-fresh-04-initiation-mechanism
+  gate_status: blocked
+  gate_status_summary: "Not yet started \u2014 investigation cloned in fresh planning state."
+  proceed_condition: 'Primary tests pass; oriC two-step pattern visible; oriC remains
+
+    unoccupied while chromosome titrates.
+
+    '
+simulation_set:
+- name: single-cycle-binding-dynamics
+  base_model: v2ecoli.composites.baseline.baseline
+  perturbation: null
+  condition: M9-minimal-glucose
+  duration_min: 60
+  seeds:
+  - 0
+  - 1
+  - 2
+  - 3
+  - 4
+  readouts:
+  - chromosome_occupied_fraction
+  - oric_high_occupancy
+  - oric_low_occupancy
+  - free_dnaA
+  applies_tests:
+  - chromosomal-occupancy-monotonic
+  - oric-stays-unoccupied-until-chromosome-saturates
+  - free-dnaa-rises-after-titration
+  - oric-occupancy-is-two-step
+  status: gated
+  blocked_by_requirements:
+  - req-1-box-catalog
+  - req-2-binding-kinetics
+- name: high-initial-dnaA
+  base_model: v2ecoli.composites.baseline.baseline
+  perturbation:
+    initial_dnaA_count_per_cell: 5000
+  condition: M9-minimal-glucose
+  duration_min: 60
+  seeds:
+  - 0
+  - 1
+  - 2
+  readouts:
+  - dnaap_occupancy
+  - dnaA_tx_init_events
+  applies_tests:
+  - high-initial-dnaa-autorepression
+  status: gated
+  blocked_by_requirements:
+  - req-3-initial-pool-hook
+  - req-1-box-catalog
+  - req-2-binding-kinetics
+- name: chromosomal-boxes-only
+  base_model: v2ecoli.composites.baseline.baseline
+  perturbation:
+    enable_oric_binding: false
+  condition: M9-minimal-glucose
+  duration_min: 60
+  seeds:
+  - 0
+  - 1
+  - 2
+  readouts:
+  - free_dnaA
+  applies_tests:
+  - chromosomal-only-no-oric-fill
+  status: gated
+  blocked_by_requirements:
+  - req-4-oric-toggle
+  - req-1-box-catalog
+  - req-2-binding-kinetics
+model_change:
+  base_model: v2ecoli.composites.baseline.baseline
+  new_state_variables:
+  - id: unique.DnaA_box (with role + affinity_class + bound_form attributes)
+    kind: unique
+  new_processes:
+  - name: DnaaBoxBinding
+    kind: Process
+    requirement_id: req-2-binding-kinetics
+  new_parameters:
+  - name: dnaA_box_binding_kd_nM
+    default:
+      high: 1.0
+      low: 100.0
+  - name: enable_oric_binding
+    default: true
+  - name: initial_dnaA_count_per_cell
+    default: null
+  new_listeners:
+  - name: dnaA_binding
+    emits:
+    - agents.<id>.listeners.dnaA_binding.{chromosome,oric,dnaap,free_total}
+  modified_processes:
+  - 'chromosome_structure: seed DnaA_boxes from data/dnaa_box_catalog.tsv at cell birth + on replication.'
+key_assumptions:
+- "307 chromosomal consensus boxes (TTWTNCACA) \u2014 Roth 1998 / Olivi 2025."
+- "11 oriC boxes: R1, R2, R4 high-affinity (1 nM); R5M, \u03C42, I1-3, C1-3 low (100 nM)."
+- '4 dnaAp boxes: 1, 2 high; b, c low.'
+- Both DnaA-ATP and DnaA-ADP bind high-affinity sites; low-affinity sites require DnaA-ATP.
+- DNA binding does NOT alter intrinsic hydrolysis rate (Sekimizu 1987).
+readouts:
+- name: chromosome_occupied_fraction
+  store_path: agents.0.listeners.dnaA_binding.chromosome.occupied_fraction
+  units: fraction
+  status: derived-needed
+  blocked_by_requirements:
+  - req-2-binding-kinetics
+- name: oric_high_occupancy
+  store_path: agents.0.listeners.dnaA_binding.oric.high_affinity_occupied
+  units: fraction
+  status: derived-needed
+  blocked_by_requirements:
+  - req-2-binding-kinetics
+- name: oric_low_occupancy
+  store_path: agents.0.listeners.dnaA_binding.oric.low_affinity_occupied
+  units: fraction
+  status: derived-needed
+  blocked_by_requirements:
+  - req-2-binding-kinetics
+- name: free_dnaA
+  store_path: agents.0.listeners.dnaA_binding.free_total
+  units: molecules/cell
+  status: derived-needed
+  blocked_by_requirements:
+  - req-2-binding-kinetics
+- name: dnaap_occupancy
+  store_path: agents.0.listeners.dnaA_binding.dnaap.occupied
+  units: fraction
+  status: derived-needed
+  blocked_by_requirements:
+  - req-2-binding-kinetics
+- name: dnaA_tx_init_events
+  store_path: agents.0.listeners.rnap_data.rna_init_event
+  index_by:
+    type: tu_id
+    value: EG10235_RNA
+  units: events/step
+  status: available
+behavior_tests:
+- name: chromosomal-occupancy-monotonic
+  classification: primary
+  description: Chromosomal box occupancy rises monotonically as DnaA accumulates.
+  measure:
+    kind: listener_path
+    path: listeners.dnaA_binding.chromosome.occupied_fraction
+    reduce: series
+    window: full
+  pass_if:
+    op: monotonic_increasing
+    allow_dip_pct: 5
+  units: fraction
+  requires_simulation: single-cycle-binding-dynamics
+  cites:
+  - Roth1998MolMicrobiol
+  - Olivi2025NatCommun
+- name: oric-stays-unoccupied-until-chromosome-saturates
+  classification: primary
+  description: oriC high-affinity occupancy stays <20% until chromosomal sites are >90% occupied (the titration prediction).
+  measure:
+    kind: cross_threshold
+    series_x:
+      kind: listener_path
+      path: listeners.dnaA_binding.chromosome.occupied_fraction
+    series_y:
+      kind: listener_path
+      path: listeners.dnaA_binding.oric.high_affinity_occupied
+    when_x_crosses: 0.9
+  pass_if:
+    op: y_was_at_most
+    value: 0.2
+  units: fraction
+  requires_simulation: single-cycle-binding-dynamics
+  cites:
+  - Hansen1991ResMicrobiol
+  - Olivi2025NatCommun
+  - Berger2022NatCommun
+- name: free-dnaa-rises-after-titration
+  classification: supporting
+  description: "Free DnaA pool rises \u22651.5\xD7 over the run."
+  measure:
+    kind: listener_path
+    path: listeners.dnaA_binding.free_total
+    reduce: first_and_last
+    window: full
+  pass_if:
+    op: ratio_at_least
+    ratio: 1.5
+  units: ratio
+  requires_simulation: single-cycle-binding-dynamics
+  cites:
+  - Hansen1991ResMicrobiol
+  - Olivi2025NatCommun
+- name: oric-occupancy-is-two-step
+  classification: supporting
+  description: "oriC high-affinity sites cross 50% occupancy \u226560s before low-affinity sites."
+  measure:
+    kind: time_lag_between
+    series_a:
+      kind: listener_path
+      path: listeners.dnaA_binding.oric.high_affinity_occupied
+    series_b:
+      kind: listener_path
+      path: listeners.dnaA_binding.oric.low_affinity_occupied
+    threshold: 0.5
+  pass_if:
+    op: at_least
+    value: 60.0
+  units: seconds
+  requires_simulation: single-cycle-binding-dynamics
+  cites:
+  - Katayama2017Frontiers
+  - Kasho2023IJMS
+  - Leonard2015FrontMicrobiol
+- name: high-initial-dnaa-autorepression
+  classification: diagnostic
+  description: "Starting with 5000 DnaA \u2192 bound-DnaA and tx-init-events anti-correlate (r \u2264 -0.3)."
+  measure:
+    kind: xy_correlation
+    x:
+      kind: listener_path
+      path: listeners.dnaA_binding.dnaap.occupied
+    y:
+      kind: listener_sum
+      path: listeners.rnap_data.rna_init_event
+    window: second_half
+  pass_if:
+    op: pearson_at_most
+    threshold: -0.3
+  units: dimensionless r
+  requires_simulation: high-initial-dnaA
+  cites:
+  - Speck1999EMBO
+  - Saggioro2013BiochemJ
+- name: chromosomal-only-no-oric-fill
+  classification: diagnostic
+  description: "With oriC binding disabled, free DnaA median is \u22653\xD7 a counterfactual baseline (cross-run)."
+  measure:
+    kind: listener_path
+    path: listeners.dnaA_binding.free_total
+    reduce: median
+    window: second_half
+  pass_if:
+    op: at_least
+    value: 3.0
+    units: ratio_vs_baseline
+  units: ratio
+  requires_simulation: chromosomal-boxes-only
+  cites:
+  - Hansen1991ResMicrobiol
+abstraction_level:
+  name: DnaA-box occupancy with per-class affinity, no cooperativity (v1)
+  resolves:
+  - site existence + coordinate distribution
+  - crude affinity classification (high/med/low)
+  does_not_resolve:
+  - "cooperative binding at oriC \u2014 v2 would add Hill exponent"
+  - accessory-factor dependence (HU/IHF/Fis)
+  - "nucleotide-form preference (ATP vs ADP) \u2014 needs dnaa-02 three-state pool fully integrated"
+  - "release dynamics on fork passage \u2014 needs dnaa-04+"
+conclusion_verdicts:
+  regression_compatibility:
+    result: PENDING
+    basis: "No runs yet \u2014 investigation cloned in fresh planning state."
+  biological_validation:
+    result: PENDING
+    basis: "No runs yet \u2014 investigation cloned in fresh planning state."
+    blocking_evidence_needed:
+    - cooperative-binding Step implementation (or accessory-factor model)
+    - site-mutation perturbation (remove subset, observe occupancy shift)
+    - in-vivo cooperativity measurement from literature (open expert question)
+  explanatory_gain:
+    result: PENDING
+    basis: "No runs yet \u2014 investigation cloned in fresh planning state."
+expert_decisions_needed:
+- id: dnaa-03-EQ-01
+  question: 'v2ecoli''s motif scan finds 456 active DnaA boxes (F-02). Literature reports ~322 (307 chromosomal + 11 oriC
+    + 4 dnaAp). What is the correct catalog: keep the 456 v2ecoli set (broader functional definition), filter to the 322 curated
+    set (stricter), or use a hybrid?'
+  alternatives:
+  - 'Use v2ecoli''s 456: trust the PWM scan; the extra ~134 sites are real low-affinity titration buffer'
+  - 'Filter to curated 322: experimental literature only; the extra 134 are PWM false-positives'
+  - 'Hybrid: 322 confirmed + 134 flagged as "candidate" with low confidence, region_type=other'
+  impact_if_wrong: Affects titration-buffer size by ~40%, which directly affects oriC fill timing in the cooperative-binding
+    model.
+  blocks:
+  - dnaa-03 implementation choice between v1 (no cooperativity) and v2 (with)
+  - dnaa-04 initiation timing (depends on titration-buffer saturation curve)
+  requested_response: Cross-reference Roth 1998 + Hansen 2018 box lists against v2ecoli's motif_coordinates output; flag agreements
+    + disagreements
+  status: open
+  asked_to: TBD
+- id: dnaa-03-EQ-02
+  question: Does dnaa-03's textbook two-step oriC fill pattern (chromosomal sites saturate first, then oriC fills sharply)
+    require cooperative DnaA-ATP binding at oriC (Hill n=5-10) OR can it be explained by accessory factors (HU, IHF, Fis)
+    that gate oriC access until specific cell-cycle windows?
+  alternatives:
+  - 'Cooperativity sufficient: implement Hill n=5-10 at oriC, no accessory-factor model needed'
+  - 'Accessory factors necessary: cooperativity alone fails (current F-05 evidence supports this); need HU/IHF/Fis time-gating'
+  - 'Both contribute: Hill n=3-5 PLUS time-gated access from accessory factors'
+  impact_if_wrong: Determines whether dnaa-03 v2 (cooperative model) is sufficient or whether dnaa-03 v3 (accessory-factor
+    model) is also needed before dnaa-04 can proceed.
+  blocks:
+  - dnaa-03 v2 implementation
+  - dnaa-04 initiation trigger (depends on robust oriC-fill mechanism)
+  requested_response: In-vivo cooperativity measurement DOI + accessory-factor expression timing data
+  status: open
+  asked_to: TBD
+conclusion_logic:
+  if_primary_tests_pass:
+    implementation_status: "DnaA-box catalog + binding kinetics produce the expected titration \u2192 free DnaA rise pattern."
+    biological_validation: Reproduces Hansen 1991's titration prediction + Olivi 2025's measurements.
+    pipeline_unblocks:
+    - dnaa-04-initiation-mechanism
+  if_primary_tests_fail:
+    diagnose:
+    - 'Monotonic fail: binding kinetics may be too slow / too fast.'
+    - 'Two-step fail: high vs low KDs not separated enough.'
+    - 'Free-DnaA-rise fail: total DnaA pool too small (recheck dnaa-01 calibration).'
+    block_downstream: dnaa-04 mechanism needs working titration.
+limitations:
+- Equilibrium (or Gillespie) binding; ignores cooperativity between adjacent boxes.
+- "DnaAp box-specific occupancy (boxes 1, 2, b, c individually) not validated \u2014 only aggregate."
+- Single doubling time; box dynamics across multiple cycles untested.
+- IHF / Fis facilitation of low-affinity binding not modeled (dnaa-04 may add).
+implementation_requirements:
+- id: req-1-box-catalog
+  kind: reference_data
+  title: DnaA-box catalog (322 sites with affinity + form preference)
+  effort: M
+  description: 'Author v2ecoli/data/dnaa_box_catalog.tsv listing 307 chromosomal +
+
+    11 oriC + 4 dnaAp sites with columns: box_id, position, region,
+
+    affinity (high/low), bound_nucleotide_preference (atp/both).
+
+    Seed chromosome_structure.DnaA_boxes from this catalog.
+
+    '
+  steps:
+  - Extract 307 chromosomal positions from Olivi 2025 supplementary.
+  - "Annotate 11 oriC boxes (R1/R2/R4/R5M/\u03C42/I1-3/C1-3) per Katayama 2017."
+  - Annotate 4 dnaAp boxes per Speck 1999.
+  - 'Validate: counts match 307 / 3+8 / 2+2.'
+  unblocks:
+  - all dnaa-03 readouts and behavior_tests
+- id: req-2-binding-kinetics
+  kind: process
+  title: DnaA-box binding Process
+  effort: L
+  description: 'Process that each timestep updates DnaA_bound + bound_form on each
+
+    box using affinity-class KDs + free-DnaA pool. Form-aware so
+
+    dnaa-04''s fork-passage release returns the correct species.
+
+    '
+  steps:
+  - Create v2ecoli/processes/dnaa_box_binding.py.
+  - 'Composite param dnaA_box_binding_kd_nM: {high: 1.0, low: 100.0}.'
+  - Update DnaA_bound + bound_form on each box per timestep.
+  - Emit listeners.dnaA_binding.{chromosome,oric,dnaap,free_total}.
+  unblocks:
+  - all dnaa-03 readouts and behavior_tests
+  - dnaa-04 mechanism trigger
+- id: req-3-initial-pool-hook
+  kind: parameter_hook
+  title: initial_dnaA_count_per_cell override
+  effort: S
+  description: Composite-level override for the cell-birth DnaA pool.
+  unblocks:
+  - simulation_set.high-initial-dnaA
+- id: req-4-oric-toggle
+  kind: parameter_hook
+  title: enable_oric_binding toggle
+  effort: XS
+  description: Composite-level boolean to disable oriC + dnaAp binding (pure titration control).
+  unblocks:
+  - simulation_set.chromosomal-boxes-only
+bibliography:
+  expert:
+  - replication_initiation_molecular_info
+  bib_keys:
+  - Roth1998MolMicrobiol
+  - Olivi2025NatCommun
+  - Hansen1991ResMicrobiol
+  - Berger2022NatCommun
+  - Katayama2017Frontiers
+  - Kasho2023IJMS
+  - Leonard2015FrontMicrobiol
+  - Speck1999EMBO
+  - Saggioro2013BiochemJ
+  - Schaper1995JBC
+  - Hansen2006JMB
+parent_studies:
+- study: dnaa-fresh-02-atp-hydrolysis
+  condition: tests-passed
+tests:
+  auto_discover: true
+  data_source: latest_run
+  pytest_args: []
+  last_results: null

--- a/studies/dnaa-fresh-04-initiation-mechanism/study.yaml
+++ b/studies/dnaa-fresh-04-initiation-mechanism/study.yaml
@@ -1,0 +1,412 @@
+schema_version: 3
+status_overwritten: 2026-05-17T09:30Z
+name: dnaa-fresh-04-initiation-mechanism
+created: '2026-05-17'
+status: planning
+phase: Design
+baseline:
+- name: baseline-mechanism
+  composite: v2ecoli.composites.baseline_recipes.dnaa_04_with_dnaa_initiation_trigger
+  params:
+    seed: 0
+    cache_dir: out/cache
+    initiation_mode: dnaa_mechanism
+visualizations:
+- name: dnaa_state
+  address: local:DnaAStateVisualization
+  config:
+    title: "dnaa-04 \u2014 DnaA pool drives the new initiation trigger"
+    sample_every: 10
+- name: dnaa_box_occupancy
+  address: local:DnaABoxOccupancyVisualization
+  config:
+    title: "dnaa-04 \u2014 Box occupancy at oriC = trigger readout"
+    sample_every: 10
+purpose:
+  question: 'Can a DnaA-driven mechanistic initiation trigger (oriC fill + ATP-DnaA
+
+    filament + DUE opening) replace v2ecoli''s mass-threshold heuristic
+
+    and reproduce the observed initiation-mass distribution + 1/N
+
+    titration scaling?
+
+    '
+  mechanism: 'Add a new initiation Process gated by oriC occupancy from dnaa-03.
+
+    Toggle behind a composite param so heuristic-vs-mechanism can be
+
+    compared 1:1. Add fork-passage release of DnaA from chromosomal
+
+    boxes (returns the bound nucleotide form to free pool).
+
+    '
+  expected_outcome: "Mechanism reproduces heuristic's mean initiation mass within \xB15%\nacross seeds; one initiation per\
+    \ generation on average; inter-\ninitiation CV widens vs heuristic (no global trigger \u2192 more noise);\nbox-count reduction\
+    \ shortens inter-initiation time linearly.\n"
+pipeline_gate:
+  prerequisites:
+  - dnaa-fresh-03-box-binding
+  enables:
+  - dnaa-fresh-05-rida-ddah-dars
+  - dnaa-fresh-06-seqa-sequestration
+  gate_status: blocked
+  gate_status_summary: "Not yet started \u2014 investigation cloned in fresh planning state."
+  proceed_condition: 'one-initiation-per-generation + initiation-mass-mean-matches-heuristic
+
+    both pass. Replication-time CV is narrow (<0.10).
+
+    '
+simulation_set:
+- name: heuristic-vs-mechanism-multigeneration
+  base_model: v2ecoli.composites.baseline.baseline
+  perturbation:
+    kind: cross_baseline
+    runs:
+    - initiation_mode: heuristic
+    - initiation_mode: dnaa_mechanism
+  condition: M9-minimal-glucose
+  duration_min: 240
+  seeds:
+  - 0
+  - 1
+  - 2
+  - 3
+  - 4
+  - 5
+  - 6
+  - 7
+  readouts:
+  - initiation_events
+  - initiation_mass
+  - c_period_min
+  - time_between_initiations
+  applies_tests:
+  - one-initiation-per-generation
+  - initiation-mass-mean-matches-heuristic
+  - replication-times-narrow
+  - inter-initiation-noisier-than-heuristic
+  status: gated
+  blocked_by_requirements:
+  - req-1-mechanism-trigger
+  - req-2-fork-passage-release
+- name: growth-rate-sweep
+  base_model: v2ecoli.composites.baseline.baseline
+  perturbation:
+    media:
+    - M9_glucose
+    - baseline
+    - LB
+  condition: sweep
+  duration_min: 240
+  seeds:
+  - 0
+  - 1
+  - 2
+  - 3
+  readouts:
+  - initiation_mass
+  - initiation_events
+  applies_tests:
+  - fast-growth-earlier-replication
+  status: gated
+  blocked_by_requirements:
+  - req-1-mechanism-trigger
+  - req-2-fork-passage-release
+- name: box-count-titration
+  base_model: v2ecoli.composites.baseline.baseline
+  perturbation:
+    chromosomal_box_count:
+    - 50
+    - 100
+    - 200
+    - 307
+  condition: sweep
+  duration_min: 240
+  seeds:
+  - 0
+  - 1
+  - 2
+  - 3
+  - 4
+  readouts:
+  - time_between_initiations
+  - initiation_mass
+  applies_tests:
+  - reduced-box-count-shortens-inter-initiation
+  status: gated
+  blocked_by_requirements:
+  - req-3-box-count-override
+  - req-1-mechanism-trigger
+- name: box-distribution-shift
+  base_model: v2ecoli.composites.baseline.baseline
+  perturbation:
+    chromosomal_box_distribution:
+    - uniform
+    - oriC_clustered
+  condition: sweep
+  duration_min: 240
+  seeds:
+  - 0
+  - 1
+  - 2
+  - 3
+  - 4
+  readouts:
+  - initiation_mass
+  - time_between_initiations
+  applies_tests:
+  - redistributed-boxes-shifts-timing
+  status: gated
+  blocked_by_requirements:
+  - req-4-box-distribution-override
+model_change:
+  base_model: v2ecoli.composites.baseline.baseline
+  new_processes:
+  - name: DnaaInitiationMechanism
+    kind: Process
+    requirement_id: req-1-mechanism-trigger
+  new_parameters:
+  - name: initiation_mode
+    default: heuristic
+    type: heuristic | dnaa_mechanism
+  - name: chromosomal_box_count
+    default: null
+  - name: chromosomal_box_distribution
+    default: uniform
+  - name: media
+    default: M9_glucose
+  new_listeners:
+  - name: replication.initiation_events + initiation_mass + c_period_min + interinitiation_min
+  modified_processes:
+  - 'chromosome_initiation: gate by initiation_mode.'
+  - 'chromosome_replication: on fork passage, call DnaaBoxBinding to release bound DnaA (correct nucleotide form).'
+key_assumptions:
+- Slow non-overlapping growth (single C-period 40 min, single D-period).
+- "Initiation fires when \u22653 high-affinity + \u22654 low-affinity oriC boxes are DnaA-ATP-occupied."
+- Fork passage removes ALL DnaA from any chromosomal box it crosses; the bound form returns to free pool.
+- Replication speed is constant (no DnaA feedback).
+readouts:
+- name: initiation_events
+  store_path: agents.0.listeners.replication.initiation_events
+  units: events
+  status: derived-needed
+  blocked_by_requirements:
+  - req-1-mechanism-trigger
+- name: initiation_mass
+  store_path: agents.0.listeners.replication.initiation_mass
+  units: fg
+  status: derived-needed
+  blocked_by_requirements:
+  - req-1-mechanism-trigger
+- name: c_period_min
+  store_path: agents.0.listeners.replication.c_period_min
+  units: min
+  status: derived-needed
+- name: time_between_initiations
+  store_path: agents.0.listeners.replication.interinitiation_min
+  units: min
+  status: derived-needed
+behavior_tests:
+- name: one-initiation-per-generation
+  classification: primary
+  description: Exactly one initiation per generation (in [0.9, 1.1] events/gen).
+  measure:
+    kind: event_count_per_window
+    event: replication_initiation
+    window_kind: generation
+  pass_if:
+    op: in_range
+    low: 0.9
+    high: 1.1
+  units: events/generation
+  requires_simulation: heuristic-vs-mechanism-multigeneration
+  cites:
+  - Hansen1991ResMicrobiol
+  - Berger2022NatCommun
+  - Katayama2017Frontiers
+- name: initiation-mass-mean-matches-heuristic
+  classification: primary
+  description: "Mechanism initiation-mass mean within \xB15% of heuristic baseline."
+  measure:
+    kind: cross_run_ratio
+    series:
+      kind: listener_path
+      path: listeners.replication.initiation_mass
+    reduce: mean
+  pass_if:
+    op: in_range
+    low: 0.95
+    high: 1.05
+  units: ratio
+  requires_simulation: heuristic-vs-mechanism-multigeneration
+  cites:
+  - Berger2022NatCommun
+  - Hansen1991ResMicrobiol
+- name: replication-times-narrow
+  classification: supporting
+  description: C-period CV stays below 10%.
+  measure:
+    kind: cv_of_listener
+    path: listeners.replication.c_period_min
+  pass_if:
+    op: at_most
+    value: 0.1
+  units: fraction
+  requires_simulation: heuristic-vs-mechanism-multigeneration
+  cites:
+  - Katayama2017Frontiers
+- name: inter-initiation-noisier-than-heuristic
+  classification: supporting
+  description: "Inter-initiation CV ratio (mechanism / heuristic) \u2265 1.3 \u2014 mechanism is noisier."
+  measure:
+    kind: cross_run_cv_ratio
+    path: listeners.replication.interinitiation_min
+  pass_if:
+    op: at_least
+    value: 1.3
+  units: ratio
+  requires_simulation: heuristic-vs-mechanism-multigeneration
+  cites:
+  - Berger2023PRXLife
+  - Olivi2025NatCommun
+- name: fast-growth-earlier-replication
+  classification: diagnostic
+  description: "Fast-growth media \u2192 mean initiation mass \u2264 0.95\xD7 slow-growth."
+  measure:
+    kind: cross_run_ratio
+    series:
+      kind: listener_path
+      path: listeners.replication.initiation_mass
+    reduce: mean
+  pass_if:
+    op: at_most
+    value: 0.95
+  units: ratio
+  requires_simulation: growth-rate-sweep
+  cites:
+  - Mori2021MolSysBiol
+  - Hansen1991ResMicrobiol
+- name: reduced-box-count-shortens-inter-initiation
+  classification: diagnostic
+  description: "Halving chromosomal box count to 100 \u2192 inter-initiation time \u2264 0.5\xD7 full-count (1/N titration\
+    \ scaling)."
+  measure:
+    kind: cross_run_ratio
+    series:
+      kind: listener_path
+      path: listeners.replication.interinitiation_min
+    reduce: mean
+  pass_if:
+    op: at_most
+    value: 0.5
+  units: ratio
+  requires_simulation: box-count-titration
+  cites:
+  - Hansen1991ResMicrobiol
+  - Berger2022NatCommun
+  - Olivi2025NatCommun
+- name: redistributed-boxes-shifts-timing
+  classification: diagnostic
+  description: "oriC-clustered box distribution shifts mean initiation mass by \u226510% vs uniform."
+  measure:
+    kind: cross_run_ratio
+    series:
+      kind: listener_path
+      path: listeners.replication.initiation_mass
+    reduce: mean
+  pass_if:
+    op: outside_range
+    low: 0.9
+    high: 1.1
+  units: ratio
+  requires_simulation: box-distribution-shift
+  cites:
+  - Olivi2025NatCommun
+conclusion_logic:
+  if_primary_tests_pass:
+    implementation_status: DnaA-driven initiation mechanism matches the mass-threshold heuristic within tolerance.
+    biological_validation: Reproduces once-per-generation timing + titration scaling per Hansen 1991 / Berger 2022.
+    pipeline_unblocks:
+    - dnaa-05-rida-ddah-dars
+    - dnaa-06-seqa-sequestration
+  if_primary_tests_fail:
+    diagnose:
+    - 'Mass-mismatch: oriC fill threshold or DnaA-ATP filament size is wrong.'
+    - 'Multiple-per-gen or zero-per-gen: DnaA-box release on fork passage is broken.'
+    - 'Wide C-period: replisome elongation rate is sensitive to DnaA-box density (shouldn''t be).'
+    block_downstream: dnaa-05 + dnaa-06 require a working mechanism baseline.
+limitations:
+- Slow non-overlapping growth only; overlapping cycles (rich media, multi-fork) not validated.
+- Constant C-period assumed; replisome speed feedback not modeled.
+- Fork-passage release returns to free pool without distinguishing apo vs ATP vs ADP downstream effects.
+- "No SeqA sequestration (dnaa-06) \u2014 assumes oriC reset after initiation."
+implementation_requirements:
+- id: req-1-mechanism-trigger
+  kind: process
+  title: DnaaInitiationMechanism Process
+  effort: L
+  description: "Replace mass-threshold heuristic with: trigger when \u22653 high-affinity\n+ \u22654 low-affinity oriC boxes\
+    \ are DnaA-ATP-occupied. Gate behind\ncomposite param initiation_mode.\n"
+  steps:
+  - 'Composite param initiation_mode: ''heuristic'' | ''dnaa_mechanism'' = ''heuristic''.'
+  - Create v2ecoli/processes/dnaa_initiation.py.
+  - 'Hook into chromosome_initiation: dispatch on initiation_mode.'
+  - 'Multi-seed test: mass distribution overlaps heuristic baseline within 5%.'
+  unblocks:
+  - all dnaa-04 behavior_tests
+  - dnaa-05
+  - dnaa-06
+- id: req-2-fork-passage-release
+  kind: step
+  title: Fork-passage DnaA release + rebinding
+  effort: M
+  description: 'Each timestep, where replisomes advance, set DnaA_bound = False on
+
+    crossed boxes and return the bound nucleotide-form to the free pool.
+
+    After fork passage, newly synthesized boxes appear with empty
+
+    occupancy.
+
+    '
+  steps:
+  - Hook into chromosome_replication's fork-advance step.
+  - On fork-cross-box, increment free-DnaA-<form> bulk count by 1.
+  - 'Validate: multi-generation runs show stable DnaA pool + correct daughter inheritance.'
+  unblocks:
+  - primary + supporting tests in dnaa-04
+- id: req-3-box-count-override
+  kind: parameter_hook
+  title: chromosomal_box_count override
+  effort: S
+  description: Composite-level int that subsamples the box catalog before binding.
+  unblocks:
+  - box-count-titration simulation
+  - reduced-box-count-shortens-inter-initiation test
+- id: req-4-box-distribution-override
+  kind: parameter_hook
+  title: chromosomal_box_distribution override
+  effort: S
+  description: "'uniform' or 'oriC_clustered' \u2014 controls how the box catalog is sampled."
+  unblocks:
+  - box-distribution-shift simulation
+bibliography:
+  expert:
+  - replication_initiation_molecular_info
+  bib_keys:
+  - Olivi2025NatCommun
+  - Katayama2017Frontiers
+  - Leonard2015FrontMicrobiol
+  - Hansen1991ResMicrobiol
+  - Berger2022NatCommun
+  - Berger2023PRXLife
+  - Mori2021MolSysBiol
+parent_studies:
+- study: dnaa-fresh-03-box-binding
+  condition: tests-passed
+tests:
+  auto_discover: true
+  data_source: latest_run
+  pytest_args: []
+  last_results: null

--- a/studies/dnaa-fresh-05-rida-ddah-dars/study.yaml
+++ b/studies/dnaa-fresh-05-rida-ddah-dars/study.yaml
@@ -1,0 +1,444 @@
+schema_version: 3
+name: dnaa-fresh-05-rida-ddah-dars
+created: '2026-05-17'
+status: planning
+phase: Design
+baseline:
+- name: baseline-extrinsic
+  composite: v2ecoli.composites.baseline_recipes.dnaa_05_full_nucleotide_cycle
+  params:
+    seed: 0
+    cache_dir: out/cache
+visualizations:
+- name: dnaa_state
+  address: local:DnaAStateVisualization
+  config:
+    title: "dnaa-05 \u2014 DnaA-ATP/ADP cycle with RIDA/DDAH/DARS contributions"
+    sample_every: 10
+purpose:
+  question: 'Does adding the three extrinsic DnaA-ATP/ADP conversion pathways
+
+    (RIDA replisome-coupled hydrolysis, DDAH datA-dependent hydrolysis,
+
+    DARS1/DARS2 reactivation) produce DnaA-ATP-fraction oscillations
+
+    through the cell cycle and tighten the inter-initiation timing
+
+    distribution vs intrinsic-only (dnaa-02)?
+
+    '
+  mechanism: "Add three new Processes: RIDA (rate \u221D replisome count), DDAH\n(rate \u221D datA copy number), DARS1 + DARS2\
+    \ (rate \u221D each locus's\ncopy number). Each modulates the existing DnaA-ATP / ADP species\nintroduced in dnaa-02.\n"
+  expected_outcome: "Cell-cycle ATP-fraction swing of \u22650.15 peak-to-trough. Inter-\ninitiation CV narrows by \u226530%\
+    \ vs the dnaa-02 intrinsic-only\nbaseline. Single-knockout phenotypes: no-DDAH = earlier initiation,\nno-DARS = ATP-fraction\
+    \ fails to recover.\n"
+pipeline_gate:
+  prerequisites:
+  - dnaa-fresh-02-atp-hydrolysis
+  - dnaa-fresh-04-initiation-mechanism
+  enables: []
+  gate_status: blocked
+  gate_status_summary: "Not yet started \u2014 investigation cloned in fresh planning state."
+  proceed_condition: 'Primary tests pass. dnaa-04 already has a working mechanism baseline
+
+    that this can compare against.
+
+    '
+simulation_set:
+- name: full-cycle-with-extrinsic
+  base_model: v2ecoli.composites.baseline.baseline
+  perturbation: null
+  condition: M9-minimal-glucose
+  duration_min: 240
+  seeds:
+  - 0
+  - 1
+  - 2
+  - 3
+  - 4
+  - 5
+  readouts:
+  - dnaA_atp_fraction
+  - rida_flux
+  - ddah_flux
+  - dars1_flux
+  - dars2_flux
+  - replisome_count
+  - initiation_events
+  applies_tests:
+  - dnaa-atp-fraction-oscillates
+  - inter-initiation-cv-narrows-vs-intrinsic-only
+  - dnaa-atp-anti-correlated-with-replisomes
+  status: gated
+  blocked_by_requirements:
+  - req-1-rida
+  - req-2-ddah
+  - req-3-dars
+- name: knockout-DDAH
+  base_model: v2ecoli.composites.baseline.baseline
+  perturbation:
+    ddah_rate_per_min_per_data: 0.0
+  condition: M9-minimal-glucose
+  duration_min: 240
+  seeds:
+  - 0
+  - 1
+  - 2
+  - 3
+  - 4
+  readouts:
+  - initiation_mass
+  - dnaA_atp_fraction
+  - ddah_flux
+  applies_tests:
+  - no-DDAH-early-initiation
+  status: gated
+  blocked_by_requirements:
+  - req-2-ddah
+- name: knockout-DARS
+  base_model: v2ecoli.composites.baseline.baseline
+  perturbation:
+    dars1_rate_per_min_per_locus: 0.0
+    dars2_rate_per_min_per_locus: 0.0
+  condition: M9-minimal-glucose
+  duration_min: 240
+  seeds:
+  - 0
+  - 1
+  - 2
+  readouts:
+  - dnaA_atp_fraction
+  - dars1_flux
+  - dars2_flux
+  applies_tests:
+  - no-DARS-fails-to-recover-atp
+  status: gated
+  blocked_by_requirements:
+  - req-3-dars
+- name: single-pathway-knockouts-comparison
+  base_model: v2ecoli.composites.baseline.baseline
+  perturbation:
+    sweep:
+    - rida_rate_per_min_per_fork: 0.0
+    - dars1_rate_per_min_per_locus: 0.0
+    - dars2_rate_per_min_per_locus: 0.0
+  condition: sweep
+  duration_min: 240
+  seeds:
+  - 0
+  - 1
+  - 2
+  readouts:
+  - dnaA_atp_fraction
+  - rida_flux
+  - dars1_flux
+  - dars2_flux
+  applies_tests: []
+  status: gated
+  blocked_by_requirements:
+  - req-1-rida
+  - req-3-dars
+model_change:
+  base_model: v2ecoli.composites.baseline.baseline
+  new_processes:
+  - name: DnaaRIDA
+    kind: Step
+    requirement_id: req-1-rida
+  - name: DnaaDDAH
+    kind: Step
+    requirement_id: req-2-ddah
+  - name: DnaaDARS1
+    kind: Step
+    requirement_id: req-3-dars
+  - name: DnaaDARS2
+    kind: Step
+    requirement_id: req-3-dars
+  new_parameters:
+  - name: rida_rate_per_min_per_fork
+  - name: ddah_rate_per_min_per_data
+  - name: dars1_rate_per_min_per_locus
+  - name: dars2_rate_per_min_per_locus
+  new_listeners:
+  - name: dnaA_cycle
+    emits:
+    - listeners.dnaA_cycle.{rida_flux,ddah_flux,dars1_flux,dars2_flux}
+key_assumptions:
+- "RIDA activity \u221D replisome count (\u03B2-clamp residence on lagging strand)."
+- "DDAH activity \u221D datA copy number; IHF saturating (not rate-limiting)."
+- DARS1 < DARS2 in vivo (Kasho 2014 NAR).
+- DARS2 IHF + Fis cell-cycle modulation modeled as continuous rate modifier (not a hard gate).
+readouts:
+- name: dnaA_atp_fraction
+  store_path: agents.0.listeners.dnaA_cycle.atp_fraction
+  units: fraction
+  status: derived-needed
+- name: rida_flux
+  store_path: agents.0.listeners.dnaA_cycle.rida_flux
+  units: molecules/min
+  status: derived-needed
+  blocked_by_requirements:
+  - req-1-rida
+- name: ddah_flux
+  store_path: agents.0.listeners.dnaA_cycle.ddah_flux
+  units: molecules/min
+  status: derived-needed
+  blocked_by_requirements:
+  - req-2-ddah
+- name: dars1_flux
+  store_path: agents.0.listeners.dnaA_cycle.dars1_flux
+  units: molecules/min
+  status: derived-needed
+  blocked_by_requirements:
+  - req-3-dars
+- name: dars2_flux
+  store_path: agents.0.listeners.dnaA_cycle.dars2_flux
+  units: molecules/min
+  status: derived-needed
+  blocked_by_requirements:
+  - req-3-dars
+- name: replisome_count
+  store_path: agents.0.listeners.replication.replisome_count
+  units: forks/cell
+  status: available
+- name: initiation_events
+  store_path: agents.0.listeners.replication.initiation_events
+  units: events
+  status: derived-needed
+behavior_tests:
+- name: dnaa-atp-fraction-oscillates
+  classification: primary
+  description: "Peak-to-trough swing of DnaA-ATP fraction \u2265 0.15 across the cycle."
+  measure:
+    kind: listener_path
+    path: listeners.dnaA_cycle.atp_fraction
+    reduce: series
+    window: full
+  pass_if:
+    op: oscillation_amplitude_at_least
+    value: 0.15
+  units: fraction
+  requires_simulation: full-cycle-with-extrinsic
+  cites:
+  - Katayama2017Frontiers
+  - Riber2016FrontMolBiosci
+  - Boesen2024PNAS
+- name: inter-initiation-cv-narrows-vs-intrinsic-only
+  classification: primary
+  description: "Inter-initiation timing CV \u2264 70% of the dnaa-02 intrinsic-only baseline."
+  measure:
+    kind: cross_run_cv_ratio
+    path: listeners.replication.interinitiation_min
+    compare_to: dnaa-02-baseline
+  pass_if:
+    op: at_most
+    value: 0.7
+  units: ratio
+  requires_simulation: full-cycle-with-extrinsic
+  cites:
+  - Riber2016FrontMolBiosci
+  - Berger2022NatCommun
+- name: dnaa-atp-anti-correlated-with-replisomes
+  classification: supporting
+  description: "During active replication, DnaA-ATP and replisome count Pearson r \u2264 -0.3 (RIDA signature)."
+  measure:
+    kind: xy_correlation
+    x:
+      kind: listener_path
+      path: listeners.dnaA_cycle.atp_fraction
+    y:
+      kind: listener_path
+      path: listeners.replication.replisome_count
+    window: replication_active
+  pass_if:
+    op: pearson_at_most
+    threshold: -0.3
+  units: dimensionless r
+  requires_simulation: full-cycle-with-extrinsic
+  cites:
+  - Katayama2017Frontiers
+  - Riber2016FrontMolBiosci
+- name: no-DDAH-early-initiation
+  classification: diagnostic
+  description: "Knock out DDAH \u2192 mean initiation mass drops \u2265 10% (delta-datA phenotype)."
+  measure:
+    kind: cross_run_ratio
+    series:
+      kind: listener_path
+      path: listeners.replication.initiation_mass
+    reduce: mean
+  pass_if:
+    op: at_most
+    value: 0.9
+  units: ratio
+  requires_simulation: knockout-DDAH
+  cites:
+  - Katayama2017Frontiers
+  - Hansen2018DnaATale
+- name: no-DARS-fails-to-recover-atp
+  classification: diagnostic
+  description: Post-initiation, DnaA-ATP fraction drops below 0.05 and doesn't recover.
+  measure:
+    kind: listener_path
+    path: listeners.dnaA_cycle.atp_fraction
+    reduce: post_event_min
+    event: replication_initiation
+    window: full
+  pass_if:
+    op: at_most
+    value: 0.05
+  units: fraction
+  requires_simulation: knockout-DARS
+  cites:
+  - Fujimitsu2009GenesDev
+  - Kasho2014NAR
+abstraction_level:
+  name: extrinsic conversion via RIDA + DDAH + DARS (per-pathway, not implemented yet)
+  resolves:
+  - spatial coupling of hydrolysis to active replisomes (RIDA)
+  - datA-localized hydrolysis pulses (DDAH)
+  - site-specific ATP reactivation (DARS1, DARS2)
+  does_not_resolve:
+  - molecular details of HdaA / IscR engagement
+  - RIDA fork-passage release kinetics
+  - whether DARS sites bind DnaA before or after Dam re-methylation
+conclusion_verdicts:
+  regression_compatibility:
+    result: PENDING
+    basis: "No runs yet \u2014 investigation cloned in fresh planning state."
+  biological_validation:
+    result: PENDING
+    basis: "No runs yet \u2014 investigation cloned in fresh planning state."
+    blocking_evidence_needed:
+    - RIDA Step implementation + replisome-coupling test
+    - DDAH Step + datA-localized binding
+    - DARS1/DARS2 Steps + ATP-reactivation cycle
+    - Per-pathway-knockout perturbation_panel
+  explanatory_gain:
+    result: PENDING
+    basis: "No runs yet \u2014 investigation cloned in fresh planning state."
+expert_decisions_needed:
+- id: dnaa-05-EQ-01
+  question: "Is v2ecoli's equilibrium reverse-rate constant (MONOMER0-160_RXN, 2.9e-8) correctly calibrated? If too high,\
+    \ RIDA/DDAH/DARS may not need to deliver the 100\xD7 extrinsic flux that dnaa-02 F-04 implies."
+  alternatives:
+  - "Reverse-rate correct: dnaa-05 must deliver ~99\xD7 the Boesen intrinsic rate via RIDA+DDAH+DARS"
+  - "Reverse-rate over-estimated by ~10\xD7: RIDA+DDAH+DARS deliver ~10\xD7 intrinsic (closer to literature per-pathway estimates)"
+  - "Reverse-rate over-estimated by ~100\xD7: extrinsic delivery only needs to match intrinsic \u2014 pathways are validation,\
+    \ not absolute-rate makers"
+  impact_if_wrong: Determines whether dnaa-05 design needs aggressive flux from each pathway (case 1) or modest contributions
+    (case 3). Affects per-Step rate parameters by an order of magnitude.
+  blocks:
+  - dnaa-05 per-Step rate calibration
+  - dnaa-02 F-04 reinterpretation
+  requested_response: ParCa rate-constant authority + cross-check against in-vivo total flux estimates (Boesen 2024 supplementary?)
+  status: open
+  asked_to: TBD
+  related_to: dnaa-02-EQ-01
+- id: dnaa-05-EQ-02
+  question: Should DARS1 and DARS2 sites also bind DnaA-ADP before re-activation, or do they catalyze nucleotide exchange
+    on already-bound DnaA?
+  alternatives:
+  - "Bind DnaA-ADP then reactivate: DARS is a sink + source \u2014 converts bound ADP to bound ATP without releasing"
+  - 'Catalyze in-situ exchange: DnaA stays bound, nucleotide swaps via DARS contact'
+  - 'Mixed: DARS1 vs DARS2 differ (paper-dependent)'
+  impact_if_wrong: Determines whether DARS pulls from the DNA-bound or free DnaA-ADP pool. Affects Step topology (which port
+    reads from which bulk species).
+  blocks:
+  - dnaa-05 DARS1 / DARS2 Step design
+  requested_response: Kasho 2023 IJMS or Frimodt-Moller author + figure pointer
+  status: open
+  asked_to: TBD
+- id: dnaa-05-EQ-03
+  question: "RIDA is replisome-coupled \u2014 but how does its activity scale with fork PROGRESS vs fork PRESENCE? Linear\
+    \ in elongation rate, or step-function at initiation/termination?"
+  alternatives:
+  - Linear in fork-elongation rate (per-nt scaling)
+  - Step-function ON at initiation, OFF at termination (per-fork constant)
+  - Step-function at specific fork-coordinate windows (e.g., near oriC)
+  impact_if_wrong: 'Affects RIDA rate modeling. Linear case: rate = k_per_nt * d(fork_coord)/dt. Step case: rate = k_per_fork
+    * n_active_forks.'
+  blocks:
+  - dnaa-05 RIDA Step rate-law choice
+  requested_response: Kawakami 2006 + Katayama review specifics
+  status: open
+  asked_to: TBD
+conclusion_logic:
+  if_primary_tests_pass:
+    implementation_status: Full DnaA cycle (RIDA + DDAH + DARS) is functional; ATP-fraction oscillates with the cell cycle.
+    biological_validation: Reproduces Katayama 2017's cycle picture + Riber 2016's narrowing-CV prediction.
+    pipeline_unblocks:
+    - Investigation completion (dnaa-05 is a leaf in the main chain).
+  if_primary_tests_fail:
+    diagnose:
+    - "No oscillation: pathway rates wrong or all balance out \u2014 check rida_flux vs dars2_flux time series."
+    - 'CV doesn''t narrow: dnaa-02 intrinsic-only baseline may already be tightly bounded for the wrong reason (e.g., box-saturation
+      noise dominates).'
+    - 'RIDA anti-correlation absent: RIDA rate too slow or replisome count too small.'
+    block_downstream: Investigation acceptance criterion 'inter-initiation-cv-narrows-vs-intrinsic-only' requires this.
+limitations:
+- Hda complex modeled as part of RIDA rate; not tracked as separate molecular species.
+- "IHF saturating assumption \u2014 at very high DnaA-ATP, DDAH could be IHF-limited."
+- DARS2 IHF + Fis cell-cycle modulation is a continuous modifier, not a hard cell-cycle gate.
+- Slow growth only; multi-fork (rich-media) regime not validated.
+implementation_requirements:
+- id: req-1-rida
+  kind: process
+  title: DnaaRIDA Step (replisome-coupled hydrolysis)
+  effort: M
+  description: "Step reading listeners.replication.replisome_count + DnaA-ATP count;\napplies hydrolysis flux \u221D fork\
+    \ count.\n"
+  steps:
+  - Create v2ecoli/processes/dnaa_rida.py.
+  - 'Composite param rida_rate_per_min_per_fork: float (tune to literature).'
+  - Wire after intrinsic hydrolysis Step (from dnaa-02).
+  - "Validate: no-RIDA \u2192 DnaA-ATP doesn't drop during C-period."
+  unblocks:
+  - simulation_set.full-cycle-with-extrinsic
+  - dnaa-atp-fraction-oscillates, dnaa-atp-anti-correlated-with-replisomes
+- id: req-2-ddah
+  kind: process
+  title: DnaaDDAH Step (datA-dependent hydrolysis)
+  effort: M
+  description: "Step reading datA copy number from chromosome_structure +\nDnaA-ATP count; applies hydrolysis flux \u221D\
+    \ datA copy count.\n"
+  steps:
+  - Catalog datA position (~94.7 min, 4.39 Mbp).
+  - Read copy number from unique.gene where gene_id='datA'.
+  - 'Composite param ddah_rate_per_min_per_data: float.'
+  - "Validate: no-DDAH \u2192 earlier initiation."
+  unblocks:
+  - no-DDAH-early-initiation
+- id: req-3-dars
+  kind: process
+  title: DnaaDARS1 + DnaaDARS2 Steps (ADP-DnaA reactivation)
+  effort: M
+  description: "Two Steps reading copy_number_<dars1|dars2> + DnaA-ADP count.\nConvert DnaA-ADP \u2192 apo-DnaA, which re-binds\
+    \ ATP via the existing\nnucleotide-binding equilibrium.\n"
+  steps:
+  - Catalog DARS1, DARS2 positions on the chromosome.
+  - Composite params dars1_rate_per_min_per_locus, dars2_rate_per_min_per_locus.
+  - 'Optionally: DARS2 IHF + Fis modifier (cell-cycle phase function).'
+  unblocks:
+  - no-DARS-fails-to-recover-atp
+bibliography:
+  expert:
+  - replication_initiation_molecular_info
+  bib_keys:
+  - Katayama2017Frontiers
+  - Hansen2018DnaATale
+  - Riber2016FrontMolBiosci
+  - Fujimitsu2009GenesDev
+  - Kasho2014NAR
+  - Boesen2024PNAS
+  - Berger2022NatCommun
+conclusion_phase_decide_at: 2026-05-17T09:35Z
+parent_studies:
+- study: dnaa-fresh-02-atp-hydrolysis
+  condition: tests-passed
+- study: dnaa-fresh-04-initiation-mechanism
+  condition: ran
+tests:
+  auto_discover: true
+  data_source: latest_run
+  pytest_args: []
+  last_results: null

--- a/studies/dnaa-fresh-06-seqa-sequestration/study.yaml
+++ b/studies/dnaa-fresh-06-seqa-sequestration/study.yaml
@@ -1,0 +1,408 @@
+schema_version: 3
+name: dnaa-fresh-06-seqa-sequestration
+created: '2026-05-17'
+status: planning
+phase: Design
+baseline:
+- name: baseline-with-seqa
+  composite: v2ecoli.composites.baseline_recipes.dnaa_06_with_seqa_sequestration
+  params:
+    seed: 0
+    cache_dir: out/cache
+visualizations:
+- name: dnaa_state
+  address: local:DnaAStateVisualization
+  config:
+    title: "dnaa-06 \u2014 DnaA pool stability under SeqA sequestration window"
+    sample_every: 10
+- name: dnaa_box_occupancy
+  address: local:DnaABoxOccupancyVisualization
+  config:
+    title: "dnaa-06 \u2014 oriC box occupancy + sequestration state"
+    sample_every: 10
+purpose:
+  question: 'Does SeqA sequestration of newly replicated, hemimethylated oriC
+
+    (~10 min window) prevent reinitiation within the same cell cycle,
+
+    and does it buffer the dnaA-promoter transient activity spike from
+
+    locus duplication?
+
+    '
+  mechanism: 'Track GATC methylation state at oriC + dnaAp (full / hemi / un).
+
+    On replication-fork passage set affected GATC sites to hemi; Dam
+
+    re-methylates over time. Add a SeqA Process that flags oriC /
+
+    dnaAp as sequestered when local hemimethylation density crosses a
+
+    threshold; block DnaA box binding (from dnaa-03) at sequestered loci.
+
+    '
+  expected_outcome: "Wildtype: exactly one initiation per generation; SeqA-bound at oriC\nfor ~10 min post-initiation. no-SeqA\
+    \ knockout: \u22651.5 init/gen\n(premature reinitiation). dnaAp transient activity spike dampened\nby \u226540% with SeqA\
+    \ active.\n"
+pipeline_gate:
+  prerequisites:
+  - dnaa-fresh-04-initiation-mechanism
+  enables: []
+  gate_status: blocked
+  gate_status_summary: "Not yet started \u2014 investigation cloned in fresh planning state."
+  proceed_condition: 'Primary tests pass; SeqA window length matches literature
+
+    (8-12 min); no-SeqA variant produces reinitiation.
+
+    '
+simulation_set:
+- name: wildtype-sequestration-window
+  base_model: v2ecoli.composites.baseline.baseline
+  perturbation: null
+  condition: M9-minimal-glucose
+  duration_min: 120
+  seeds:
+  - 0
+  - 1
+  - 2
+  - 3
+  - 4
+  readouts:
+  - oric_sequestered
+  - oric_hemimethylated_fraction
+  - initiation_events
+  applies_tests:
+  - seqa-sequestration-lasts-10-minutes
+  - wildtype-one-initiation-per-generation
+  status: gated
+  blocked_by_requirements:
+  - req-1-methylation-state
+  - req-2-seqa-process
+- name: seqa-knockout
+  base_model: v2ecoli.composites.baseline.baseline
+  perturbation:
+    seqa_active: false
+  condition: M9-minimal-glucose
+  duration_min: 120
+  seeds:
+  - 0
+  - 1
+  - 2
+  - 3
+  - 4
+  - 5
+  readouts:
+  - initiation_events
+  - dnaap_sequestered
+  - dnaA_tx_init_events
+  applies_tests:
+  - no-seqa-causes-reinitiation
+  - dnaap-sequestration-dampens-tx-spike
+  status: gated
+  blocked_by_requirements:
+  - req-2-seqa-process
+- name: extended-sequestration
+  base_model: v2ecoli.composites.baseline.baseline
+  perturbation:
+    seqa_sequestration_min: 20.0
+  condition: M9-minimal-glucose
+  duration_min: 180
+  seeds:
+  - 0
+  - 1
+  - 2
+  - 3
+  readouts:
+  - oric_sequestered
+  - initiation_events
+  - time_between_initiations
+  applies_tests:
+  - long-sequestration-delays-reinitiation
+  status: gated
+  blocked_by_requirements:
+  - req-2-seqa-process
+model_change:
+  base_model: v2ecoli.composites.baseline.baseline
+  new_state_variables:
+  - GATC methylation state per site (in unique.GATC or as attribute on existing chromosome_segment)
+  new_processes:
+  - name: DamMethylation
+    kind: Step
+    requirement_id: req-1-methylation-state
+  - name: SeqaSequestration
+    kind: Process
+    requirement_id: req-2-seqa-process
+  new_parameters:
+  - name: seqa_active
+    default: true
+  - name: seqa_sequestration_min
+    default: 10.0
+  - name: dam_remethylation_rate_per_min
+  new_listeners:
+  - name: seqa
+    emits:
+    - listeners.seqa.{oric_sequestered_bool, dnaap_sequestered_bool, oric_hemimethylated_fraction}
+  modified_processes:
+  - 'chromosome_replication: on fork-cross-GATC, set daughter strand to hemi-methylated.'
+  - 'DnaaBoxBinding (from dnaa-03): block binding at sequestered loci.'
+key_assumptions:
+- Dam methylates GATC adenines on both strands; post-replication oriC is transiently hemimethylated.
+- SeqA binds hemimethylated GATC clusters cooperatively; binds >10 sites near oriC.
+- Sequestration window ~10 min (~1/3 of doubling at rapid growth).
+- SeqA at dnaAp transiently buffers gene-dosage doubling of dnaA transcription.
+readouts:
+- name: oric_sequestered
+  store_path: agents.0.listeners.seqa.oric_sequestered_bool
+  units: bool
+  status: derived-needed
+  blocked_by_requirements:
+  - req-2-seqa-process
+- name: oric_hemimethylated_fraction
+  store_path: agents.0.listeners.seqa.oric_hemimethylated_fraction
+  units: fraction
+  status: derived-needed
+  blocked_by_requirements:
+  - req-1-methylation-state
+- name: dnaap_sequestered
+  store_path: agents.0.listeners.seqa.dnaap_sequestered_bool
+  units: bool
+  status: derived-needed
+  blocked_by_requirements:
+  - req-3-dnaap-listener
+- name: initiation_events
+  store_path: agents.0.listeners.replication.initiation_events
+  units: events
+  status: derived-needed
+- name: time_between_initiations
+  store_path: agents.0.listeners.replication.interinitiation_min
+  units: min
+  status: derived-needed
+- name: dnaA_tx_init_events
+  store_path: agents.0.listeners.rnap_data.rna_init_event
+  index_by:
+    type: tu_id
+    value: EG10235_RNA
+  units: events/step
+  status: available
+behavior_tests:
+- name: seqa-sequestration-lasts-10-minutes
+  classification: primary
+  description: Post-initiation, oriC stays SeqA-sequestered for 8-12 min.
+  measure:
+    kind: event_duration
+    event_start: oriC_sequestered_true
+    event_end: oriC_sequestered_false
+    reduce: median
+    window: post_initiation_30min
+  pass_if:
+    op: in_range
+    low: 480.0
+    high: 720.0
+  units: seconds
+  requires_simulation: wildtype-sequestration-window
+  cites:
+  - Katayama2017Frontiers
+  - Leonard2015FrontMicrobiol
+- name: wildtype-one-initiation-per-generation
+  classification: primary
+  description: With SeqA active, exactly one initiation per cell cycle.
+  measure:
+    kind: event_count_per_window
+    event: replication_initiation
+    window_kind: generation
+  pass_if:
+    op: in_range
+    low: 0.95
+    high: 1.05
+  units: events/generation
+  requires_simulation: wildtype-sequestration-window
+  cites:
+  - Katayama2017Frontiers
+  - Hansen1991ResMicrobiol
+- name: no-seqa-causes-reinitiation
+  classification: primary
+  description: "Without SeqA, \u22651.5 init/generation (premature reinitiation)."
+  measure:
+    kind: event_count_per_window
+    event: replication_initiation
+    window_kind: generation
+  pass_if:
+    op: at_least
+    value: 1.5
+  units: events/generation
+  requires_simulation: seqa-knockout
+  cites:
+  - Katayama2017Frontiers
+  - Leonard2015FrontMicrobiol
+- name: dnaap-sequestration-dampens-tx-spike
+  classification: diagnostic
+  description: "no-SeqA / WT ratio of peak dnaA tx-init rate post-initiation \u2265 1.4\xD7 (SeqA dampens by \u226540%)."
+  measure:
+    kind: cross_run_ratio
+    series:
+      kind: listener_sum
+      path: listeners.rnap_data.rna_init_event
+    reduce: max
+    window: post_initiation_10min
+  pass_if:
+    op: at_least
+    value: 1.4
+  units: ratio
+  requires_simulation: seqa-knockout
+  cites:
+  - Speck1999EMBO
+  - Saggioro2013BiochemJ
+- name: long-sequestration-delays-reinitiation
+  classification: diagnostic
+  description: "Long-sequestration variant delays mean inter-initiation by \u226510 min vs baseline."
+  measure:
+    kind: cross_run_delta
+    series:
+      kind: listener_path
+      path: listeners.replication.interinitiation_min
+    reduce: mean
+  pass_if:
+    op: at_least
+    value: 10.0
+  units: minutes
+  requires_simulation: extended-sequestration
+  cites:
+  - Katayama2017Frontiers
+  - Leonard2015FrontMicrobiol
+abstraction_level:
+  versions:
+  - name: seqa_v0_fixed_timer
+    resolves:
+    - one-initiation-per-generation gate (10-min lockout window)
+    does_not_resolve:
+    - why 10 min
+    - methylation kinetics
+    - cooperative binding
+  - name: seqa_v1_methylation_state
+    resolves:
+    - Dam re-methylation kinetics, SeqA binding to hemimethylated GATC
+    does_not_resolve:
+    - cooperative SeqA-Dam dynamics
+  - name: seqa_v2_cooperative_seqa_dam
+    resolves:
+    - full SeqA-Dam mutual regulation
+    does_not_resolve:
+    - inter-strain SeqA binding-energy variation
+  current_implementation: not_yet_implemented
+conclusion_verdicts:
+  regression_compatibility:
+    result: PENDING
+    basis: "No runs yet \u2014 investigation cloned in fresh planning state."
+  biological_validation:
+    result: PENDING
+    basis: "No runs yet \u2014 investigation cloned in fresh planning state."
+    blocking_evidence_needed:
+    - SeqASequestration Step implementation + oriC schema extension
+    - seqA-knockout perturbation showing reinitiation events
+    - time-since-initiation distribution matching Lu1994 / Kang2003 ~10-min window
+  explanatory_gain:
+    result: PENDING
+    basis: "No runs yet \u2014 investigation cloned in fresh planning state."
+expert_decisions_needed:
+- id: dnaa-06-EQ-01
+  question: 'What sets the ~10-minute sequestration window length in vivo: SeqA dissociation kinetics, Dam re-methylation
+    kinetics, or competitive DNA binding?'
+  alternatives:
+  - "SeqA dissociation rate-limiting: window \u2248 1 / k_off(SeqA). v0 fixed timer is a fine approximation."
+  - "Dam re-methylation rate-limiting: window \u2248 time for Dam to re-methylate the cluster. v1 methylation model required\
+    \ to capture."
+  - 'Competitive DNA binding: window depends on SeqA pool size + chromosomal GATC site distribution. v2 cooperative model
+    required.'
+  impact_if_wrong: Determines whether v0 (fixed timer) is sufficient or v1/v2 required. Affects scope of dnaa-06 implementation.
+  blocks:
+  - dnaa-06 implementation version choice (v0 / v1 / v2)
+  requested_response: Lu 1994 + Kang 2003 rate-limiting analysis; ideally an in-vivo time-resolved measurement
+  status: open
+  asked_to: TBD
+- id: dnaa-06-EQ-02
+  question: Does SeqA sequester ONLY oriC, or also the dnaAp promoter region (which has GATC sites)? If both, does dnaA expression
+    also drop during the SeqA window?
+  alternatives:
+  - 'Only oriC: dnaa expression continues during the window'
+  - 'oriC + dnaAp: dnaa transcription is silenced during the window'
+  - 'oriC + dnaAp + datA: maximum effect; window also affects DDAH dynamics (dnaa-05 interaction)'
+  impact_if_wrong: Cross-couples to dnaa-01 (autorepression dynamics if dnaAp is bound) and dnaa-05 (DDAH dynamics if datA
+    is bound).
+  blocks:
+  - dnaa-06 oriC.sequestered_until vs dnaAp.sequestered_until schema choice
+  requested_response: Hansen 2018 review + specific SeqA-binding-site catalog citations
+  status: open
+  asked_to: TBD
+conclusion_logic:
+  if_primary_tests_pass:
+    implementation_status: SeqA sequestration prevents reinitiation in v2ecoli.
+    biological_validation: "Reproduces ~10-min window + once-per-generation prediction; no-SeqA phenotype matches \u0394seqA\
+      \ reinitiation observations."
+    pipeline_unblocks:
+    - Investigation acceptance criterion wildtype-zero-reinitiation.
+  if_primary_tests_fail:
+    diagnose:
+    - 'Window too long/short: Dam re-methylation rate is wrong, or SeqA cooperativity threshold mistuned.'
+    - 'no-SeqA WITHOUT reinitiation: the binding-prevention hook isn''t wired into dnaa-03''s box binding correctly.'
+    - 'WT > 1 init/gen: SeqA isn''t actually blocking dnaa-04''s mechanism trigger.'
+limitations:
+- SeqA modeled as a binary sequestered/free state on oriC + dnaAp; doesn't track individual SeqA multimers.
+- Dam re-methylation rate is a single global parameter, not site-specific.
+- Only oriC + dnaAp; other GATC-rich loci (e.g., other promoters) ignored.
+- Slow growth only; rapid-growth regime (where sequestration is ~1/3 of doubling) not validated.
+implementation_requirements:
+- id: req-1-methylation-state
+  kind: state_variables
+  title: GATC methylation state tracking
+  effort: S
+  description: "Add a methylation_state \u2208 {fully, hemi-top, hemi-bottom, un} attribute\non GATC sites in chromosome_structure\
+    \ (or a new unique.GATC). Add\nDam re-methylation Step with rate dam_remethylation_rate_per_min.\n"
+  unblocks:
+  - oric_hemimethylated_fraction readout
+  - seqa-sequestration-lasts-10-minutes test
+- id: req-2-seqa-process
+  kind: process
+  title: SeqaSequestration Process
+  effort: M
+  description: 'Process that flags oriC + dnaAp as sequestered when local
+
+    hemimethylation density crosses a threshold. Hooks into
+
+    DnaaBoxBinding (dnaa-03''s req-2) to BLOCK binding at sequestered
+
+    loci.
+
+    '
+  steps:
+  - Create v2ecoli/processes/seqa.py.
+  - 'Composite params: seqa_active: bool, seqa_sequestration_min: float = 10.0.'
+  - 'Listener: emit listeners.seqa.oric_sequestered_bool + .dnaap_sequestered_bool.'
+  - "Behavior: WT \u2192 \u22641 init/gen; no-SeqA \u2192 >1.5 init/gen."
+  unblocks:
+  - all dnaa-06 behavior_tests
+- id: req-3-dnaap-listener
+  kind: listener
+  title: dnaAp-specific sequestration listener
+  effort: XS
+  description: Second listener output for SeqA binding at dnaAp's GATC cluster.
+  unblocks:
+  - dnaap-sequestration-dampens-tx-spike
+bibliography:
+  expert:
+  - replication_initiation_molecular_info
+  bib_keys:
+  - Katayama2017Frontiers
+  - Leonard2015FrontMicrobiol
+  - Kasho2023IJMS
+  - Hansen1991ResMicrobiol
+  - Speck1999EMBO
+  - Saggioro2013BiochemJ
+conclusion_phase_decide_at: 2026-05-17T09:40Z
+parent_studies:
+- study: dnaa-fresh-04-initiation-mechanism
+  condition: tests-passed
+tests:
+  auto_discover: true
+  data_source: latest_run
+  pytest_args: []
+  last_results: null


### PR DESCRIPTION
## Summary

- Adds `scripts/clone_investigation.py`: a CLI + library that clones an investigation into a fresh planning state. Strips simulation results (sims/, tests/, charts/, viz/, runs.db*, run-*.html, *.log, REPORT.md, probe scripts/JSON under overnight-*/); keeps planning docs (PLAN.md, ADDENDUM.md, FRICTION.md, PROGRESS.md, STATUS.md, expert PDFs); rewrites study-name refs by prefix swap; resets `status:` → planning, `gate_status:` → blocked, `runs/findings/conclusion` dropped, `conclusion_verdicts` → PENDING.
- Demo clone: `investigations/dnaa-replication-fresh/` + 8 cloned studies (`studies/dnaa-fresh-*-*`) — the dnaa-replication investigation as it would look in the dashboard before any sims have been run.
- Designed to be the single source of truth for cloning. The dashboard's `POST /api/investigation-clone` endpoint (separate PR in vivarium-dashboard) shells out / imports this; the wrapper skill (separate PR in pbg-superpowers) also calls it.

## Why

Lets us simulate a fresh planning-state dashboard view (regression/demo fixture) and provides a reusable knob for starting a parallel attempt at the same investigation without manual copy-rename-strip work.

## Test plan

- [x] `python scripts/lint-workspace.py` → `workspace lint: OK`
- [x] Spot-checked rewritten investigation.yaml + a study.yaml (verdicts → PENDING, prerequisites remapped, runs/findings/conclusion stripped, gate_status → blocked).
- [x] Confirmed dashboard reads `investigation.yaml` via `yaml.safe_load`; no extra schema gating to satisfy.
- [ ] Visual: `vivarium-dashboard serve` → confirm the Investigations tab shows dnaa-replication-fresh in planning state with no run results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)