### PR TITLE
feat(study-framework): generic types, validator, viz Step template

### DIFF
--- a/scripts/lint-workspace.py
+++ b/scripts/lint-workspace.py
@@ -8,6 +8,7 @@ import re
 import subprocess
 import sys
 from pathlib import Path
+from collections import Counter
 
 import yaml
 from jsonschema import Draft7Validator, FormatChecker, ValidationError
@@ -220,7 +221,135 @@ def main() -> None:
             for err in _validate_simulation_processes(ws, registry):
                 _fail(err)
 
+    # ---- Summary -------------------------------------------------------
+    # Count expert_docs
+    expert_docs = ws.get("expert_docs", []) or []
+    n_expert = len(expert_docs)
+    expert_names = [d.get("name", "?") for d in expert_docs if isinstance(d, dict)]
+
+    # Count bib keys
+    bib_file = WS_ROOT / "references" / "papers.bib"
+    bib_keys_found: set = set()
+    if bib_file.exists():
+        bib_keys_found = set(re.findall(r"@\w+\{([A-Za-z0-9_:-]+),", bib_file.read_text()))
+    n_bib = len(bib_keys_found)
+
+    # Count claims
+    claims_file = WS_ROOT / "references" / "claims.yaml"
+    n_claims = 0
+    if claims_file.exists():
+        try:
+            claims_data = yaml.safe_load(claims_file.read_text()) or {}
+            if isinstance(claims_data, dict):
+                n_claims = len(claims_data.get("claims", claims_data) or {})
+            elif isinstance(claims_data, list):
+                n_claims = len(claims_data)
+        except Exception:
+            # Fall back to line count
+            n_claims = sum(1 for ln in claims_file.read_text().splitlines() if ln.strip() and not ln.startswith("#"))
+
+    # Enumerate studies
+    study_schema_path = WS_ROOT / ".pbg" / "schemas" / "study.schema.json"
+    study_schema: dict | None = None
+    if study_schema_path.exists():
+        try:
+            study_schema = json.loads(study_schema_path.read_text())
+        except Exception:
+            pass
+
+    study_names: list[str] = []
+    study_statuses: list[str] = []
+    study_warnings: list[str] = []
+
+    for study_yaml_path in sorted((WS_ROOT / "studies").glob("*/study.yaml")):
+        study_dir = study_yaml_path.parent.name
+        try:
+            study_data = yaml.safe_load(study_yaml_path.read_text()) or {}
+            s_name = study_data.get("name", study_dir)
+            s_status = study_data.get("status", "unknown")
+            study_names.append(s_name)
+            study_statuses.append(s_status)
+
+            # Validate against schema if available
+            if study_schema is not None:
+                try:
+                    from jsonschema import Draft202012Validator
+                    validator = Draft202012Validator(study_schema)
+                    errs = sorted(validator.iter_errors(study_data), key=lambda e: list(e.path))
+                    for err in errs:
+                        path_str = ".".join(str(p) for p in err.path) if err.path else "(root)"
+                        study_warnings.append(f"  WARN study {s_name}: [{path_str}] {err.message}")
+                except ImportError:
+                    # jsonschema draft 2020-12 validator not available; fall back silently
+                    try:
+                        Draft7Validator(study_schema, format_checker=FormatChecker()).validate(study_data)
+                    except Exception as ve:
+                        study_warnings.append(f"  WARN study {s_name}: {ve.message}")
+                except Exception as ve:
+                    study_warnings.append(f"  WARN study {s_name}: {ve}")
+        except Exception as exc:
+            study_warnings.append(f"  WARN could not parse {study_yaml_path}: {exc}")
+
+    n_studies = len(study_names)
+    status_counts = Counter(study_statuses)
+    status_summary = ", ".join(f"{v} {k}" for k, v in sorted(status_counts.items()))
+
+    # Count runs (by checking for runs.db files)
+    n_active_runs = 0
+    n_completed_runs = 0
+    for runs_db in (WS_ROOT / "studies").glob("*/runs.db"):
+        try:
+            import sqlite3
+            conn = sqlite3.connect(str(runs_db))
+            try:
+                cur = conn.execute("SELECT status FROM runs")
+                for (row_status,) in cur.fetchall():
+                    if row_status in ("running", "pending"):
+                        n_active_runs += 1
+                    elif row_status == "completed":
+                        n_completed_runs += 1
+            except Exception:
+                pass
+            finally:
+                conn.close()
+        except Exception:
+            pass
+
+    # Print summary
+    ws_name = ws.get("name", "?")
+    ws_pkg = ws.get("package_path", "")
+    study_names_preview = ", ".join(study_names[:3])
+    if n_studies > 3:
+        study_names_preview += f", ... (+{n_studies - 3} more)"
+
     print("workspace lint: OK")
