### PR TITLE
ParCa: build condition caches for non-default nutrient conditions

### DIFF
--- a/scripts/build_cache.py
+++ b/scripts/build_cache.py
@@ -38,7 +38,9 @@ DEFAULT_FIXTURE = "models/parca/parca_state.pkl.gz"
 DEFAULT_CACHE_DIR = "out/cache"
 
 
-def build_cache(fixture: str, cache_dir: str) -> None:
+def build_cache(fixture: str, cache_dir: str,
+                media_condition: str | None = None,
+                fixed_media: str | None = None) -> None:
     repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     os.chdir(repo_root)
 
@@ -52,9 +54,18 @@ def build_cache(fixture: str, cache_dir: str) -> None:
     sim_data = hydrate_sim_data_from_state(state)
     print(f"    hydrated in {time.time()-t1:.1f}s")
 
+    if media_condition is not None:
+        avail = dict(getattr(sim_data, "condition_to_doubling_time", {}) or {})
+        if media_condition not in avail:
+            raise SystemExit(f"unknown media_condition {media_condition!r}; "
+                             f"known: {sorted(avail)}")
+        print(f"    nutrient condition {media_condition!r} "
+              f"(doubling {avail[media_condition]}), media {fixed_media!r}")
+
     t2 = time.time()
     print(f"[{time.strftime('%H:%M:%S')}] Building bundle at {cache_dir} ...")
-    save_sim_input(sim_data, cache_dir)
+    save_sim_input(sim_data, cache_dir,
+                   condition=media_condition, fixed_media=fixed_media)
 
     version = write_cache_version(cache_dir, repo_root=repo_root)
     print(f"    bundle built in {time.time()-t2:.1f}s")
@@ -74,8 +85,14 @@ def main() -> None:
                         help=f"ParCa fixture pickle (default: {DEFAULT_FIXTURE})")
     parser.add_argument("--cache", default=DEFAULT_CACHE_DIR, dest="cache_dir",
                         help=f"output bundle dir (default: {DEFAULT_CACHE_DIR})")
+    parser.add_argument("--media-condition", default=None,
+                        help="ParCa nutrient condition for the initial state / "
+                             "doubling time (e.g. acetate; default basal)")
+    parser.add_argument("--fixed-media", default=None,
+                        help="media id pinned for the run (e.g. minimal_acetate)")
     args = parser.parse_args()
-    build_cache(args.fixture, args.cache_dir)
+    build_cache(args.fixture, args.cache_dir,
+                media_condition=args.media_condition, fixed_media=args.fixed_media)
 
 
 if __name__ == "__main__":

--- a/scripts/build_condition_cache.py
+++ b/scripts/build_condition_cache.py
@@ -159,7 +159,9 @@ def _git_sha() -> str:
 
 
 def build(condition: str, fixture: str, cache_dir: str,
-          transcription_factor: float, te_factor: float) -> None:
+          transcription_factor: float, te_factor: float,
+          media_condition: str | None = None,
+          fixed_media: str | None = None) -> None:
     repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     os.chdir(repo_root)
     if condition not in PATCHES:
