### PR TITLE
fix(listeners): wrap all plain array[…] outputs in overwrite[] (7 files, 43 fields)

### DIFF
--- a/v2ecoli/steps/listeners/dna_supercoiling.py
+++ b/v2ecoli/steps/listeners/dna_supercoiling.py
@@ -47,10 +47,10 @@ class DnaSupercoiling(Step):
         return {
             'listeners': {
                 'dna_supercoiling': {
-                    'segment_left_boundary_coordinates': {'_type': 'array[integer]', '_default': []},
-                    'segment_right_boundary_coordinates': {'_type': 'array[integer]', '_default': []},
-                    'segment_domain_indexes': {'_type': 'array[integer]', '_default': []},
-                    'segment_superhelical_densities': {'_type': 'array[float]', '_default': []},
+                    'segment_left_boundary_coordinates': {'_type': 'overwrite[array[integer]]', '_default': []},
+                    'segment_right_boundary_coordinates': {'_type': 'overwrite[array[integer]]', '_default': []},
+                    'segment_domain_indexes': {'_type': 'overwrite[array[integer]]', '_default': []},
+                    'segment_superhelical_densities': {'_type': 'overwrite[array[float]]', '_default': []},
                 },
             },
         }

--- a/v2ecoli/steps/listeners/mass_listener.py
+++ b/v2ecoli/steps/listeners/mass_listener.py
@@ -34,9 +34,9 @@ class MassListener(Step):
     config_schema = {
         'cellDensity': {'_type': 'float', '_default': 1100.0},
         'bulk_ids': 'list[string]',
-        'bulk_masses': {'_type': 'array[float]', '_default': None},
+        'bulk_masses': {'_type': 'overwrite[array[float]]', '_default': None},
         'unique_ids': 'list[string]',
-        'unique_masses': {'_type': 'array[float]', '_default': None},
+        'unique_masses': {'_type': 'overwrite[array[float]]', '_default': None},
         'submass_to_idx': {'_type': 'map[integer]', '_default': {
             "rRNA": 0,
             "tRNA": 1,

--- a/v2ecoli/steps/listeners/replication_data.py
+++ b/v2ecoli/steps/listeners/replication_data.py
@@ -50,9 +50,9 @@ class ReplicationData(Step):
         return {
             'listeners': {
                 'replication_data': {
-                    'fork_coordinates': {'_type': 'array[integer]', '_default': []},
-                    'fork_domains': {'_type': 'array[integer]', '_default': []},
-                    'fork_unique_index': {'_type': 'array[integer]', '_default': []},
+                    'fork_coordinates': {'_type': 'overwrite[array[integer]]', '_default': []},
+                    'fork_domains': {'_type': 'overwrite[array[integer]]', '_default': []},
+                    'fork_unique_index': {'_type': 'overwrite[array[integer]]', '_default': []},
                     'number_of_oric': {'_type': 'overwrite[integer]', '_default': []},
                     'free_DnaA_boxes': {'_type': 'overwrite[integer]', '_default': []},
                     'total_DnaA_boxes': {'_type': 'overwrite[integer]', '_default': []},

--- a/v2ecoli/steps/listeners/ribosome_data.py
+++ b/v2ecoli/steps/listeners/ribosome_data.py
@@ -48,8 +48,8 @@ class RibosomeData(Step):
         return {
             'listeners': {
                 'ribosome_data': {
-                    'rRNA_initiated_TU': {'_type': f'array[{self.n_rRNA_TUs},integer]', '_default': []},
-                    'rRNA_init_prob_TU': {'_type': f'array[{self.n_rRNA_TUs},float]', '_default': []},
+                    'rRNA_initiated_TU': {'_type': f'overwrite[array[{self.n_rRNA_TUs},integer]]', '_default': []},
+                    'rRNA_init_prob_TU': {'_type': f'overwrite[array[{self.n_rRNA_TUs},float]]', '_default': []},
                 },
             },
             'active_ribosomes': {'_type': ACTIVE_RIBOSOME_ARRAY, '_default': []},
@@ -64,21 +64,21 @@ class RibosomeData(Step):
             'listeners': {
                 'ribosome_data': {
                     # Counts (dimensionless integers)
-                    'n_ribosomes_per_transcript': {'_type': f'array[{self.n_monomers},integer]', '_default': []},
-                    'n_ribosomes_on_partial_mRNA_per_transcript': {'_type': f'array[{self.n_monomers},integer]', '_default': []},
+                    'n_ribosomes_per_transcript': {'_type': f'overwrite[array[{self.n_monomers},integer]]', '_default': []},
+                    'n_ribosomes_on_partial_mRNA_per_transcript': {'_type': f'overwrite[array[{self.n_monomers},integer]]', '_default': []},
                     'total_rRNA_initiated': {'_type': 'overwrite[integer]', '_default': 0},
                     'rRNA5S_initiated': {'_type': 'overwrite[integer]', '_default': 0},
                     'rRNA16S_initiated': {'_type': 'overwrite[integer]', '_default': 0},
                     'rRNA23S_initiated': {'_type': 'overwrite[integer]', '_default': 0},
-                    'mRNA_TU_index': {'_type': 'array[integer]', '_default': []},
-                    'n_ribosomes_on_each_mRNA': {'_type': 'array[integer]', '_default': []},
+                    'mRNA_TU_index': {'_type': 'overwrite[array[integer]]', '_default': []},
+                    'n_ribosomes_on_each_mRNA': {'_type': 'overwrite[array[integer]]', '_default': []},
                     # Probabilities (dimensionless floats in [0,1])
                     'total_rRNA_init_prob': {'_type': 'overwrite[float]', '_default': 0.0},
                     'rRNA5S_init_prob': {'_type': 'overwrite[float]', '_default': 0.0},
                     'rRNA16S_init_prob': {'_type': 'overwrite[float]', '_default': 0.0},
                     'rRNA23S_init_prob': {'_type': 'overwrite[float]', '_default': 0.0},
                     # Mass per polysome — femtograms
-                    'protein_mass_on_polysomes': {'_type': 'array[float[fg]]', '_default': []},
+                    'protein_mass_on_polysomes': {'_type': 'overwrite[array[float[fg]]]', '_default': []},
                 },
             },
             'next_update_time': 'overwrite[float]',

--- a/v2ecoli/steps/listeners/rna_counts.py
+++ b/v2ecoli/steps/listeners/rna_counts.py
@@ -60,14 +60,14 @@ class RNACounts(Step):
         return {
             'listeners': {
                 'rna_counts': {
-                    'mRNA_counts': {'_type': f'array[{self.n_mRNA_TU},integer]', '_default': []},
-                    'full_mRNA_counts': {'_type': f'array[{self.n_mRNA_TU},integer]', '_default': []},
-                    'partial_mRNA_counts': {'_type': f'array[{self.n_mRNA_TU},integer]', '_default': []},
-                    'mRNA_cistron_counts': {'_type': f'array[{self.n_mRNA_cistron},integer]', '_default': []},
-                    'full_mRNA_cistron_counts': {'_type': f'array[{self.n_mRNA_cistron},integer]', '_default': []},
-                    'partial_mRNA_cistron_counts': {'_type': f'array[{self.n_mRNA_cistron},integer]', '_default': []},
-                    'partial_rRNA_counts': {'_type': f'array[{self.n_rRNA_TU},integer]', '_default': []},
-                    'partial_rRNA_cistron_counts': {'_type': f'array[{self.n_rRNA_cistron},integer]', '_default': []},
+                    'mRNA_counts': {'_type': f'overwrite[array[{self.n_mRNA_TU},integer]]', '_default': []},
+                    'full_mRNA_counts': {'_type': f'overwrite[array[{self.n_mRNA_TU},integer]]', '_default': []},
+                    'partial_mRNA_counts': {'_type': f'overwrite[array[{self.n_mRNA_TU},integer]]', '_default': []},
+                    'mRNA_cistron_counts': {'_type': f'overwrite[array[{self.n_mRNA_cistron},integer]]', '_default': []},
+                    'full_mRNA_cistron_counts': {'_type': f'overwrite[array[{self.n_mRNA_cistron},integer]]', '_default': []},
+                    'partial_mRNA_cistron_counts': {'_type': f'overwrite[array[{self.n_mRNA_cistron},integer]]', '_default': []},
+                    'partial_rRNA_counts': {'_type': f'overwrite[array[{self.n_rRNA_TU},integer]]', '_default': []},
+                    'partial_rRNA_cistron_counts': {'_type': f'overwrite[array[{self.n_rRNA_cistron},integer]]', '_default': []},
                 },
             },
         }

--- a/v2ecoli/steps/listeners/rna_synth_prob.py
+++ b/v2ecoli/steps/listeners/rna_synth_prob.py
@@ -44,9 +44,9 @@ class RnaSynthProb(Step):
     def inputs(self):
         return {
             'rna_synth_prob': {
-                'actual_rna_synth_prob': {'_type': f'array[{self.n_TU},float]', '_default': []},
-                'target_rna_synth_prob': {'_type': f'array[{self.n_TU},float]', '_default': []},
-                'n_bound_TF_per_TU': {'_type': f'array[({self.n_TU}|{self.n_TF}),integer]', '_default': []},
+                'actual_rna_synth_prob': {'_type': f'overwrite[array[{self.n_TU},float]]', '_default': []},
+                'target_rna_synth_prob': {'_type': f'overwrite[array[{self.n_TU},float]]', '_default': []},
+                'n_bound_TF_per_TU': {'_type': f'overwrite[array[({self.n_TU}|{self.n_TF}),integer]]', '_default': []},
                 'total_rna_init': {'_type': 'integer', '_default': 0},
             },
             'promoters': {'_type': PROMOTER_ARRAY, '_default': []},
@@ -58,16 +58,16 @@ class RnaSynthProb(Step):
     def outputs(self):
         return {
             'rna_synth_prob': {
-                'promoter_copy_number': {'_type': f'array[{self.n_TU},integer]', '_default': []},
-                'gene_copy_number': {'_type': f'array[{self.n_cistron},integer]', '_default': []},
-                'bound_TF_indexes': {'_type': 'array[integer]', '_default': []},
-                'bound_TF_coordinates': {'_type': 'array[integer]', '_default': []},
-                'bound_TF_domains': {'_type': 'array[integer]', '_default': []},
+                'promoter_copy_number': {'_type': f'overwrite[array[{self.n_TU},integer]]', '_default': []},
+                'gene_copy_number': {'_type': f'overwrite[array[{self.n_cistron},integer]]', '_default': []},
+                'bound_TF_indexes': {'_type': 'overwrite[array[integer]]', '_default': []},
+                'bound_TF_coordinates': {'_type': 'overwrite[array[integer]]', '_default': []},
+                'bound_TF_domains': {'_type': 'overwrite[array[integer]]', '_default': []},
                 # Probabilities — dimensionless floats in [0, 1]
-                'expected_rna_init_per_cistron': {'_type': f'array[{self.n_cistron},float]', '_default': []},
-                'actual_rna_synth_prob_per_cistron': {'_type': f'array[{self.n_cistron},float]', '_default': []},
-                'target_rna_synth_prob_per_cistron': {'_type': f'array[{self.n_cistron},float]', '_default': []},
-                'n_bound_TF_per_cistron': {'_type': f'array[{self.n_cistron},integer]', '_default': []},
+                'expected_rna_init_per_cistron': {'_type': f'overwrite[array[{self.n_cistron},float]]', '_default': []},
+                'actual_rna_synth_prob_per_cistron': {'_type': f'overwrite[array[{self.n_cistron},float]]', '_default': []},
+                'target_rna_synth_prob_per_cistron': {'_type': f'overwrite[array[{self.n_cistron},float]]', '_default': []},
+                'n_bound_TF_per_cistron': {'_type': f'overwrite[array[{self.n_cistron},integer]]', '_default': []},
             },
         }
 

--- a/v2ecoli/steps/listeners/rnap_data.py
+++ b/v2ecoli/steps/listeners/rnap_data.py
@@ -47,7 +47,7 @@ class RnapData(Step):
         return {
             'listeners': {
                 'rnap_data': {
-                    'rna_init_event': {'_type': f'array[{self.n_TUs},integer]', '_default': []},
+                    'rna_init_event': {'_type': f'overwrite[array[{self.n_TUs},integer]]', '_default': []},
                 },
             },
             'active_RNAPs': {'_type': ACTIVE_RNAP_ARRAY, '_default': []},
@@ -62,12 +62,12 @@ class RnapData(Step):
         return {
             'listeners': {
                 'rnap_data': {
-                    'rna_init_event_per_cistron': {'_type': f'array[{self.n_cistrons},integer]', '_default': []},
-                    'active_rnap_coordinates': {'_type': 'array[integer]', '_default': []},
-                    'active_rnap_domain_indexes': {'_type': 'array[integer]', '_default': []},
-                    'active_rnap_unique_indexes': {'_type': 'array[integer]', '_default': []},
-                    'active_rnap_on_stable_RNA_indexes': {'_type': 'array[integer]', '_default': []},
-                    'active_rnap_n_bound_ribosomes': {'_type': 'array[integer]', '_default': []},
+                    'rna_init_event_per_cistron': {'_type': f'overwrite[array[{self.n_cistrons},integer]]', '_default': []},
+                    'active_rnap_coordinates': {'_type': 'overwrite[array[integer]]', '_default': []},
+                    'active_rnap_domain_indexes': {'_type': 'overwrite[array[integer]]', '_default': []},
+                    'active_rnap_unique_indexes': {'_type': 'overwrite[array[integer]]', '_default': []},
+                    'active_rnap_on_stable_RNA_indexes': {'_type': 'overwrite[array[integer]]', '_default': []},
+                    'active_rnap_n_bound_ribosomes': {'_type': 'overwrite[array[integer]]', '_default': []},
                 },
             },
             'next_update_time': 'overwrite[float]',


### PR DESCRIPTION
## Summary

Same bigraph-schema merge bug that PR #51 fixed in
`monomer_counts_listener`, applied to the 7 other v2ecoli listeners.
Outputs declared as plain `array[…]` accumulate across timesteps
because the default array combinator is element-wise addition. The
fix wraps each plain-array output in `overwrite[…]` so each
timestep's emission replaces (not adds to) the previous value.

| Listener                | Fields wrapped |
|-------------------------|---------------:|
| `dna_supercoiling.py`   | 4 |
| `mass_listener.py`      | 2 |
| `replication_data.py`   | 3 |
| `ribosome_data.py`      | 7 |
| `rna_counts.py`         | 8 |
| `rna_synth_prob.py`     | 12 |
| `rnap_data.py`          | 7 |
| **Total**               | **43** |

Affects every v2ecoli workspace, not just the dnaA investigation
where the bug was originally observed. Behavior tests against the
unfixed listeners produced linearly-growing values that looked like
simulation bugs but were actually emission bugs (e.g.,
`rnap_data.rna_init_event` hitting 28,945 cumulative at step 600 vs
the actual ~44-62 events/step).

## Test plan

- [x] Same fix pattern as PR #51's `monomer_counts_listener`
- [x] Verified against a 10-min seed-0 baseline run of
      dnaa-01-expression-dynamics: `rnap_data.rna_init_event` no
      longer accumulates (steady 44-62 events/step, was 28,945
      cumulative at step 600); `rna_counts.mRNA_counts` returns
      physiological per-step values
- [ ] CI fast-tests + behavior-tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)