+    print(f"  workspace: {ws_name}  (package: {ws_pkg})")
+    print(f"  {n_expert} expert_docs, {n_bib} bib keys, {n_claims} claims")
+    if n_studies == 0:
+        print("  0 studies")
+    else:
+        print(f"  {n_studies} studies: {study_names_preview}  (status: {status_summary})")
+    print(f"  {n_active_runs} active runs, {n_completed_runs} completed runs")
+
+    for w in study_warnings:
+        print(w, file=sys.stderr)
+
+    # Cross-study biology consistency (P2b-7): validates enum-typed fields
+    # against the registered bigraph-schema enums in v2ecoli/types/biology.py
+    # AND checks that the same literature/model observable maps to the same
+    # pool across studies. Fails the lint on enum violations or pool conflicts.
+    biology_validator = WS_ROOT / "scripts" / "validate_study_biology.py"
+    if biology_validator.exists():
+        result = subprocess.run(
+            [sys.executable, str(biology_validator)],
+            cwd=WS_ROOT, capture_output=True, text=True, timeout=30,
+        )
+        if result.stdout:
+            print(result.stdout.rstrip())
+        if result.stderr:
+            print(result.stderr.rstrip(), file=sys.stderr)
+        if result.returncode != 0:
+            _fail("cross-study biology consistency check failed")
 
 
 if __name__ == "__main__":

