### PR TITLE
fix(sqlite_run): rebuild composite path caches after agent prune (multi-gen daughter crash)

### DIFF
--- a/scripts/debug_multigen_daughter_crash.py
+++ b/scripts/debug_multigen_daughter_crash.py
@@ -1,0 +1,101 @@
+"""Minimal repro for the multi-gen sqlite daughter crash.
+
+Builds dnaa_stage1_constitutive on the Stage-1 glycerol cache, runs to
+first division (~5000 ticks ≈ 83 min on glycerol), then applies the
+same prune that `_prune_to_followed_lineage` does in
+`v2ecoli/library/sqlite_run.py`, then attempts `composite.run(1)` to
+capture the exception.
+
+Goal: see the actual exception type + traceback so we can fix the prune
+or the daughter-state init.
+
+Usage:
+    .venv/bin/python scripts/debug_multigen_daughter_crash.py
+"""
+from __future__ import annotations
+
+import sys
+import traceback
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+
+def main() -> None:
+    import warnings
+    warnings.filterwarnings("ignore")
+    from v2ecoli.core import build_core
+    from v2ecoli.composites.baseline_recipes import dnaa_stage1_constitutive
+    from process_bigraph import Composite
+
+    print("[1/4] building composite on out/cache-stage1-glycerol ...", flush=True)
+    core = build_core()
+    doc = dnaa_stage1_constitutive(
+        core=core, seed=0, cache_dir="out/cache-stage1-glycerol")
+    composite = Composite({"state": doc.get("state", doc)}, core=core)
+    initial_agents = sorted((composite.state.get("agents") or {}).keys())
+    print(f"  initial agents: {initial_agents}", flush=True)
+
+    print("[2/4] running until first division (max 6000 ticks, chunk 100) ...",
+          flush=True)
+    done = 0
+    while done < 6000:
+        composite.run(100)
+        done += 100
+        agents = composite.state.get("agents") or {}
+        agent_ids = sorted(agents.keys())
+        if set(agent_ids) != set(initial_agents):
+            print(f"  DIVISION at tick {done}: {initial_agents} → {agent_ids}",
+                  flush=True)
+            break
+    else:
+        print(f"  no division within 6000 ticks; last agents={agent_ids}", flush=True)
+        return
+
+    # Daughter selection: smallest agent_id (matches sqlite_run's default).
+    daughter = sorted(set(agent_ids) - set(initial_agents))[0]
+    print(f"[3/4] pruning to followed lineage = {daughter!r} (mirrors "
+          f"_prune_to_followed_lineage)", flush=True)
+    agents = composite.state["agents"]
+    to_drop = [aid for aid in list(agents.keys()) if aid != daughter]
+    for aid in to_drop:
+        del agents[aid]
+    # APPLY THE FIX from sqlite_run.py: rebuild composite path caches
+    # to drop stale refs to the deleted agent.
+    print(f"  before find_instance_paths: process_paths has "
+          f"{len(composite.process_paths)} entries; front has {len(composite.front)}",
+          flush=True)
+    composite.find_instance_paths(composite.state)
+    print(f"  after  find_instance_paths: process_paths has "
+          f"{len(composite.process_paths)} entries; front has {len(composite.front)}",
+          flush=True)
+    import gc
+    gc.collect()
+    print(f"  pruned {len(to_drop)} sibling(s); state['agents'] now = "
+          f"{sorted(agents.keys())}", flush=True)
+
+    print(f"[4/4] attempting composite.run(1) — expecting the crash ...",
+          flush=True)
+    try:
+        composite.run(1)
+    except Exception as e:
+        print(f"\n*** CAPTURED EXCEPTION ***", flush=True)
+        print(f"  type: {type(e).__name__}", flush=True)
+        print(f"  message: {e}", flush=True)
+        print(f"\n--- full traceback ---", flush=True)
+        traceback.print_exc()
+        return
+    # If we get here, no crash. Try a few more ticks.
+    print(f"  composite.run(1) succeeded! Trying 100 more ticks...", flush=True)
+    try:
+        composite.run(100)
+        print(f"  composite.run(100) also succeeded — bug not reproduced!", flush=True)
+    except Exception as e:
+        print(f"\n*** CAPTURED EXCEPTION on 100 ticks ***", flush=True)
+        print(f"  type: {type(e).__name__}", flush=True)
+        print(f"  message: {e}", flush=True)
+        traceback.print_exc()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_prune_to_followed_lineage.py
+++ b/tests/test_prune_to_followed_lineage.py
@@ -1,0 +1,101 @@
+"""Regression test for `prune_to_followed_lineage`.
+
+The bug being guarded against (2026-05-25, fixed in 7f3d0a2):
+process-bigraph's Composite caches `process_paths` / `step_paths` /
+`front` from the most recent `find_instance_paths` call. Deleting an
+agent from `composite.state['agents']` without rebuilding those caches
+leaves dangling None refs that crash on the next tick with
+`TypeError: 'NoneType' object is not subscriptable` in run_process.
+
+These tests pin the contract:
+  1. siblings are deleted from state.agents
+  2. composite.find_instance_paths(composite.state) is called after the
+     delete (the actual fix — without it, run() crashes next tick)
+  3. count of dropped agents is returned
+
+Tests use a tiny mock composite (state + find_instance_paths spy) so
+they don't need a full v2ecoli composite — fast + isolated.
+"""
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from v2ecoli.library.sqlite_run import prune_to_followed_lineage
+
+
+def _fake_composite(agent_ids: list[str]) -> Any:
+    """Tiny mock composite. `state['agents']` populated with mock agents;
+    `find_instance_paths` is a Mock so we can assert it was called."""
+    comp = MagicMock()
+    comp.state = {"agents": {aid: {"_mock_agent": aid} for aid in agent_ids}}
+    return comp
+
+
+def test_drops_all_but_followed_lineage():
+    comp = _fake_composite(["00", "01"])
+    dropped = prune_to_followed_lineage(comp, "00")
+    assert dropped == 1
+    assert sorted(comp.state["agents"].keys()) == ["00"]
+
+
+def test_no_op_when_only_followed_present():
+    comp = _fake_composite(["00"])
+    dropped = prune_to_followed_lineage(comp, "00")
+    assert dropped == 0
+    assert sorted(comp.state["agents"].keys()) == ["00"]
+
+
+def test_handles_missing_followed_in_state():
+    # followed_id not in state — drop everything.
+    comp = _fake_composite(["00", "01"])
+    dropped = prune_to_followed_lineage(comp, "doesnotexist")
+    assert dropped == 2
+    assert comp.state["agents"] == {}
+
+
+def test_drops_many_siblings():
+    comp = _fake_composite(["0", "00", "01", "10", "11"])
+    dropped = prune_to_followed_lineage(comp, "0")
+    assert dropped == 4
+    assert sorted(comp.state["agents"].keys()) == ["0"]
+
+
+def test_calls_find_instance_paths_after_delete():
+    """THE REGRESSION TEST. Without this call, the composite's cached
+    process_paths/step_paths/front hold dangling refs and the next tick
+    crashes."""
+    comp = _fake_composite(["00", "01"])
+    prune_to_followed_lineage(comp, "00")
+    comp.find_instance_paths.assert_called_once()
+    # And it must be called with the NOW-pruned state.
+    args, _ = comp.find_instance_paths.call_args
+    assert args[0] is comp.state
+    assert sorted(args[0]["agents"].keys()) == ["00"]
+
+
+def test_call_order_state_mutation_before_find_instance_paths():
+    """The state must be pruned BEFORE find_instance_paths is called —
+    otherwise find_instance_paths sees the stale (un-pruned) state and
+    re-registers paths we're about to drop."""
+    comp = _fake_composite(["00", "01"])
+    captured = {}
+
+    def capture(state):
+        captured["agents_at_call_time"] = sorted(state.get("agents", {}).keys())
+
+    comp.find_instance_paths.side_effect = capture
+    prune_to_followed_lineage(comp, "00")
+    assert captured["agents_at_call_time"] == ["00"]
+
+
+def test_empty_state_no_crash():
+    comp = MagicMock()
+    comp.state = {}
+    dropped = prune_to_followed_lineage(comp, "00")
+    assert dropped == 0
+    # find_instance_paths still called (defensive: composite may have
+    # other internal state we want re-derived).
+    comp.find_instance_paths.assert_called_once()

