### PR TITLE
feat(library): multi-gen sqlite runner + xarray runner robustness

### DIFF
--- a/v2ecoli/library/sqlite_run.py
+++ b/v2ecoli/library/sqlite_run.py
@@ -1,0 +1,228 @@
+"""Multi-generation SQLite run helper for v2ecoli composites.
+
+Mirrors :func:`v2ecoli.library.xarray_run.run_multigen_xarray` for the SQLite
+emitter branch. Workspace-side (v2ecoli) because the daughter-walk rule
+("first sorted new agent_id after parent disappears") and the
+``agents/<id>/`` lineage convention are biological/v2ecoli choices, not
+framework contracts — keeping them out of vivarium-dashboard avoids the
+anti-pattern flagged in dashboard PR #104.
+
+**Why external emitter driving (not in-composite injection)**
+
+The dashboard's default sqlite path injects a SQLiteEmitter into the
+composite state with `inputs` wired to `agents/0/listeners/...` — when
+the composite divides (parent `'0'` removed, daughters `'00'` + `'01'`
+appear), the injected emitter's static paths don't resolve to anything,
+so it writes empty rows for the rest of the run. Mirrors the same
+problem the xarray runner solves by managing the emitter externally
+and feeding it the followed agent's state per-chunk.
+
+For multi-gen, we construct the SQLiteEmitter externally, run the
+composite in chunks, extract the *currently-followed* agent's state
+after each chunk, and call `emitter.update(...)` directly. On division
+the runner picks the first sorted new agent_id and continues — the
+emitter keeps writing to the same db under the same simulation_id, with
+the changing agent_id encoded in the JSON `state` column.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable
+
+
+def _normalize_emit_paths(emit_paths: list[str]) -> list[tuple[str, ...]]:
+    """Convert dotted/slash emit paths to relative tuple paths.
+
+    Each path may carry an `agents/<id>/` prefix (the legacy form);
+    strip it so the result is rooted at the agent's subtree. Drop empty
+    paths. Dedupe.
+    """
+    out: set[tuple[str, ...]] = set()
+    for p in emit_paths or []:
+        parts = [x for x in str(p).replace(".", "/").split("/") if x]
+        if not parts:
+            continue
+        if parts[0] == "agents" and len(parts) >= 3:
+            parts = parts[2:]
+        out.add(tuple(parts))
+    return sorted(out)
+
+
+def _filter_agent_state(agent_state: dict, leaves: list[tuple[str, ...]]) -> dict:
+    """Pull declared leaves out of one agent's state into a nested dict.
+
+    Each `leaf` is a tuple path under the agent (e.g.
+    `('listeners', 'dnaA_cycle', 'atp_count')`). Missing leaves are left
+    out so the SQLiteEmitter's `emit` schema records JSON `null` rather
+    than crashing.
+    """
+    out: dict = {}
+    for leaf in leaves:
+        if not leaf:
+            continue
+        value: Any = agent_state
+        for k in leaf:
+            value = (value or {}).get(k) if isinstance(value, dict) else None
+            if value is None:
+                break
+        if value is None:
+            continue
+        cursor = out
+        for k in leaf[:-1]:
+            cursor = cursor.setdefault(k, {})
+        cursor[leaf[-1]] = value
+    return out
+
+
+def _build_emit_schema(leaves: list[tuple[str, ...]]) -> dict:
+    """Build a process-bigraph emit schema mirroring the leaf structure.
+
+    SQLiteEmitter's `config.emit` declares which paths it writes. We use
+    `'any'` for the leaf type since the captured values are
+    JSON-serialised; the schema's job here is structural, not type-
+    checking.
+    """
+    schema: dict = {}
+    for leaf in leaves:
+        if not leaf:
+            continue
+        cursor = schema
+        for k in leaf[:-1]:
+            cursor = cursor.setdefault(k, {})
+        cursor[leaf[-1]] = "any"
+    return schema
+
+
+def run_multigen_sqlite(
+    composite: Any,
+    *,
+    run_id: str,
+    db_file: str | Path,
+    emit_paths: list[str],
+    max_steps: int,
+    max_generations: int = 1,
+    chunk: int = 100,
+    initial_agent_id: str = "0",
+    division_detector: Callable[[set[str], set[str]], tuple[bool, str | None]] | None = None,
+    core: Any = None,
+) -> dict:
+    """Run a v2ecoli composite past divisions, externally-driven SQLiteEmitter.
+
+    Args:
+      composite: process-bigraph ``Composite`` with v2ecoli agent state.
+        Should NOT have a SQLiteEmitter already injected — this runner
+        owns the emitter lifecycle.
+      run_id: simulation_id stamp for runs_meta + history rows.
+      db_file: path to the sqlite db. Schema is set up by
+        ``vivarium_dashboard.lib.composite_runs.connect``; this runner
+        only writes history rows.
+      emit_paths: list of dotted/slash paths to capture from the
+        followed agent. Optional `agents/<id>/` prefix is stripped.
+      max_steps: hard cap on total ticks to run.
+      max_generations: cap on how many generations to follow.
+        ``1`` (default) = single-generation behaviour, same as legacy
+        ``run_with_division``.
+      chunk: how many ticks between emitter updates / division checks.
+      initial_agent_id: agent_id to start following.
+      division_detector: optional ``(prev_ids, curr_ids) -> (divided?, daughter_id|None)``
+        override. Default: when the followed agent is absent, pick the
+        first sorted new agent_id (matches
+        :func:`v2ecoli.library.xarray_run.run_multigen_xarray`'s rule).
+      core: process-bigraph core for the SQLiteEmitter. Defaults to
+        ``composite.core``.
+
+    Returns: ``{"steps": int, "generations": list[int]}``.
+
+    Notes:
+      * Composite that *raises* (not just division-via-state-mutation)
+        is terminal regardless of ``max_generations`` — that signal
+        means a real error. v2ecoli's ``dnaa_atp_fraction_clamp`` used
+        to raise on division (band={} on daughter re-init); fixed
+        2026-05-23 so no v2ecoli composite should raise on normal
+        division any more.
+      * No `gather_emitter_results(composite)` is needed downstream —
+        the SQLiteEmitter writes durably to ``db_file`` as we go.
+        Caller should query the db directly.
+    """
+    from process_bigraph.emitter import SQLiteEmitter
+
+    if division_detector is None:
+        def division_detector(prev: set[str], curr: set[str]) -> tuple[bool, str | None]:
+            new = sorted(curr - prev)
+            if len(curr) > len(prev) and new:
+                return True, new[0]
+            return False, None
+
+    leaves = _normalize_emit_paths(emit_paths)
+    emit_schema = _build_emit_schema(leaves)
+    db_path = Path(db_file)
+
+    em = SQLiteEmitter(config={
+        "file_path": str(db_path.parent),
+        "db_file": db_path.name,
+        "simulation_id": run_id,
+        "emit": emit_schema,
+        "subsample": 1,
+        "batch_size": 1,
+    }, core=core or composite.core)
+
+    max_steps = int(max_steps)
+    followed = initial_agent_id
+    gen = 1
+    done = 0
+    gens_seen = [gen]
+    prev_ids = set(((composite.state or {}).get("agents") or {}).keys())
+
+    while done < max_steps:
+        n = min(chunk, max_steps - done)
+        try:
+            composite.run(n)
+        except Exception as e:
+            print(f"[multigen_sqlite] composite stopped at tick {done}: "
+                  f"{type(e).__name__}: {str(e)[:120]}")
+            break
+        done += n
+        agents = (composite.state or {}).get("agents") or {}
+        curr_ids = set(agents.keys())
+
+        if followed in agents:
+            payload = _filter_agent_state(agents[followed], leaves)
+            try:
+                em.update({
+                    "time": float(done),
+                    "global_time": float(done),
+                    "agents": {followed: payload},
+                })
+            except Exception as e:
+                print(f"[multigen_sqlite] emit failed at tick {done}: "
+                      f"{type(e).__name__}: {str(e)[:120]}")
+        else:
+            # The followed agent disappeared — division. Pick daughter
+            # if we have generations left; else stop.
+            if gen >= max_generations:
+                break
+            divided, daughter = division_detector(prev_ids, curr_ids)
+            if not divided or daughter is None:
+                remaining = sorted(curr_ids)
+                if not remaining:
+                    break
+                daughter = remaining[0]
+            followed = daughter
+            gen += 1
+            gens_seen.append(gen)
+            print(f"[multigen_sqlite] gen {gen} → following agent "
+                  f"{followed!r} at tick {done}")
+            # Emit immediately so the gen handoff has a marker row.
+            if followed in agents:
+                payload = _filter_agent_state(agents[followed], leaves)
+                try:
+                    em.update({
+                        "time": float(done),
+                        "global_time": float(done),
+                        "agents": {followed: payload},
+                    })
+                except Exception:
+                    pass
+        prev_ids = curr_ids
+
+    return {"steps": done, "generations": gens_seen}

--- a/v2ecoli/library/xarray_run.py
+++ b/v2ecoli/library/xarray_run.py
@@ -24,12 +24,22 @@ import shutil
 from pathlib import Path
 from typing import Any, Callable
 
+import numpy as np
+
 from v2ecoli.library.xarray_emitter import XArrayEmitter
 
 
-#: v2ecoli observables known to be vectors/arrays — auto-view skips them.
-#: Vectors need an explicit view config with a declared shape; the auto-view
-#: only handles scalar leaves for v0.
+#: v2ecoli observables known to be vectors/arrays.
+#:
+#: Vectors need a coord array in ``output_metadata`` so XArrayEmitter can
+#: allocate them as (buf_size, N)-shape buffers instead of scalar slots.
+#: :func:`extract_output_metadata_from_state` discovers coord arrays from
+#: the composite's live state.
+#:
+#: ``view_from_emit_paths`` previously SKIPPED these leaves entirely
+#: (so vector-only studies fell back to SQLite). Setting
+#: ``include_vectors=True`` (the default since 2026-05-23) keeps them
+#: in the view; the caller supplies output_metadata.
 _KNOWN_VECTOR_LEAVES: set[str] = {
     "monomer_counts",
     "mRna_counts",
@@ -42,6 +52,7 @@ _KNOWN_VECTOR_LEAVES: set[str] = {
 def view_from_emit_paths(
     emit_paths: list[str], *, default_dtype: str = "<f8",
     skip_leaves: set[str] | None = None,
+    include_vectors: bool = True,
 ) -> list[dict]:
     """Build a v2ecoli-shaped XArray view config from a flat list of dotted emit paths.
 
@@ -55,7 +66,13 @@ def view_from_emit_paths(
     Default dtype is ``<f8`` (float64); pass an explicit ``dtype_overrides``
     map at the call site if int dtypes are needed for specific leaves.
     """
-    skip = (skip_leaves if skip_leaves is not None else _KNOWN_VECTOR_LEAVES)
+    # Behaviour: by default INCLUDE known vector leaves (caller must supply
+    # output_metadata coord arrays); old callers using include_vectors=False
+    # keep the legacy scalar-only behaviour.
+    if skip_leaves is None:
+        skip = set() if include_vectors else _KNOWN_VECTOR_LEAVES
+    else:
+        skip = skip_leaves
     variables: dict = {}
     for p in emit_paths:
         # Accept dotted or slash-separated paths; strip optional agents/<id>/ prefix.
@@ -77,6 +94,75 @@ def view_from_emit_paths(
     return [{"root": ("listeners",), "variables": variables}]
 
 
+def _flatten_keys(d: dict, prefix: str = "") -> Any:
+    for k, v in d.items():
+        full = f"{prefix}.{k}" if prefix else k
+        if isinstance(v, dict):
+            yield from _flatten_keys(v, full)
+        else:
+            yield full
+
+
+def extract_output_metadata_from_state(state: dict, view: list[dict]) -> dict:
+    """Inspect a live composite state + a view config; build XArrayEmitter
+    ``output_metadata`` with integer-indexed coord arrays for vector leaves.
+
+    XArrayEmitter consumes ``config["output_metadata"]`` at construction time
+    to learn the per-leaf coord arrays (which determine each variable's
+    additional dimension beyond the time axis). Scalar leaves get no coord
+    (and the storage allocates a scalar slot per emit step). Vector leaves
+    need a coord array — currently defaults to integer indices
+    ``list(range(N))`` where N is the vector length discovered in state.
+
+    The returned dict mirrors the view's path structure (so
+    ``make_coords`` can resolve each leaf via ``get_in``).
+
+    Reads from ``state['agents']['0']`` first; falls back to top-level state.
+    Returns ``{}`` if no vector leaves found (XArrayEmitter then renders all
+    leaves as scalars, the legacy behaviour).
+
+    Output is shaped RELATIVE to the view root: e.g. for view
+    ``root=('listeners',)`` with a vector leaf ``monomer_counts``, the result
+    is ``{'monomer_counts': [0..N-1]}`` — NOT ``{'listeners': {...}}``.
+    TreeView.make_coords does ``get_in(coords, root.metadata_path)`` where
+    metadata_path is ``()`` for plain listener roots, then walks the leaf
+    paths from there. So the coords dict must be flat under the view root.
+    """
+    cell = (state.get("agents") or {}).get("0") or state
+    if not isinstance(cell, dict):
+        return {}
+
+    out: dict = {}
+    for entry in view:
+        root_path = tuple(entry.get("root") or ())
+        # Walk the state to the view root.
+        cursor: Any = cell
+        for k in root_path:
+            cursor = (cursor or {}).get(k, {})
+        if not isinstance(cursor, dict):
+            continue
+        # For each declared leaf, check if the value at that path is a vector.
+        for leaf_input_path, leaf_output_name in _view_leaves([entry]):
+            value: Any = cursor
+            for k in leaf_input_path:
+                value = (value or {}).get(k)
+                if value is None:
+                    break
+            if value is None:
+                continue
+            arr = np.asarray(value)
+            if arr.ndim == 0 or arr.size <= 1:
+                continue  # scalar — no coord needed
+            # Build integer coord = 0..N-1 and nest it under leaf path
+            # (RELATIVE to root — see docstring).
+            coord = list(range(int(arr.shape[0])))
+            cursor_out = out
+            for k in leaf_input_path[:-1]:
+                cursor_out = cursor_out.setdefault(k, {})
+            cursor_out[leaf_input_path[-1] if leaf_input_path else leaf_output_name] = coord
+    return out
+
+
 def _view_leaves(view: list[dict]) -> list[tuple[tuple[str, ...], str]]:
     """Walk a view config; return [(input_path_under_root, output_name), ...]."""
     leaves: list[tuple[tuple[str, ...], str]] = []
@@ -92,6 +178,78 @@ def _view_leaves(view: list[dict]) -> list[tuple[tuple[str, ...], str]]:
     for entry in view:
         walk(entry.get("variables", {}), ())
     return leaves
+
+
+def filter_view_to_existing_leaves(state: dict, view: list[dict]) -> list[dict]:
+    """Drop view leaves that aren't produced by the composite's current state.
+
+    XArrayEmitter raises ``KeyError: Missing emit paths`` when the view
+    declares a leaf the composite doesn't emit. SQLite was lenient and
+    silently captured only what was there. This mirrors that leniency
+    for the xarray path: walks each leaf path in ``state['agents']['0']``,
+    drops any leaf whose value is ``None`` (path doesn't exist), and
+    returns a new view with the same shape minus the missing leaves.
+
+    Empty variable subtrees collapse out — if a TreeView ends up with no
+    leaves it is removed entirely (TreeView raises ``Missing arguments``
+    on an empty variables dict).
+    """
+    cell = (state.get("agents") or {}).get("0") or state
+    if not isinstance(cell, dict):
+        return view
+
+    out_view: list[dict] = []
+    for entry in view:
+        root_path = tuple(entry.get("root") or ())
+        cursor: Any = cell
+        for k in root_path:
+            cursor = (cursor or {}).get(k, {})
+        if not isinstance(cursor, dict):
+            continue
+
+        # Rebuild the variables dict, keeping only present leaves.
+        # A leaf is "present" iff the composite emits a scalar/array at it.
+        # Missing OR empty-container values (None, {}, []) are dropped — they
+        # show up when ``inject_emitter_for_declared_paths`` registers a path
+        # whose listener Step isn't in this particular composite variant
+        # (the schema default for the slot is an empty container).
+        # XArrayEmitter raises ``KeyError: Missing emit paths`` on those at
+        # tick 1 because ``dict_to_paths`` yields nothing for an empty
+        # container, so the path never gets discarded from ``emit_queue``.
+        new_vars: dict = {}
+        kept_any = False
+        for leaf_input_path, leaf_output_name in _view_leaves([entry]):
+            value: Any = cursor
+            for k in leaf_input_path:
+                value = (value or {}).get(k)
+                if value is None:
+                    break
+            if value is None:
+                continue
+            if isinstance(value, (dict, list, str)) and len(value) == 0:
+                continue
+            # Re-attach this leaf at its original path in new_vars.
+            # Need to find the original list-spec from entry["variables"].
+            orig_spec = entry.get("variables", {})
+            for k in leaf_input_path[:-1]:
+                orig_spec = orig_spec.get(k, {})
+            if not isinstance(orig_spec, dict):
+                continue
+            spec_list = orig_spec.get(leaf_input_path[-1] if leaf_input_path else leaf_output_name)
+            if not isinstance(spec_list, list):
+                continue
+            cursor_out = new_vars
+            for k in leaf_input_path[:-1]:
+                cursor_out = cursor_out.setdefault(k, {})
+            cursor_out[leaf_input_path[-1] if leaf_input_path else leaf_output_name] = spec_list
+            kept_any = True
+
+        if kept_any:
+            new_entry = dict(entry)
+            new_entry["variables"] = new_vars
+            out_view.append(new_entry)
+
+    return out_view
 
 
 def _filter_agent_state(agent_state: dict, view: list[dict]) -> dict:
@@ -131,6 +289,7 @@ def _build_emitter(
     generation: int,
     agent_id: str,
     buffer_size: int = 4,
+    output_metadata: dict | None = None,
 ) -> XArrayEmitter:
     md = dict(metadata_base)
     md["agent_id"] = agent_id
@@ -152,7 +311,7 @@ def _build_emitter(
         "metadata": md,
         "metadata_keys": [],
         "metadata_validators": {},
-        "output_metadata": {},
+        "output_metadata": output_metadata or {},
         "debug": False,
     }
     return XArrayEmitter(config=cfg, core=core)
@@ -203,13 +362,54 @@ def run_multigen_xarray(
                 return True, new[0]
             return False, None
 
+    # Discover output_metadata (coord arrays) for any vector leaves in the
+    # view by inspecting the composite's live state. Without this, vector
+    # observables (e.g. listeners.monomer_counts) crash the emitter with
+    # "shape mismatch: value array of shape (N,) could not be broadcast to
+    # indexing result with 0 dimensions."
+    #
+    # At t=0 v2ecoli's listeners are empty dicts — the listener Steps
+    # populate them only on first run-tick. Warm the composite with 1 tick
+    # so the listener vectors materialise and we can read their length.
+    # Cost: we lose tick 0 from the capture, which is fine (the emit
+    # predicate's subsample interval is usually > 1 anyway).
+    try:
+        composite.run(1)
+    except Exception as _e:
+        print(f"[xarray_run] warm-up run failed: {_e!r}")
+    # Filter out view leaves the composite doesn't actually emit. XArrayEmitter
+    # is strict on missing-emit-paths (raises KeyError), so cross-variant views
+    # that target listeners only some composites have would otherwise sink the
+    # run. We mirror SQLite's lenient behaviour: keep what's there, drop what
+    # isn't.
+    state_after_warmup = composite.state or {}
+    filtered_view = filter_view_to_existing_leaves(state_after_warmup, view)
+    if not filtered_view:
+        raise RuntimeError(
+            "[xarray_run] no view leaves remain after filtering against "
+            "composite state — the composite emits none of the declared "
+            f"observables. Declared view: {view}"
+        )
+    dropped = sum(len(_view_leaves([e])) for e in view) - \
+              sum(len(_view_leaves([e])) for e in filtered_view)
+    if dropped:
+        print(f"[xarray_run] dropped {dropped} view leaf(s) absent from composite state")
+    view = filtered_view
+    output_metadata = extract_output_metadata_from_state(state_after_warmup, view)
+    if output_metadata:
+        print(f"[xarray_run] discovered vector coord arrays for: "
+              f"{list(_flatten_keys(output_metadata))}")
+
     followed = initial_agent_id
     gen = 1
     em = _build_emitter(
         core=core, store_path=store_path, view=view,
         metadata_base=metadata_base, generation=gen, agent_id=followed,
+        output_metadata=output_metadata,
     )
-    done = 0
+    # ``done`` counts ticks already advanced past tick 0 (we used 1 for the
+    # coord-discovery warm-up so first chunk completes at done = 1 + chunk).
+    done = 1
     gens_seen = [gen]
     prev_ids = set(((composite.state or {}).get("agents") or {}).keys())
 
@@ -242,6 +442,7 @@ def run_multigen_xarray(
             em = _build_emitter(
                 core=core, store_path=store_path, view=view,
                 metadata_base=metadata_base, generation=gen, agent_id=followed,
+                output_metadata=output_metadata,
             )
 
         prev_ids = curr_ids


### PR DESCRIPTION
## Summary
Two workspace-agnostic infra additions extracted from the dnaa-replication investigation branch:

### `library/sqlite_run.py` (new) — `run_multigen_sqlite`
Mirrors `xarray_run.run_multigen_xarray` for the SQLite emitter branch. Drives the emitter externally (constructs it, extracts the followed agent's state per chunk, calls `emitter.update(...)`). On division it picks the first sorted new agent_id and continues.

External-emitter pattern is required because the dashboard's default sqlite injection wires the emitter to `agents/0/listeners/...` statically; post-division when the parent disappears it writes empty rows. Verified end-to-end on dnaa-02 3500-tick smoke — history rows span generations with real data on both sides of division.

Paired with vivarium-dashboard PR #105 (already merged) which wires the subprocess template to import this when `max_generations > 1`.

### `library/xarray_run.py` — vector observables + view filter
- `extract_output_metadata_from_state(state, view)` — discover coord arrays for vector leaves (e.g. `listeners.monomer_counts`, 4309 elements)
- `filter_view_to_existing_leaves(state, view)` — drop view leaves the composite doesn't emit; mirrors SQLite's lenient behaviour
- `view_from_emit_paths(..., include_vectors=True)` — keep known vector leaves in view; caller supplies output_metadata

## Test plan
- [x] dnaa-02 3500-tick smoke: history rows show parent `'0'` then daughter `'00'` with real listener values
- [x] dnaa-07 seed-sweep: 6 zarr stores × `monomer_counts[3861]` overlay renders 6 traces (vector support)
- [x] dnaa-04 cross-variant: `view_from_emit_paths` + `filter_view_to_existing_leaves` no longer crash on heuristic-only-control's missing dnaA_initiation listener

🤖 Generated with [Claude Code](https://claude.com/claude-code)