--- a/scripts/validate_study_biology.py
+++ b/scripts/validate_study_biology.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+"""Cross-study consistency validator.
+
+Walks every ``studies/*/study.yaml`` and:
+
+  1. Validates enum-typed fields against the registered bigraph-schema
+     enums in ``v2ecoli/types/biology.py`` (``BIOLOGY_TYPES``):
+       target_class, narrative_confidence, failure_cause,
+       perturbation_kind, verdict_result (the ``result`` field inside
+       ``conclusion_verdicts`` / ``last_results``).
+
+     Unknown enum types are skipped gracefully — if a workspace
+     extends ``BIOLOGY_TYPES`` with domain-specific enums (e.g. a
+     ``dnaa_pool_kind`` or similar), referencing the new type name in
+     the maps below will pick it up automatically.
+
+  2. Cross-study consistency:
+       - Same ``literature_observable.name`` must map to the same
+         ``biological_pool`` across studies (ERROR on divergence).
+       - Same ``model_observable.state_path`` must map to the same
+         ``molecular_pool`` across studies (ERROR on divergence).
+       - Same ``literature_observable.name`` must cite an overlapping
+         ``source_ids`` set across studies (WARNING on totally disjoint
+         citations).
+
+Exit code 0 if clean, 1 if any errors. ``--strict`` promotes warnings
+to errors.
+
+Standalone usage:
+    python scripts/validate_study_biology.py
+    python scripts/validate_study_biology.py --json     # machine-readable
+    python scripts/validate_study_biology.py --strict   # warnings → errors
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Iterable
+
+import yaml
+
+WS_ROOT = Path(__file__).resolve().parents[1]
+
+# Load v2ecoli/types/biology.py directly without triggering the v2ecoli
+# package __init__ (which pulls in heavy simulator deps like `multi_cell`).
+# biology.py has zero runtime imports — safe to side-load.
+_bio_spec = importlib.util.spec_from_file_location(
+    "v2ecoli_types_biology",
+    WS_ROOT / "v2ecoli" / "types" / "biology.py",
+)
+_bio_mod = importlib.util.module_from_spec(_bio_spec)
+_bio_spec.loader.exec_module(_bio_mod)
+BIOLOGY_TYPES = _bio_mod.BIOLOGY_TYPES
+
+
+# Map study.yaml YAML field-names to their bigraph-schema enum type name.
+# A field-path key is the LAST element of the breadcrumb (the leaf YAML key).
+# Enum types not registered in BIOLOGY_TYPES are silently skipped, so
+# workspaces that extend BIOLOGY_TYPES with new pool-kind / region-type
+# enums can register them here without modifying the validator logic.
+SCALAR_ENUM_FIELDS: dict[str, str] = {
+    "target_class":         "target_class",
+    "narrative_confidence": "narrative_confidence",
+    # Workspace-specific pool-kind enums (skipped when not registered):
+    "biological_pool":      "dnaa_pool_kind",
+    "molecular_pool":       "dnaa_pool_kind",
+}
+
+# Enum fields where the parent breadcrumb matters to disambiguate. Each rule
+# specifies the parent container shape:
+#   shape='list_item' — leaf is a direct field on an item of a list named
+#                       `parent`. Path = [..., parent, [i], leaf].
+#   shape='dict_value'— leaf is a direct field on a dict value of a dict named
+#                       `parent` keyed by arbitrary names.
+#                       Path = [..., parent, <key>, leaf].
+# Strict shape matching prevents over-matching deeper occurrences of the
+# same leaf name (e.g. `measure.kind` nested two levels under a parent
+# named ``perturbation_panel`` is NOT checked against perturbation_kind).
+CONTEXTUAL_ENUM_FIELDS: list[tuple[str, str, str, str]] = [
+    # parent_name,                leaf_name, enum_type_name,   shape
+    ("conclusion_verdicts",       "result",  "verdict_result", "dict_value"),
+    ("perturbation_panel",        "kind",    "perturbation_kind", "list_item"),
+    # tests.last_results.<test_name> sub-blocks like {result: PASS, observed: 707}
+    ("last_results",              "result",  "verdict_result", "dict_value"),
+]
+
+# Fields whose values are LISTS of enum members. Value ``None`` means
+# the list is free-text and should be skipped (declared here so the
+# walker doesn't try to enum-check it).
+LIST_ENUM_FIELDS: dict[str, str | None] = {
+    "failure_cause_candidates": "failure_cause",
+    "requires_perturbations":   None,  # free-text perturbation names
+    "forbidden_proxies":        None,  # free-text path strings
+}
+
+
+def _enum_values(type_name: str) -> set[str] | None:
+    spec = BIOLOGY_TYPES.get(type_name)
+    if spec is None:
+        return None
+    return set(spec.get("_values", []))
+
+
+def _walk(node: Any, crumbs: list[str]) -> Iterable[tuple[list[str], str, Any]]:
+    """Yield (breadcrumbs, leaf_name, value) for every scalar leaf.
+
+    For list items, the breadcrumb element is f'{parent}[{i}]'.
+    For dict items, the breadcrumb element is the key.
+    """
+    if isinstance(node, dict):
+        for k, v in node.items():
+            new_crumbs = crumbs + [str(k)]
+            if isinstance(v, (dict, list)):
+                yield from _walk(v, new_crumbs)
+            else:
+                yield (new_crumbs, str(k), v)
+    elif isinstance(node, list):
+        for i, item in enumerate(node):
+            new_crumbs = crumbs + [f"[{i}]"]
+            if isinstance(item, (dict, list)):
+                yield from _walk(item, new_crumbs)
+            else:
+                # list of scalars — emit with parent leaf name (last non-index crumb)
+                parent_name = None
+                for c in reversed(crumbs):
+                    if not c.startswith("["):
+                        parent_name = c
+                        break
+                yield (new_crumbs, parent_name or "", item)
+
+
+def _validate_enums(
+    study_name: str,
+    study_data: dict,
+    errors: list[str],
+    warnings: list[str],
+) -> None:
+    for crumbs, leaf, value in _walk(study_data, []):
+        if value is None:
+            continue
+        path_str = ".".join(crumbs)
+
+        # List-of-enum fields: handled via the parent crumb.
+        # Detect: the second-to-last crumb is in LIST_ENUM_FIELDS and the
+        # last crumb is an index marker.
+        if len(crumbs) >= 2 and crumbs[-1].startswith("["):
+            list_field = crumbs[-2]
+            if list_field in LIST_ENUM_FIELDS:
+                enum_type = LIST_ENUM_FIELDS[list_field]
+                if enum_type is None:
+                    continue  # explicitly skipped
+                vals = _enum_values(enum_type)
+                if vals is not None and str(value) not in vals:
+                    errors.append(
+                        f"{study_name}: {path_str} = {value!r} not in "
+                        f"{enum_type} enum {sorted(vals)}"
+                    )
+                continue
+
+        # Contextual enum fields. Match strict path shapes only.
+        matched = False
+        for parent_name, leaf_name, enum_type, shape in CONTEXTUAL_ENUM_FIELDS:
+            if leaf != leaf_name:
+                continue
+            ok = False
+            if shape == "list_item":
+                # Path tail must be [..., parent_name, [i], leaf]
+                if (len(crumbs) >= 3
+                        and crumbs[-3] == parent_name
+                        and crumbs[-2].startswith("[")):
+                    ok = True
+            elif shape == "dict_value":
+                # Path tail must be [..., parent_name, <key>, leaf]
+                # where <key> is not a list index.
+                if (len(crumbs) >= 3
+                        and crumbs[-3] == parent_name
+                        and not crumbs[-2].startswith("[")):
+                    ok = True
+            if not ok:
+                continue
+            vals = _enum_values(enum_type)
+            if vals is not None and str(value) not in vals:
+                errors.append(
+                    f"{study_name}: {path_str} = {value!r} not in "
+                    f"{enum_type} enum {sorted(vals)}"
+                )
+            matched = True
+            break
+        if matched:
+            continue
+        # Scalar enum fields by leaf name (no parent disambiguation needed).
+        if leaf in SCALAR_ENUM_FIELDS:
+                enum_type = SCALAR_ENUM_FIELDS[leaf]
+                vals = _enum_values(enum_type)
+                if vals is not None and str(value) not in vals:
+                    errors.append(
+                        f"{study_name}: {path_str} = {value!r} not in "
+                        f"{enum_type} enum {sorted(vals)}"
+                    )
+
+
+def _collect_observable_mappings(
+    study_name: str,
+    study_data: dict,
+    lit_to_pool: dict[str, list[tuple[str, str, str]]],   # lit_name → [(study, pool, path)]
+    state_to_pool: dict[str, list[tuple[str, str, str]]], # state_path → [(study, pool, path)]
+    lit_to_sources: dict[str, list[tuple[str, set, str]]],# lit_name → [(study, source_set, path)]
+) -> None:
+    """Walk behavior_tests[*].measurement_mapping and harvest tuples."""
+    for crumbs, leaf, value in _walk(study_data, []):
+        pass  # We need a different traversal that surfaces the parent dict;
+              # do that explicitly below.
+
+    def _walk_dicts(node: Any, crumbs: list[str]) -> Iterable[tuple[list[str], dict]]:
+        if isinstance(node, dict):
+            yield (crumbs, node)
+            for k, v in node.items():
+                yield from _walk_dicts(v, crumbs + [str(k)])
+        elif isinstance(node, list):
+            for i, item in enumerate(node):
+                yield from _walk_dicts(item, crumbs + [f"[{i}]"])
+
+    for crumbs, d in _walk_dicts(study_data, []):
+        # measurement_mapping block
+        if crumbs and crumbs[-1] == "measurement_mapping":
+            lit = d.get("literature_observable") or {}
+            mdl = d.get("model_observable") or {}
+            path = ".".join(crumbs)
+            lit_name = lit.get("name")
+            bio_pool = lit.get("biological_pool")
+            if lit_name and bio_pool:
+                lit_to_pool[str(lit_name)].append((study_name, str(bio_pool), path))
+            sources = lit.get("source_ids")
+            if lit_name and isinstance(sources, list) and sources:
+                lit_to_sources[str(lit_name)].append((study_name, set(sources), path))
+            state_path = mdl.get("state_path")
+            mol_pool = mdl.get("molecular_pool")
+            if state_path and mol_pool:
+                state_to_pool[str(state_path)].append((study_name, str(mol_pool), path))
+
+
+def _cross_study_consistency(
+    lit_to_pool: dict[str, list[tuple[str, str, str]]],
+    state_to_pool: dict[str, list[tuple[str, str, str]]],
+    lit_to_sources: dict[str, list[tuple[str, set, str]]],
+    errors: list[str],
+    warnings: list[str],
+) -> None:
+    for lit_name, entries in lit_to_pool.items():
+        pools = {pool for (_s, pool, _p) in entries}
+        if len(pools) > 1:
+            studies_pools = ", ".join(
+                f"{s}={pool}" for (s, pool, _p) in entries
+            )
+            errors.append(
+                f"cross-study: literature_observable '{lit_name}' mapped "
+                f"to DIVERGENT biological_pool values across studies: "
+                f"{studies_pools}"
+            )
+
+    for state_path, entries in state_to_pool.items():
+        pools = {pool for (_s, pool, _p) in entries}
+        if len(pools) > 1:
+            studies_pools = ", ".join(
+                f"{s}={pool}" for (s, pool, _p) in entries
+            )
+            errors.append(
+                f"cross-study: model_observable state_path '{state_path}' "
+                f"mapped to DIVERGENT molecular_pool values: {studies_pools}"
+            )
+
+    for lit_name, entries in lit_to_sources.items():
+        if len(entries) < 2:
+            continue
+        # If two studies cite this observable with NO overlap, warn.
+        for i in range(len(entries)):
+            for j in range(i + 1, len(entries)):
+                s_i, sources_i, _ = entries[i]
+                s_j, sources_j, _ = entries[j]
+                if not (sources_i & sources_j):
+                    warnings.append(
+                        f"cross-study: literature_observable '{lit_name}' "
+                        f"is cited with disjoint source_ids in {s_i} "
+                        f"({sorted(sources_i)}) vs {s_j} "
+                        f"({sorted(sources_j)}) — verify they refer to "
+                        f"the same biological quantity"
+                    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--json", action="store_true",
+                    help="emit a machine-readable JSON summary")
+    ap.add_argument("--strict", action="store_true",
+                    help="treat warnings as errors (non-zero exit)")
+    args = ap.parse_args(argv)
+
+    studies_dir = WS_ROOT / "studies"
+    study_files = sorted(studies_dir.glob("*/study.yaml")) if studies_dir.exists() else []
+    if not study_files:
+        # No studies yet — no enums to check. Clean exit so the validator
+        # is safe to invoke from lint-workspace.py on freshly-scaffolded
+        # workspaces.
+        if args.json:
+            print(json.dumps({
+                "studies_checked": 0, "errors": [], "warnings": [],
+            }, indent=2))
+        else:
+            print("validate_study_biology: no studies/ found — nothing to check")
+        return 0
+
+    errors: list[str] = []
+    warnings: list[str] = []
+    lit_to_pool: dict[str, list[tuple[str, str, str]]] = defaultdict(list)
+    state_to_pool: dict[str, list[tuple[str, str, str]]] = defaultdict(list)
+    lit_to_sources: dict[str, list[tuple[str, set, str]]] = defaultdict(list)
+
+    n_studies = 0
+    per_study_field_counts: dict[str, int] = defaultdict(int)
+
+    for path in study_files:
+        try:
+            data = yaml.safe_load(path.read_text()) or {}
+        except Exception as exc:
+            errors.append(f"{path.parent.name}: YAML parse failed — {exc}")
+            continue
+        study_name = data.get("name", path.parent.name)
+        n_studies += 1
+
+        _validate_enums(study_name, data, errors, warnings)
+        _collect_observable_mappings(
+            study_name, data, lit_to_pool, state_to_pool, lit_to_sources,
+        )
+
+        # Count enum-tagged fields for the summary.
+        for crumbs, leaf, value in _walk(data, []):
+            if leaf in SCALAR_ENUM_FIELDS:
+                per_study_field_counts[leaf] += 1
+
+    _cross_study_consistency(
+        lit_to_pool, state_to_pool, lit_to_sources, errors, warnings,
+    )
+
+    if args.json:
+        out = {
+            "studies_checked": n_studies,
+            "errors": errors,
+            "warnings": warnings,
+            "field_counts": dict(per_study_field_counts),
+            "literature_observables_with_pool": len(lit_to_pool),
+            "model_observables_with_pool": len(state_to_pool),
+        }
+        print(json.dumps(out, indent=2, sort_keys=True))
+    else:
+        print(f"validate_study_biology: scanned {n_studies} studies")
+        print(f"  enum-tagged fields: " + ", ".join(
+            f"{k}={v}" for k, v in sorted(per_study_field_counts.items())
+        ) if per_study_field_counts else
+            "  (no enum-tagged fields found)")
+        print(f"  cross-study: {len(lit_to_pool)} literature observables "
+              f"with biological_pool, {len(state_to_pool)} model observables "
+              f"with molecular_pool")
+        for w in warnings:
+            print(f"  WARN: {w}", file=sys.stderr)
+        for e in errors:
+            print(f"  ERROR: {e}", file=sys.stderr)
+        if not errors and not warnings:
+            print("  OK")
+
+    if errors:
+        return 1
+    if args.strict and warnings:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/v2ecoli/types/__init__.py
+++ b/v2ecoli/types/__init__.py
@@ -338,3 +338,9 @@ ECOLI_TYPES = {
     'listener_store': ListenerStore,
     'accumulate_float': AccumulateFloat,
 }
+
+# Study-evaluation framework enums (target_class, verdict_result,
+# failure_cause, ...). Kept in a separate module so per-investigation
+# layers can extend the framework without touching this file.
+from v2ecoli.types.biology import BIOLOGY_TYPES  # noqa: E402
+ECOLI_TYPES.update(BIOLOGY_TYPES)

--- a/v2ecoli/types/biology.py
+++ b/v2ecoli/types/biology.py
@@ -1,0 +1,219 @@
+"""Bigraph-schema types for the study-evaluation framework.
+
+A small registry of enums that any v2ecoli study can reuse to declare
+how its behavior_tests should be interpreted, how its conclusions
+break down across target classes, and how its outcomes get classified.
+These are first-class bigraph-schema types so:
+
+  1. Listener output ports + ``behavior_tests`` blocks can declare
+     ``target_class``, ``failure_cause``, etc. and have the registry
+     reject invalid values at composite-build time.
+  2. The dashboard, test runner, and viz Steps can introspect the
+     registry to filter / group by these categories (e.g., "show all
+     biological_validation tests across the workspace").
+  3. Cross-study consistency: every place that talks about a verdict
+     result or failure cause uses the same enum members; a workspace-
+     level validator can catch divergence early
+     (``scripts/validate_study_biology.py``).
+
+All types are registered into ``ECOLI_TYPES`` in
+``v2ecoli/types/__init__.py`` and become available as type strings:
+``target_class``, ``verdict_result``, ``failure_cause``, etc.
+
+The shape is deliberately enum-light: each entry is a registered
+bigraph-schema ``enum`` type. Domain-specific enums (e.g. the
+DnaA-pool-kind catalog, the autorepression-test-kind catalog) are
+left for the per-investigation modules to add on top — this file
+ships only the framework primitives.
+"""
+from __future__ import annotations
+
+
+# ─── verdict_result: per-target-class outcome in conclusion_verdicts ────
+
+VERDICT_RESULT = {
+    '_type': 'enum',
+    '_values': [
+        'PASS',            # mechanism / target satisfied
+        'FAIL',            # mechanism / target violated
+        'PENDING',         # required evidence not yet collected
+        'NOT_APPLICABLE',  # this class doesn't apply to this study
+        'NOT_CLAIMED',     # study deliberately doesn't make this claim
+    ],
+    '_description': (
+        'Outcome for one of the three target_class verdicts in '
+        "conclusion_verdicts. A study's final verdict should report "
+        'regression_compatibility, biological_validation, and '
+        'explanatory_gain INDEPENDENTLY — not collapsed to a single '
+        'pass/fail.'
+    ),
+}
+
+
+# ─── narrative_confidence: textbook-consensus rating on mechanism cards ─
+
+NARRATIVE_CONFIDENCE = {
+    '_type': 'enum',
+    '_values': ['strong', 'moderate', 'contested', 'open'],
+    '_description': (
+        'Rating attached to mechanism_cards (or other narrative claims) '
+        'so the framework can distinguish "settled textbook" from '
+        '"actively contested" assertions and flag claims built on '
+        'contested narrative.'
+    ),
+}
+
+
+# ─── target_class: how to interpret a behavior_test result ──────────────
+
+TARGET_CLASS = {
+    '_type': 'enum',
+    '_values': [
+        # Test passes when the model matches a heuristic / regression target.
+        # Does NOT validate the underlying biology — it just says the model
+        # reproduces the result we already had (or that the literature is
+        # consistent at a coarse level).
+        'regression_compatibility',
+
+        # Test passes ONLY when the mechanism is genuinely doing the right
+        # biology. Requires perturbation panel evidence (wild-type baseline
+        # alone is insufficient).
+        'biological_validation',
+
+        # Test passes when the model EXPLAINS something previously unexplained
+        # (a quantitative relationship, an emergent timing, a robustness
+        # property). Highest bar — requires both validation and a counterfactual.
+        'explanatory_gain',
+    ],
+    '_description': (
+        'How a behavior_test should be interpreted. Heuristic regression '
+        'cannot count as biological validation; biological validation '
+        'cannot count as explanatory gain. Studies must declare which '
+        'bar each test is reaching for.'
+    ),
+}
+
+
+# ─── failure_cause: classify a FAIL outcome ─────────────────────────────
+
+FAILURE_CAUSE = {
+    '_type': 'enum',
+    '_values': [
+        'missing_mechanism',         # biology required isn't in the model yet
+        'miscalibration',            # mechanism present, parameter wrong
+        'observable_mismatch',       # literature and model measure different things
+        'insufficient_statistics',   # data exists but not enough samples
+    ],
+    '_description': (
+        'Every FAIL outcome should declare the likely cause. Drives '
+        'downstream triage: a miscalibration is solvable in place; a '
+        'missing mechanism opens a new study; an observable mismatch '
+        'asks for a measurement_mapping fix.'
+    ),
+}
+
+
+# ─── autorepression_test_result: PASS/FAIL/INSUFFICIENT_EVIDENCE shape ──
+# Generic result tier for tests where the underlying statistic may be
+# uncomputable for reasons unrelated to PASS/FAIL (too few samples,
+# zero-variance signal, etc.). Originally introduced for the
+# autorepression test suite; reusable by any sample-bounded test.
+
+AUTOREPRESSION_TEST_RESULT = {
+    '_type': 'enum',
+    '_values': ['PASS', 'FAIL', 'INSUFFICIENT_EVIDENCE', 'NOT_RUN'],
+    '_description': (
+        'Outcome of a sample-bounded behavior_test. Distinguishes '
+        '"the data exists and the test failed" (FAIL) from "the data is '
+        'too sparse or degenerate for the test to be meaningful" '
+        '(INSUFFICIENT_EVIDENCE). The evaluator must emit '
+        'INSUFFICIENT_EVIDENCE rather than a false PASS or FAIL when '
+        'sample count is below a per-test threshold or when the input '
+        'signal has zero variance.'
+    ),
+}
+
+
+# ─── perturbation panel: required for biological_validation ─────────────
+
+PERTURBATION_KIND = {
+    '_type': 'enum',
+    '_values': [
+        'expression_step',     # toggle gene expression up/down mid-sim
+        'parameter_swap',      # change a parameter at t=0
+        'pathway_swap',        # disable a whole Step
+        'site_mutation',       # remove a binding / regulatory site
+        'media_shift',         # change growth condition
+        'inducible_promoter',  # toggle expression at a specific time
+    ],
+    '_description': (
+        'Categories of perturbation a study may run to discharge a '
+        'biological_validation claim. Wild-type baseline alone cannot '
+        'close validation — the study must run at least one perturbation '
+        'and report the prediction-vs-observation delta.'
+    ),
+}
+
+
+# ─── measurement_mapping: literature → model observable correspondence ──
+# Compound dict-shaped block; documented here for reference but NOT a
+# bigraph-schema-registered type (bigraph-schema's tree[any] parser doesn't
+# accept the nested-fields form cleanly). Validated at the study-loader
+# layer instead (see scripts/validate_study_biology.py). The validator
+# checks: literature_observable + model_observable blocks both exist;
+# biological_pool / molecular_pool reference a registered pool-kind enum
+# if the workspace has one; source_ids non-empty.
+#
+# Shape (use this in study.yaml):
+#   measurement_mapping:
+#     literature_observable:
+#       name:            <str>
+#       biological_pool: <enum value, workspace-specific>
+#       condition:       <str>
+#       statistic:       <str>
+#       source_ids:      [<bib_key>, ...]
+#     model_observable:
+#       listener_path:         <str>
+#       state_path:            <str>
+#       molecular_pool:        <enum value, workspace-specific>
+#       units:                 <str>
+#       includes_bound_species:<bool>
+#     transformation:
+#       formula:     <str>
+#       time_window: <str>
+#       aggregation: <str>
+#     caveats: [<str>, ...]
+MEASUREMENT_MAPPING_SHAPE = {
+    'description': (
+        'Documented YAML shape for behavior_tests[].measurement_mapping. '
+        'Every numeric literature threshold should carry a '
+        'measurement_mapping showing how the literature quantity maps to '
+        'a concrete model quantity.'
+    ),
+    'required_top_level_keys': ['literature_observable', 'model_observable',
+                                'transformation'],
+    'pool_kind_fields': ['literature_observable.biological_pool',
+                         'model_observable.molecular_pool'],
+}
+
+
+# ─── Public registry ────────────────────────────────────────────────────
+
+BIOLOGY_TYPES = {
+    # All enum types — registered as first-class bigraph-schema types.
+    # Listener output ports / behavior_tests can reference these by name
+    # ('target_class', 'verdict_result', ...); invalid values are rejected
+    # at composite-build time.
+    'target_class':                  TARGET_CLASS,
+    'verdict_result':                VERDICT_RESULT,
+    'narrative_confidence':          NARRATIVE_CONFIDENCE,
+    'failure_cause':                 FAILURE_CAUSE,
+    'autorepression_test_result':    AUTOREPRESSION_TEST_RESULT,
+    'perturbation_kind':             PERTURBATION_KIND,
+}
+
+# Compound shapes that aren't registered as bigraph types but are validated
+# at the study-loader layer:
+COMPOUND_SHAPES = {
+    'measurement_mapping': MEASUREMENT_MAPPING_SHAPE,
+}

--- a/v2ecoli/visualizations/_live_step_template.py
+++ b/v2ecoli/visualizations/_live_step_template.py
@@ -1,0 +1,88 @@
+"""Template + reference for live-sim Visualization Steps.
+
+A live Visualization Step runs INSIDE a composite simulation and emits
+a self-contained HTML/SVG artifact at sim end. It complements:
+
+  * **probes** — scripts run OUTSIDE the sim that rebuild a composite,
+    re-execute, and write side-by-side artifacts.
+  * **per-study charts** — pre-rendered SVGs checked in under
+    ``studies/<name>/charts/`` that the dashboard surfaces.
+
+| pattern  | per-tick cost              | sees emitted-only data | persists with sim |
+|----------|----------------------------|------------------------|-------------------|
+| probe    | composite rebuild + dt loop | no — reads live state  | no (probe writes side artifacts) |
+| Step     | accumulate(state) per tick  | yes (same stream the emitter writes) | yes (HTML is an emitter output) |
+
+The base class is ``pbg_superpowers.visualization.Visualization``. It
+ships ``config_schema`` keys ``title``, ``render_mode``, and
+``sample_every`` out of the box; subclasses extend with their own keys.
+
+This file is documentation-as-example only. Nothing here is imported
+by the composite layer; copy/adapt for new live Visualization Steps.
+
+Pattern (minimal):
+
+    from pbg_superpowers.visualization import Visualization
+
+
+    class MyLiveVisualization(Visualization):
+        '''One-line summary of what gets rendered.'''
+
+        # ── 1. Extend config_schema with your own keys ──────────────
+        config_schema = {
+            **Visualization.config_schema,
+            # 'my_threshold': {'_type': 'float', '_default': 0.5},
+        }
+
+        # ── 2. Declare typed input ports ────────────────────────────
+        # Inputs should match a slice of the composite state tree —
+        # only what render() needs to see. Use registered v2ecoli
+        # type names (bulk_array, listener_store, etc.) where possible
+        # so the bigraph-schema registry validates the wiring.
+        def inputs(self):
+            return {
+                'global_time': {'_type': 'float', '_default': 0.0},
+                # 'bulk': {'_type': 'bulk_array', '_default': []},
+                # 'listeners': {...},
+            }
+
+        # ── 3. Initialise per-tick accumulator buffers ──────────────
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self._times: list[float] = []
+            # self._series_a: list[float] = []
+            # self._series_b: list[float] = []
+
+        # ── 4. Per-tick callback ────────────────────────────────────
+        # Called once per simulation tick with the current state slice.
+        # Respect self.config['sample_every'] to downsample expensive
+        # per-tick work (e.g. avoid recording every tick when the sim
+        # runs at 1-second resolution but the chart only needs 10s).
+        def accumulate(self, state):
+            t = float(state['global_time'])
+            if self._times and (t - self._times[-1]) < self.config['sample_every']:
+                return
+            self._times.append(t)
+            # self._series_a.append(_extract_a(state))
+            # self._series_b.append(_extract_b(state))
+
+        # ── 5. Sim-end render ───────────────────────────────────────
+        # Called once at sim end. Return a self-contained HTML/SVG
+        # string (no external CSS/JS deps so it works inside the
+        # dashboard's offline-HTML report payload).
+        def render(self) -> str:
+            return (
+                '<svg xmlns="http://www.w3.org/2000/svg" width="600" '
+                'height="200"><text x="20" y="40">replace me</text></svg>'
+            )
+
+
+Conventions:
+  * **One Step per chart** — easier to compose, reuse, and disable.
+  * **No external assets** — render output must be self-contained so
+    the dashboard's offline-HTML payload stays portable.
+  * **Sample every N ticks** — accumulate cheaply; long sims with
+    per-tick recording bloat the emitter's history table.
+  * **Render is pure** — render() reads only self.* (no I/O), so the
+    same accumulator state is reproducible from the recorded history.
+"""


### PR DESCRIPTION
## Summary

A small, investigation-agnostic framework for declaring how studies
should be evaluated. Lifted out of the dnaA biology-feedback work so
the framework can be merged independently of the dnaA-specific
content (which stays on its own unmerged branch).

- **`v2ecoli/types/biology.py`** — 6 bigraph-schema enums registered
  into `ECOLI_TYPES`:
  - `target_class` (regression_compatibility / biological_validation / explanatory_gain)
  - `verdict_result` (PASS / FAIL / PENDING / NOT_APPLICABLE / NOT_CLAIMED)
  - `narrative_confidence` (strong / moderate / contested / open)
  - `failure_cause` (missing_mechanism / miscalibration / observable_mismatch / insufficient_statistics)
  - `autorepression_test_result` (PASS / FAIL / **INSUFFICIENT_EVIDENCE** / NOT_RUN) — generic sample-bounded test outcome
  - `perturbation_kind` (expression_step / parameter_swap / pathway_swap / site_mutation / media_shift / inducible_promoter)

  Domain-specific enums (pool kinds, region types, etc.) are left
  for per-investigation modules to add on top by updating
  `BIOLOGY_TYPES`.

- **`scripts/validate_study_biology.py`** — walks `studies/*/study.yaml`
  and validates enum-typed fields against `BIOLOGY_TYPES`. Unknown
  enum types are skipped, so extending `BIOLOGY_TYPES` with
  workspace-specific enums automatically picks up validation. Also
  enforces cross-study consistency:
  - same `literature_observable.name` → same `biological_pool` (ERROR)
  - same `model_observable.state_path` → same `molecular_pool` (ERROR)
  - same literature observable cited with disjoint `source_ids` (WARNING)

  Clean exit when no `studies/` directory exists; safe to invoke on
  fresh workspaces.

- **`scripts/lint-workspace.py`** — enumerates studies, validates each
  against the optional `.pbg/schemas/study.schema.json`, prints
  workspace summary (expert_docs / bib keys / claims / studies /
  active+completed runs), and invokes the biology validator. All
  generic.

- **`v2ecoli/visualizations/_live_step_template.py`** — documentation-
  as-example for live Visualization Steps (subclass
  `pbg_superpowers.visualization.Visualization`, accumulate/render
  lifecycle, `sample_every` downsampling, self-contained HTML/SVG
  output). Not imported anywhere; meant to be copied and adapted.

## Test plan

- [x] `workspace lint` passes on bare `main` (0 studies)
- [x] `ECOLI_TYPES` contains 6/6 framework enums after import
- [x] Validator catches 4/4 deliberate enum violations on a synthetic
      study fixture (bad `target_class`, bad `failure_cause`,
      bad `verdict_result`, bad `perturbation_kind`)
- [x] Validator silently ignores unregistered domain-specific enums
      (synthetic fixture with bad `biological_pool` and
      `autorepression_test_suite[].kind` produces no false positives)
- [x] Cross-study consistency check fires correctly when two studies
      map the same observable name to different pool values
- [ ] Manual: workspace using this framework can extend `BIOLOGY_TYPES`
      via its own module and have the validator pick up the new enums

🤖 Generated with [Claude Code](https://claude.com/claude-code)