--- a/v2ecoli/library/sqlite_run.py
+++ b/v2ecoli/library/sqlite_run.py
@@ -81,16 +81,84 @@ def _build_emit_schema(leaves: list[tuple[str, ...]]) -> dict:
     `'any'` for the leaf type since the captured values are
     JSON-serialised; the schema's job here is structural, not type-
     checking.
+
+    Conflict handling: when a leaf is a strict prefix of another leaf
+    (e.g. `agents/0/listeners/monomer_counts` AND
+    `agents/0/listeners/monomer_counts/monomerCounts`), drop the
+    shorter one and keep the more specific. Mixing them yields a
+    'str does not support item assignment' crash on `cursor.setdefault`
+    when the second-pass walks into a key that was already set to 'any'.
+    Surfaced 2026-05-25 wiring dnaa-01's `agents/0/listeners/monomer_counts`
+    readout alongside an existing `monomer_counts/monomerCounts` test
+    measure path.
     """
+    leaf_set = {tuple(l) for l in leaves if l}
+    # Drop any leaf that is a strict prefix of a longer leaf in the set.
+    keep: list[tuple[str, ...]] = []
+    for leaf in leaf_set:
+        is_prefix_of_other = any(
+            other != leaf and len(other) > len(leaf) and other[:len(leaf)] == leaf
+            for other in leaf_set
+        )
+        if not is_prefix_of_other:
+            keep.append(leaf)
+
     schema: dict = {}
-    for leaf in leaves:
-        if not leaf:
-            continue
+    for leaf in keep:
         cursor = schema
         for k in leaf[:-1]:
             cursor = cursor.setdefault(k, {})
         cursor[leaf[-1]] = "any"
     return schema
+
+
+def prune_to_followed_lineage(composite: Any, followed_id: str) -> int:
+    """Drop all agents from ``composite.state['agents']`` except ``followed_id``.
+
+    Used by :func:`run_multigen_sqlite` when ``single_daughters=True`` to
+    bound peak memory at the one-cell footprint instead of 2^N at
+    generation N (v2ecoli's composite is single-cell-by-design but
+    follows all daughters in state by default).
+
+    CRITICAL behaviour: process-bigraph's Composite caches
+    ``process_paths`` / ``step_paths`` / ``front`` /
+    ``_active_protocol_runtimes`` from the most recent
+    :meth:`find_instance_paths` call. Simply deleting
+    ``state['agents']['01']`` leaves those caches with dangling entries
+    that resolve to ``None`` on the next tick — ``composite.run_process``
+    then crashes with::
+
+        TypeError: 'NoneType' object is not subscriptable
+        at process_bigraph/composite.py:2834
+            state_interval = process['interval']
+
+    The fix: call ``composite.find_instance_paths(composite.state)``
+    after the agent deletes. That rebuilds ``process_paths`` /
+    ``step_paths`` against the pruned state, and also pops stale entries
+    from ``self.front`` (composite.py:1789–1791).
+
+    Args:
+        composite: process-bigraph Composite. Must expose ``state`` (a dict
+            with optional ``"agents"`` key) and ``find_instance_paths(state)``.
+        followed_id: agent key to keep. All other agents are deleted.
+
+    Returns:
+        Number of sibling agents dropped.
+
+    Bug history: 2026-05-25 multi-gen sqlite reproduction (commit 7f3d0a2)
+    captured the dangling-ref crash. Memory note:
+    ``multigen-sqlite-daughter-run-crashes``.
+    """
+    state = composite.state or {}
+    agents = state.get("agents") or {}
+    to_drop = [aid for aid in list(agents.keys()) if aid != followed_id]
+    for aid in to_drop:
+        try:
+            del agents[aid]
+        except KeyError:
+            pass
+    composite.find_instance_paths(composite.state)
+    return len(to_drop)
 
 
 def run_multigen_sqlite(
@@ -188,23 +256,6 @@ def run_multigen_sqlite(
     gens_seen = [gen]
     prev_ids = set(((composite.state or {}).get("agents") or {}).keys())
 
-    def _prune_to_followed_lineage(state: dict, followed_id: str) -> int:
-        """Drop all agents from state['agents'] except the followed one.
-
-        Only invoked when ``single_daughters=True``. See the
-        run_multigen_sqlite docstring for the rationale (bounds peak
-        memory at one-cell footprint instead of 2^N at generation N).
-        Returns count of dropped agents.
-        """
-        agents = (state or {}).get("agents") or {}
-        to_drop = [aid for aid in list(agents.keys()) if aid != followed_id]
-        for aid in to_drop:
-            try:
-                del agents[aid]
-            except KeyError:
-                pass
-        return len(to_drop)
-
     while done < max_steps:
         n = min(chunk, max_steps - done)
         try:
@@ -247,7 +298,7 @@ def run_multigen_sqlite(
             # semantics; opt in via `single_daughters=True` when memory
             # bounds matter (single-lineage multi-gen studies).
             if single_daughters:
-                dropped = _prune_to_followed_lineage(composite.state or {}, followed)
+                dropped = prune_to_followed_lineage(composite, followed)
                 gc.collect()
                 print(f"[multigen_sqlite] gen {gen} → following agent "
                       f"{followed!r} at tick {done} (single_daughters: "


### PR DESCRIPTION
## Summary

Carved out of `feat/dnaa-mock-investigation-start` (#59) — critical correctness fix that helps any v2ecoli user doing multi-gen + single_daughters.

### Bug

`run_multigen_sqlite` with `single_daughters=True` silently terminated after the first division. Sim's `status='completed'` was reported but only one generation's worth of data was captured.

Root cause: process-bigraph's `Composite` caches `process_paths` / `step_paths` / `front` from the last `find_instance_paths` call. Deleting `state['agents']['01']` after division left those caches with dangling entries that resolved to `None` on the next tick — `composite.run_process` crashed at `state_interval = process['interval']` with `TypeError: 'NoneType' object is not subscriptable` (process_bigraph composite.py:2834). The runner's `try/except` caught it, printed to stdout (lost by the dashboard subprocess wrapper), and returned normally.

### Fix

Lift `_prune_to_followed_lineage` from nested scope to module-level `prune_to_followed_lineage(composite, followed_id)` and call `composite.find_instance_paths(composite.state)` after the agent deletes. Rebuilds path caches against the pruned state + pops stale `self.front` entries.

Bonus: also fixes a separate crash in `_build_emit_schema` when `emit_paths` contains both `X` and `X/Y` (e.g. a readout alongside a test path that's a child of it). Pre-pass drops prefix-conflicting leaves.

### Verification

`scripts/debug_multigen_daughter_crash.py` reproduces the original crash AND verifies the fix end-to-end. Before fix: `composite.run(1)` after prune raises immediately. After fix: `composite.run(1)` + `composite.run(100)` both succeed.

### Tests

`tests/test_prune_to_followed_lineage.py` — 7 tests, all green:
- drops siblings, keeps followed
- no-op / missing-followed / many-siblings handling
- **regression**: `find_instance_paths` is called after delete (THE fix)
- order: state mutation happens BEFORE `find_instance_paths`
- empty state doesn't crash

### Test plan

- [x] 7 new unit tests pass locally
- [x] End-to-end reproducer (debug script) confirms fix
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)