### PR TITLE
infra(agents+test): PR conventions doc + CI utf-8 fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,3 +207,41 @@ pytest -m sim tests/test_model_behavior.py   # behavior tests
 
 If you changed a process, also run the relevant report script and attach the
 output HTML (or the diff against `main`) to the PR.
+
+## PR conventions
+
+Two distinct PR types live in this repo, and they look different on GitHub:
+
+### Feature / fix PRs (merge candidates)
+
+Standard `gh pr create`. Conventional-commit-style title
+(`feat(...)`, `fix(...)`, `chore(...)`). Opens as ready-for-review (not
+draft). Target `main`. CI must pass before merge. Live examples: most
+PRs on `main`'s log.
+
+### Investigation PRs (living integration branches)
+
+A long-running branch hosting an investigation (a collection of related
+studies under a shared research question). NOT a merge target — the
+branch lives indefinitely; infrastructure carved out of it gets shipped
+via separate feature PRs against `main`.
+
+Two conventions:
+
+1. **Title prefix `investigation:`** — e.g.
+   `investigation: DnaA-driven replication initiation — mechanistic vs heuristic`.
+   Visually distinguishes from feature PRs in the PR list.
+
+2. **Draft state** — open with `gh pr create --draft ...` (or, when
+   creating from the vivarium-dashboard GitHub tab, the `draft=True`
+   default applies automatically). Draft signals "don't merge me" to
+   both reviewers and to GitHub's auto-merge / branch-policy machinery.
+
+Live examples on this repo: #59 (dnaa-replication), #69 (multiscale-
+bioprocess), #72 (PDMP whole-cell reformulation).
+
+Body should call out:
+- That this branch is NOT a merge target.
+- Companion feature PRs (already merged) that ship the infrastructure
+  this investigation depends on, vs. content that stays on this branch.
+- The investigation's primary research question + headline figures.

--- a/tests/test_workflow_parca_integration.py
+++ b/tests/test_workflow_parca_integration.py
@@ -76,7 +76,7 @@ def test_workflow_has_no_external_vecoli_paths():
     """Structural smoke test — the rewritten workflow_report.py must not
     import from bare ``reconstruction`` / ``wholecell`` (the vEcoli top-
     level) and must not path-join into ``../vEcoli/``."""
-    src = (REPO_ROOT / 'reports' / 'workflow_report.py').read_text()
+    src = (REPO_ROOT / 'reports' / 'workflow_report.py').read_text(encoding='utf-8')
     assert not re.search(
         r"^from (reconstruction|wholecell)\.", src, re.MULTILINE), \
         'workflow_report.py still imports bare vEcoli modules — should use ' \


### PR DESCRIPTION
## Summary
Two pure-infrastructure changes that surfaced while the dnaa investigation branch was being closed out — carved into their own ready-for-review PR off main so they ship independently of any biology work.

- **fix(test):** force `encoding='utf-8'` when reading `reports/workflow_report.py` in the structural smoke test. CI's default ASCII locale was tripping on the em-dashes in the file's docstring (`UnicodeDecodeError`), failing the test.
- **docs(AGENTS):** new "PR conventions" section codifying two distinct PR types in this repo — standard Feature/fix PRs (merge candidates) vs Investigation PRs (`investigation:` title prefix + draft state; not merge targets). Lists live examples (#59, #69, #72).

## Why
- CI fix is small but blocks the test workflow on any branch that triggers it.
- AGENTS.md change makes a previously-tribal convention discoverable, so future contributors (and AI assistants) won't accidentally try to merge investigation branches to main.

## Test plan
- [x] `pytest tests/test_workflow_parca_integration.py::test_workflow_has_no_external_vecoli_paths` passes locally
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)