@@ -172,6 +174,16 @@ def build(condition: str, fixture: str, cache_dir: str,
     print(f"[{time.strftime('%H:%M:%S')}] Hydrating sim_data ...")
     sim_data = hydrate_sim_data_from_state(state)
 
+    if media_condition is not None:
+        avail = dict(getattr(sim_data, "condition_to_doubling_time", {}) or {})
+        if media_condition not in avail:
+            raise SystemExit(
+                f"unknown media_condition {media_condition!r}; known: "
+                f"{sorted(avail)}")
+        print(f"[{time.strftime('%H:%M:%S')}] Nutrient condition "
+              f"{media_condition!r} (doubling {avail[media_condition]}), "
+              f"media {fixed_media!r}")
+
     print(f"[{time.strftime('%H:%M:%S')}] Applying '{condition}' patch "
           f"(transcription×{transcription_factor}, te×{te_factor}) ...")
     patch_record = PATCHES[condition](
@@ -179,11 +191,14 @@ def build(condition: str, fixture: str, cache_dir: str,
     print(f"    {json.dumps(patch_record['patched'], indent=2)}")
 
     print(f"[{time.strftime('%H:%M:%S')}] Building bundle at {cache_dir} ...")
-    save_sim_input(sim_data, cache_dir)
+    save_sim_input(sim_data, cache_dir,
+                   condition=media_condition, fixed_media=fixed_media)
     write_cache_version(cache_dir, repo_root=repo_root)
 
     manifest = {
         "condition": condition,
+        "media_condition": media_condition,
+        "fixed_media": fixed_media,
         "created_at": datetime.datetime.now().isoformat(),
         "git_sha": _git_sha(),
         "base_fixture": fixture,
@@ -209,10 +224,17 @@ def main() -> None:
                     help="scale dnaA transcription arrays (calibration finds this)")
     ap.add_argument("--te-factor", type=float, default=1.0,
                     help="scale dnaA translation-efficiency weight")
+    ap.add_argument("--media-condition", default=None,
+                    help="ParCa nutrient condition for the initial state / "
+                         "doubling time (e.g. acetate, succinate; default basal)")
+    ap.add_argument("--fixed-media", default=None,
+                    help="media id pinned for the whole run (e.g. minimal_acetate)")
     args = ap.parse_args()
-    cache_dir = args.cache_dir or f"out/cache-{args.condition}"
+    suffix = f"-{args.media_condition}" if args.media_condition else ""
+    cache_dir = args.cache_dir or f"out/cache-{args.condition}{suffix}"
     build(args.condition, args.fixture, cache_dir,
-          args.transcription_factor, args.te_factor)
+          args.transcription_factor, args.te_factor,
+          media_condition=args.media_condition, fixed_media=args.fixed_media)
 
 
 if __name__ == "__main__":

--- a/v2ecoli/core.py
+++ b/v2ecoli/core.py
@@ -160,7 +160,8 @@ def save_cache(sim_data_path, cache_dir='out/cache', seed=0):
     _write_sim_input_bundle(loader, cache_dir)
 
 
-def save_sim_input(sim_data, bundle_dir='out/cache', seed=0):
+def save_sim_input(sim_data, bundle_dir='out/cache', seed=0,
+                   condition=None, fixed_media=None):
     """Generate the simulation-input bundle from a live ``SimulationDataEcoli``.
 
     Skips the ~300 MB dill round-trip that ``save_cache`` performs to load
@@ -168,7 +169,18 @@ def save_sim_input(sim_data, bundle_dir='out/cache', seed=0):
     ``SimulationDataEcoli`` in hand (e.g. straight off the parca composite or
     its fixture) — the resulting bundle is byte-for-byte equivalent to what
     ``save_cache`` would produce from the same sim_data dilled to a file.
+
+    ``condition`` (e.g. "acetate") and ``fixed_media`` (e.g. "minimal_acetate")
+    select a non-default nutrient condition so the generated initial state
+    reflects that condition's growth rate / doubling time — both already live in
+    the ParCa state's ``condition_to_doubling_time`` / saved media, so no refit
+    is needed. Omitted → default basal / minimal (glucose).
     """
     from v2ecoli.library.sim_data import LoadSimData
-    loader = LoadSimData(sim_data=sim_data, seed=seed)
+    kwargs = {"sim_data": sim_data, "seed": seed}
+    if condition is not None:
+        kwargs["condition"] = condition
+    if fixed_media is not None:
+        kwargs["fixed_media"] = fixed_media
+    loader = LoadSimData(**kwargs)
     _write_sim_input_bundle(loader, bundle_dir)


### PR DESCRIPTION
## Summary
Lets us build a ParCa condition cache for any nutrient condition already present in the state's `condition_to_doubling_time` — no refit.

- `save_sim_input(... , condition=None, fixed_media=None)` threads both to `LoadSimData`, so the generated initial state reflects that condition's growth rate / doubling time.
- `build_condition_cache.py` gains `--media-condition` / `--fixed-media` (validated against available conditions; recorded in the manifest; cache dir suffixed `-<condition>`).

## Why
The DnaA investigation needs a slow, non-overlapping cell cycle (≥1 doubling time) to judge DnaA steadiness (Haochen rounds 1–2). Glucose (`minimal`, τ=44 min) is too fast and runs stop at the first division; `minimal_acetate` (τ=136 min) is the closest existing condition. Glycerol (τ=150) isn't in v2ecoli's ParCa, so acetate is the no-refit proxy.

## Test plan
- [x] `import v2ecoli.core` — `save_sim_input` accepts `condition`/`fixed_media`
- [ ] Build `out/cache-stage1-heuristic-acetate` and verify the bundle's doubling time = 136 min (in progress)
- [ ] Run dnaa-01 on the acetate cache for a ≥1-doubling-time trace