### PR TITLE
docs(AGENTS): codify PR conventions — feature PRs vs investigation PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,3 +207,41 @@ pytest -m sim tests/test_model_behavior.py   # behavior tests
 
 If you changed a process, also run the relevant report script and attach the
 output HTML (or the diff against `main`) to the PR.
+
+## PR conventions
+
+Two distinct PR types live in this repo, and they look different on GitHub:
+
+### Feature / fix PRs (merge candidates)
+
+Standard `gh pr create`. Conventional-commit-style title
+(`feat(...)`, `fix(...)`, `chore(...)`). Opens as ready-for-review (not
+draft). Target `main`. CI must pass before merge. Live examples: most
+PRs on `main`'s log.
+
+### Investigation PRs (living integration branches)
+
+A long-running branch hosting an investigation (a collection of related
+studies under a shared research question). NOT a merge target — the
+branch lives indefinitely; infrastructure carved out of it gets shipped
+via separate feature PRs against `main`.
+
+Two conventions:
+
+1. **Title prefix `investigation:`** — e.g.
+   `investigation: DnaA-driven replication initiation — mechanistic vs heuristic`.
+   Visually distinguishes from feature PRs in the PR list.
+
+2. **Draft state** — open with `gh pr create --draft ...` (or, when
+   creating from the vivarium-dashboard GitHub tab, the `draft=True`
+   default applies automatically). Draft signals "don't merge me" to
+   both reviewers and to GitHub's auto-merge / branch-policy machinery.
+
+Live examples on this repo: #59 (dnaa-replication), #69 (multiscale-
+bioprocess), #72 (PDMP whole-cell reformulation).
+
+Body should call out:
+- That this branch is NOT a merge target.
+- Companion feature PRs (already merged) that ship the infrastructure
+  this investigation depends on, vs. content that stays on this branch.
+- The investigation's primary research question + headline figures.


### PR DESCRIPTION
## What
Adds a "PR conventions" section to AGENTS.md describing the two PR types in this repo:

1. **Feature / fix PRs** — standard \`gh pr create\`, conventional-commit title, opens ready-for-review, targets \`main\`, CI must pass.
2. **Investigation PRs** — long-running integration branches for collections of related studies. Open with \`gh pr create --draft\`, title prefix \`investigation:\`. **NOT** merge targets; infrastructure carved out of them ships via separate feature PRs against \`main\`.

## Why
Three open investigation PRs already follow the convention manually (#59 dnaa-replication, #69 multiscale-bioprocess, #72 PDMP). New agents + human contributors should find this documented on repo entry rather than rediscover it.

## Companion
- **vivarium-dashboard PR #113** (open as draft) — auto-prefixes \`investigation:\` + opens as draft when PR is created from the dashboard's GitHub tab on a branch touching \`investigations/\`. Enforces the convention end-to-end for the dashboard-driven path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)