### PR TITLE
fix(listeners): tolerate absent unique-molecule types + surface seed_mass_listener failures

### DIFF
--- a/v2ecoli/composites/_helpers.py
+++ b/v2ecoli/composites/_helpers.py
@@ -22,6 +22,7 @@ Exported names (all are considered semi-private implementation details):
 from __future__ import annotations
 
 import copy
+import warnings
 
 import numpy as np
 
@@ -444,8 +445,18 @@ def seed_mass_listener(cell_state, core):
             if delta and 'listeners' in delta:
                 mass = delta['listeners'].get('mass', {})
                 cell_state['listeners']['mass'].update(mass)
-        except Exception:
-            pass
+        except Exception as exc:
+            # Don't crash composite construction if the mass listener fails
+            # on partial state — but surface the failure. A silent miss here
+            # leaves cell_mass=0, which surfaces several layers downstream
+            # as a non-finite y_init in Equilibrium's ODE solver.
+            warnings.warn(
+                f"seed_mass_listener({name}) failed: "
+                f"{type(exc).__name__}: {exc}. "
+                f"cell_mass / dry_mass left unset.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
         break
 
 

--- a/v2ecoli/steps/listeners/mass_listener.py
+++ b/v2ecoli/steps/listeners/mass_listener.py
@@ -245,6 +245,13 @@ class MassListener(Step):
         unique_compartment_masses = np.zeros_like(bulk_compartment_masses)
         for unique_id, unique_mass in zip(self.unique_ids, self.unique_masses):
             molecules = states["unique"].get(unique_id)
+            # self.unique_ids comes from the cache, which lists every
+            # unique-molecule type the ParCa fixture defines (incl. plasmid
+            # molecules baked in by --mode full). State from a non-plasmid
+            # sim (e.g. the pre-division checkpoint, or any daughter built
+            # from it) omits those keys — treat absent == zero count.
+            if molecules is None:
+                continue
             n_molecules = molecules["_entryState"].sum()
 
             if n_molecules == 0:

--- a/v2ecoli/steps/listeners/unique_molecule_counts.py
+++ b/v2ecoli/steps/listeners/unique_molecule_counts.py
@@ -56,11 +56,18 @@ class UniqueMoleculeCounts(Step):
         return (states["global_time"] % states["timestep"]) == 0
 
     def update(self, states, interval=None):
-        # Guard: return empty on first tick if data not yet populated
+        # self.unique_ids comes from the cache, which lists every
+        # unique-molecule type in the ParCa fixture (incl. plasmid molecules
+        # baked in by --mode full). State from a non-plasmid sim may omit
+        # those keys — report 0 instead of raising KeyError.
+        unique = states["unique"]
         return {
             "listeners": {
                 "unique_molecule_counts": {
-                    str(unique_id): states["unique"][unique_id]["_entryState"].sum()
+                    str(unique_id): (
+                        unique[unique_id]["_entryState"].sum()
+                        if unique_id in unique else 0
+                    )
                     for unique_id in self.unique_ids
                 }
             }


### PR DESCRIPTION
## Summary

Two small defensive changes around the mass / unique-molecule listeners, extracted from work on the plasmids branch where they were load-bearing. On `main` today these are **preventive** (the only path that currently triggers the bug is on the plasmids branch); landing them now keeps the framework robust for any future scenario where the cache's `unique_names` drifts from a runtime state's `unique` keys.

- **`mass_listener.update` / `unique_molecule_counts.update`:** both iterate `self.unique_ids`, sourced from the cache's `unique_names`. Previously they assumed every key was present in `states["unique"]`. If a state was constructed from a different sim (smaller `unique` set), the lookup returned `None` / raised `KeyError`. Treat absent unique IDs as zero count — semantically equivalent to "no molecules of this type."
- **`seed_mass_listener` in `composites/_helpers.py`:** previously did `except Exception: pass`. When the mass listener failed on partial state, `cell_mass` stayed at `0`, which surfaced three layers downstream as a non-finite `y_init` inside Equilibrium's ODE solver — a confusing failure mode that cost real debugging time. Keep the don't-crash-construction policy, but emit a `RuntimeWarning` so the next variant surfaces immediately.

## Motivation

While merging `origin/main` into the long-running `plasmids` branch (PR #10), `test_daughters_build_and_grow` failed with `RuntimeError: Could not solve ODEs in equilibrium to SS.` The chain was:

1. ParCa fixture was regenerated in `--mode full`, so the cache's `unique_names` now includes the four plasmid molecules (`full_plasmid`, `plasmid_domain`, `oriV`, `plasmid_active_replisome`).
2. The pre-division checkpoint (`tests/fixtures/pre_division_state.json.gz`) was produced by a non-plasmid sim, so its `unique` dict has only 11 keys.
3. Daughters built from it via `divide_cell` also have 11 keys.
4. `mass_listener.update` did `states["unique"].get("full_plasmid")` → `None`, `None["_entryState"]` → `TypeError`, which `seed_mass_listener` silently swallowed.
5. `cell_mass` stayed at `0`, Equilibrium divided by `cell_volume * nAvogadro = 0`, ODE solver got non-finite inputs and gave up.

`main` itself doesn't currently exhibit this because `v2ecoli/library/sim_data.py` on main has no plasmid wiring (the cache's `unique_names` stays at 11). But the **listener code paths are common to both branches**, and the same pattern would bite anyone in the future who adds an optional unique-molecule type or uses a fixture that predates a `unique_names` update.

## Test plan
- [x] Local fast tests pass on cherry-picked branch (123 passed, 13 skipped)
- [x] Originating failure (`test_daughters_build_and_grow` on plasmids) is restored to green by these edits
- [ ] CI behavior-tests on this PR confirm no regression on `main`