### PR TITLE
feat(scripts): calibration + chromosome-viz + condition-cache tooling

### DIFF
--- a/scripts/build_condition_cache.py
+++ b/scripts/build_condition_cache.py
@@ -161,7 +161,9 @@ def _git_sha() -> str:
 def build(condition: str, fixture: str, cache_dir: str,
           transcription_factor: float, te_factor: float,
           media_condition: str | None = None,
-          fixed_media: str | None = None) -> None:
+          fixed_media: str | None = None,
+          c_period_minutes: float | None = None,
+          d_period_seconds: float | None = None) -> None:
     repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     os.chdir(repo_root)
     if condition not in PATCHES:
@@ -190,15 +192,27 @@ def build(condition: str, fixture: str, cache_dir: str,
         sim_data, transcription_factor, te_factor)
     print(f"    {json.dumps(patch_record['patched'], indent=2)}")
 
+    if c_period_minutes is not None:
+        print(f"[{time.strftime('%H:%M:%S')}] C-period override: "
+              f"{c_period_minutes} min (basal_elongation_rate will be "
+              f"computed from replichore length)")
+    if d_period_seconds is not None:
+        print(f"[{time.strftime('%H:%M:%S')}] D-period override: "
+              f"{d_period_seconds} s ({d_period_seconds/60} min)")
+
     print(f"[{time.strftime('%H:%M:%S')}] Building bundle at {cache_dir} ...")
     save_sim_input(sim_data, cache_dir,
-                   condition=media_condition, fixed_media=fixed_media)
+                   condition=media_condition, fixed_media=fixed_media,
+                   c_period_minutes=c_period_minutes,
+                   d_period_seconds=d_period_seconds)
     write_cache_version(cache_dir, repo_root=repo_root)
 
     manifest = {
         "condition": condition,
         "media_condition": media_condition,
         "fixed_media": fixed_media,
+        "c_period_minutes": c_period_minutes,
+        "d_period_seconds": d_period_seconds,
         "created_at": datetime.datetime.now().isoformat(),
         "git_sha": _git_sha(),
         "base_fixture": fixture,
@@ -229,12 +243,23 @@ def main() -> None:
                          "doubling time (e.g. acetate, succinate; default basal)")
     ap.add_argument("--fixed-media", default=None,
                     help="media id pinned for the whole run (e.g. minimal_acetate)")
+    ap.add_argument("--c-period-min", type=float, default=None,
+                    dest="c_period_minutes",
+                    help="Stage-1 C-period override (e.g. 70). Forwarded to "
+                         "LoadSimData; computes basal_elongation_rate from "
+                         "the cached replichore length.")
+    ap.add_argument("--d-period-min", type=float, default=None,
+                    help="Stage-1 D-period override in MINUTES (e.g. 30). "
+                         "Converted to seconds before forwarding.")
     args = ap.parse_args()
     suffix = f"-{args.media_condition}" if args.media_condition else ""
     cache_dir = args.cache_dir or f"out/cache-{args.condition}{suffix}"
+    d_period_seconds = args.d_period_min * 60.0 if args.d_period_min is not None else None
     build(args.condition, args.fixture, cache_dir,
           args.transcription_factor, args.te_factor,
-          media_condition=args.media_condition, fixed_media=args.fixed_media)
+          media_condition=args.media_condition, fixed_media=args.fixed_media,
+          c_period_minutes=args.c_period_minutes,
+          d_period_seconds=d_period_seconds)
 
 
 if __name__ == "__main__":

--- a/scripts/calibrate_dnaa_stage1.py
+++ b/scripts/calibrate_dnaa_stage1.py
@@ -1,0 +1,221 @@
+"""Calibrate the dnaA Stage-1 condition cache to the absolute expert targets.
+
+The Stage-1 targets (1.5 dnaA mRNA/min/gene, TE 1 protein/mRNA) are NOT
+closed-form in v2ecoli's normalized ParCa representation — basal_prob /
+expression / TE weights renormalize across all TUs/monomers. So we calibrate
+empirically: build the condition cache with scaling factors, run a short sim,
+measure the REALIZED rates from listeners, rescale the factors by
+target/realized, and repeat until within tolerance.
+
+Measured quantities (per iteration):
+  - dnaA mRNA synthesis rate (mRNA/min/gene)
+      = sum_t rnap_data.rna_init_event_per_cistron[dnaA_cistron]
+        / run_minutes / mean(gene_copy_number[dnaA])
+  - realized TE (protein/mRNA)
+      = total dnaA ribosome-initiation events / total dnaA mRNA synthesized
+        over the run. Both are direct INITIATION-EVENT counts
+        (ribosome_data.ribosome_init_event_per_monomer[dnaA] and
+        rnap_data.rna_init_event_per_cistron[dnaA]), so this is the true
+        proteins-made-per-mRNA-made ratio — NOT a count-delta (free-monomer
+        count is confounded by ATP/ADP binding + degradation, which is why
+        the earlier Δprotein proxy gave a spurious 0.037).
+
+Rescale rule (locally linear away from the renorm denominator):
+  transcription_factor *= target_mrna_rate / realized_mrna_rate
+  te_factor            *= target_te        / realized_te
+
+Usage:
+    python scripts/calibrate_dnaa_stage1.py --iterations 1 --sim-minutes 15
+    # iteration 0 uses factors 1.0 (baseline measurement)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import numpy as np
+
+DNAA_CISTRON_GENE = "EG10235"
+DNAA_MONOMER_IDX = 3861          # PD03831[c] in monomer_counts (confirmed)
+TARGET_MRNA_RATE = 1.5           # mRNA/min/gene
+TARGET_TE = 1.0                  # protein/mRNA
+
+
+def _dnaa_cistron_index(sim_data) -> int:
+    gene_ids = np.asarray(sim_data.process.transcription.cistron_data["gene_id"])
+    return int(np.where(gene_ids == DNAA_CISTRON_GENE)[0][0])
+
+
+def measure(cache_dir: str, sim_minutes: float, seed: int = 0) -> dict:
+    """Run the Stage-1 baseline on `cache_dir` and measure realized rates."""
+    import warnings
+    warnings.filterwarnings("ignore")
+    from v2ecoli.composites.baseline_recipes import dnaa_00_baseline_with_dnaa_readout
+    from process_bigraph import Composite
+    import v2ecoli.core as vc
+    from v2ecoli.processes.parca.data_loader import (
+        hydrate_sim_data_from_state, load_parca_state)
+
+    cistron_idx = _dnaa_cistron_index(
+        hydrate_sim_data_from_state(load_parca_state("models/parca/parca_state.pkl.gz")))
+
+    # CRITICAL: v2ecoli.core._load_cache_bundle_cached is lru_cache'd by
+    # cache_dir, so a cache rebuilt between iterations is NOT reloaded within
+    # one process. Clear it so each measurement reflects the freshly-built
+    # cache. (Without this, iteration 1+ silently measures the iteration-0
+    # bundle.) Best practice: also run each iteration in a fresh subprocess.
+    vc._load_cache_bundle_cached.cache_clear()
+
+    core = vc.build_core()
+    doc = dnaa_00_baseline_with_dnaa_readout(seed=seed, cache_dir=cache_dir)
+    comp = Composite({"state": doc["state"]}, core=core)
+
+    total_s = sim_minutes * 60.0
+    # CRITICAL: chunk must be 1.0. rnap_data.rna_init_event_per_cistron is
+    # OVERWRITTEN per tick (it's the events that fired in the most recent
+    # update_period — see v2ecoli/steps/listeners/rnap_data.py). Reading at
+    # chunk=60 captures only the last tick's events, missing 59 ticks of
+    # events per chunk. dnaA-specific rate is low (<<1 event/tick) so this
+    # bias makes the sum round to 0 even when the actual rate is fine.
+    # Same for ribosome_data.ribosome_init_event_per_monomer.
+    # (Original chunk=60 silently undercounted by ~60x.)
+    chunk = 1.0
+    done = 0.0
+    mrna_events = 0.0          # dnaA mRNA initiation events (RNAP)
+    protein_events = 0.0       # dnaA ribosome initiation events
+    copy_samples: list[float] = []
+
+    def _read(path):
+        node = comp.state["agents"]["0"].get("listeners") or {}
+        for k in path:
+            if not isinstance(node, dict):
+                return None
+            node = node.get(k)
+        return node
+
+    while done < total_s:
+        step = min(chunk, total_s - done)
+        comp.run(step)
+        done += step
+        ev = _read(["rnap_data", "rna_init_event_per_cistron"])
+        if ev is not None and len(ev) > cistron_idx:
+            mrna_events += float(ev[cistron_idx])
+        ri = _read(["ribosome_data", "ribosome_init_event_per_monomer"])
+        if ri is not None and len(ri) > DNAA_MONOMER_IDX:
+            protein_events += float(ri[DNAA_MONOMER_IDX])
+        cn = _read(["rna_synth_prob", "gene_copy_number"])
+        if cn is not None and len(cn) > cistron_idx:
+            copy_samples.append(float(cn[cistron_idx]))
+
+    run_min = total_s / 60.0
+    mean_copy = float(np.mean(copy_samples)) if copy_samples else 1.0
+    mrna_rate = mrna_events / run_min / max(mean_copy, 1e-9)         # mRNA/min/gene
+    # True proteins-made-per-mRNA-made (both are initiation-event counts).
+    realized_te = (protein_events / mrna_events) if mrna_events > 0 else float("nan")
+    return {
+        "mrna_events": mrna_events,
+        "protein_events": protein_events,
+        "mean_gene_copy": mean_copy,
+        "mrna_rate_per_min_per_gene": mrna_rate,
+        "realized_te_protein_per_mrna": realized_te,
+        "run_minutes": run_min,
+    }
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--iterations", type=int, default=1)
+    ap.add_argument("--sim-minutes", type=float, default=15.0)
+    ap.add_argument("--tol", type=float, default=0.15, help="rel. tolerance")
+    ap.add_argument("--condition", default="stage1-heuristic")
+    ap.add_argument("--media-condition", default=None,
+                    help="ParCa nutrient condition (e.g. glycerol). Forwarded "
+                         "to build_condition_cache.py. Cache dir gets the "
+                         "matching -{media} suffix.")
+    ap.add_argument("--fixed-media", default=None,
+                    help="media id (e.g. minimal_glycerol). Forwarded.")
+    ap.add_argument("--fixture", default=None,
+                    help="parca_state.pkl.gz path; pass when calibrating "
+                         "against a fresh-rebuild fixture (e.g. glycerol).")
+    ap.add_argument("--start-tx-factor", type=float, default=1.0,
+                    help="bootstrap transcription factor (default 1.0). Set to "
+                         "the prior-converged value when recalibrating a "
+                         "different condition — at 1.0, ParCa's basal dnaA "
+                         "rate is so low (~0.05/min/gene) that a 15-min sim "
+                         "sees 0 events and the rescale loop divides by zero.")
+    ap.add_argument("--start-te-factor", type=float, default=1.0,
+                    help="bootstrap translation efficiency factor (default 1.0). "
+                         "Same zero-realized concern as --start-tx-factor.")
+    ap.add_argument("--zero-fallback-multiplier", type=float, default=10.0,
+                    help="when realized rate is zero (no events), multiply the "
+                         "factor by this to bootstrap upward instead of dividing "
+                         "by zero. Default 10 = order-of-magnitude jump.")
+    args = ap.parse_args()
+
+    import subprocess
+    tx_factor, te_factor = float(args.start_tx_factor), float(args.start_te_factor)
+    suffix = f"-{args.media_condition}" if args.media_condition else ""
+    cache_dir = f"out/cache-{args.condition}{suffix}"
+    history = []
+    for it in range(args.iterations + 1):  # iteration 0 = baseline measurement
+        print(f"\n=== iteration {it}: tx_factor={tx_factor:.4g} te_factor={te_factor:.4g} ===",
+              flush=True)
+        t0 = time.time()
+        build_cmd = [sys.executable, "scripts/build_condition_cache.py",
+                     "--condition", args.condition,
+                     "--transcription-factor", str(tx_factor),
+                     "--te-factor", str(te_factor)]
+        if args.media_condition:
+            build_cmd += ["--media-condition", args.media_condition]
+        if args.fixed_media:
+            build_cmd += ["--fixed-media", args.fixed_media]
+        if args.fixture:
+            build_cmd += ["--fixture", args.fixture]
+        subprocess.run(build_cmd, check=True, capture_output=True)
+        m = measure(cache_dir, args.sim_minutes)
+        m.update({"iteration": it, "tx_factor": tx_factor, "te_factor": te_factor,
+                  "wall_s": round(time.time() - t0, 1)})
+        history.append(m)
+        print(f"  realized: {m['mrna_rate_per_min_per_gene']:.4g} mRNA/min/gene "
+              f"(target {TARGET_MRNA_RATE}), TE {m['realized_te_protein_per_mrna']:.4g} "
+              f"(target {TARGET_TE}); mean_copy={m['mean_gene_copy']:.3g}", flush=True)
+        # Rescale for next iteration. Zero-realized → multiply by the
+        # zero-fallback factor (bootstrap upward) instead of skipping the
+        # update (which would stall the loop at the cold-start factor).
+        rate = m["mrna_rate_per_min_per_gene"]
+        te = m["realized_te_protein_per_mrna"]
+        if rate and rate > 0:
+            tx_factor *= TARGET_MRNA_RATE / rate
+        else:
+            print(f"  ⚠ realized mRNA rate is 0 (no events in {args.sim_minutes} min); "
+                  f"multiplying tx_factor by {args.zero_fallback_multiplier} to bootstrap upward")
+            tx_factor *= args.zero_fallback_multiplier
+        if te and te == te and te > 0:  # not NaN
+            te_factor *= TARGET_TE / te
+        else:
+            # Don't update te_factor if we have no mRNA events (te is meaningless).
+            # Only fall back when mRNA fires but ribosomes don't (rare).
+            if rate and rate > 0:
+                print(f"  ⚠ realized TE is NaN/0 (events: {m['protein_events']} protein / "
+                      f"{m['mrna_events']} mRNA); multiplying te_factor by {args.zero_fallback_multiplier}")
+                te_factor *= args.zero_fallback_multiplier
+        within = (abs(rate - TARGET_MRNA_RATE) / TARGET_MRNA_RATE < args.tol
+                  if rate else False)
+        if within and it > 0:
+            print("  → within tolerance, stopping.")
+            break
+
+    print("\n=== CALIBRATION HISTORY ===")
+    print(json.dumps(history, indent=2))
+    print(f"\nSuggested factors for next build: "
+          f"--transcription-factor {tx_factor:.6g} --te-factor {te_factor:.6g}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/render_dnaa00_chromosome_viz.py
+++ b/scripts/render_dnaa00_chromosome_viz.py
@@ -1,0 +1,215 @@
+"""Render the dnaa-00 chromosome-state visualization for the investigation report.
+
+Builds the dnaa_00_baseline composite, runs it past the first replication
+initiation (~3000 sim seconds), captures live snapshots from `composite.state`
+at intervals (avoiding the SQLite-emit-loses-numpy-dtype problem), and calls
+`v2ecoli.visualizations.workflow._plot_chromosome_state` to render the
+multi-panel chromosome figure (circular maps at 5 timepoints + replication-fork
+progress timeseries + mass growth).
+
+Output: a self-contained HTML at
+`studies/dnaa-00-parameter-foundation/viz/chromosome_state.html` that wraps the
+matplotlib PNG (base64) in a small page suitable for the report's iframe embed.
+
+Usage:
+  .venv/bin/python scripts/render_dnaa00_chromosome_viz.py [--steps 3600]
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, ".")
+import numpy as np
+from bigraph_schema import allocate_core
+from process_bigraph import Composite
+from pbg_superpowers.composite_generator import _REGISTRY, build_generator
+import v2ecoli.composites  # noqa: F401  - registers composites
+from v2ecoli.visualizations.workflow import _plot_chromosome_state
+
+
+def extract_snapshot(state: dict, t: float) -> dict | None:
+    """Pull the chromosome-state fields out of the live agent state.
+
+    Unique molecules live under ``cell['unique'][<type>]`` as numpy structured
+    arrays (with `_entryState` boolean field marking active entries). Listeners
+    live under ``cell['listeners']`` as plain dicts.
+    """
+    cell = (state.get("agents") or {}).get("0")
+    if not cell:
+        return None
+    mass = cell.get("listeners", {}).get("mass", {}) if isinstance(cell.get("listeners"), dict) else {}
+    unique = cell.get("unique") or {}
+
+    fc = unique.get("full_chromosome")
+    n_chrom = 0
+    if fc is not None and hasattr(fc, "dtype") and "_entryState" in fc.dtype.names:
+        n_chrom = int(fc["_entryState"].view(np.bool_).sum())
+
+    rep = unique.get("active_replisome")
+    fork_coords: list[int] = []
+    fork_domains: list[int] = []
+    if rep is not None and hasattr(rep, "dtype") and "_entryState" in rep.dtype.names:
+        active_rep = rep[rep["_entryState"].view(np.bool_)]
+        if len(active_rep) > 0 and "coordinates" in rep.dtype.names:
+            fork_coords = [int(c) for c in active_rep["coordinates"]]
+            if "domain_index" in active_rep.dtype.names:
+                fork_domains = [int(d) for d in active_rep["domain_index"]]
+
+    domains = unique.get("chromosome_domain")
+    n_domains = 0
+    domain_children: dict[int, list[int]] = {}
+    if domains is not None and hasattr(domains, "dtype") and "_entryState" in domains.dtype.names:
+        active_dom = domains[domains["_entryState"].view(np.bool_)]
+        n_domains = int(len(active_dom))
+        if {"domain_index", "child_domains"}.issubset(set(active_dom.dtype.names)):
+            for entry in active_dom:
+                kids = entry["child_domains"]
+                kids = [int(k) for k in kids if int(k) >= 0]
+                domain_children[int(entry["domain_index"])] = kids
+
+    rnap = unique.get("active_RNAP")
+    rnap_coords: list[int] = []
+    rnap_domains: list[int] = []
+    n_rnap = 0
+    if rnap is not None and hasattr(rnap, "dtype") and "_entryState" in rnap.dtype.names:
+        active_rnap = rnap[rnap["_entryState"].view(np.bool_)]
+        n_rnap = len(active_rnap)
+        if n_rnap > 0 and "coordinates" in rnap.dtype.names:
+            rnap_coords = [int(c) for c in active_rnap["coordinates"]]
+            if "domain_index" in active_rnap.dtype.names:
+                rnap_domains = [int(d) for d in active_rnap["domain_index"]]
+
+    # dnaA-binding (dnaa-03 / load-and-trigger). Fractions of occupied boxes
+    # at oriC for the high-affinity tier (3 boxes: R1/R2/R4) and low-affinity
+    # tier (8 boxes: R5M/τ2/I1-3/C1-3). Multiply by tier sizes to get counts.
+    dnaa_binding = cell.get("listeners", {}).get("dnaA_binding", {}) or {}
+    oric_binding = dnaa_binding.get("oric", {}) or {}
+    high_frac = float(oric_binding.get("high_affinity_occupied", 0.0) or 0.0)
+    low_frac = float(oric_binding.get("low_affinity_occupied", 0.0) or 0.0)
+
+    return {
+        "time": float(t),
+        "n_chromosomes": n_chrom,
+        "n_domains": n_domains,
+        "fork_coords": fork_coords,
+        "fork_domains": fork_domains,
+        "rnap_coords": rnap_coords,
+        "rnap_domains": rnap_domains,
+        "domain_children": domain_children,
+        "n_rnap": n_rnap,
+        "dna_mass": float(mass.get("dna_mass", 0)),
+        "dry_mass": float(mass.get("dry_mass", 0)),
+        "protein_mass": float(mass.get("protein_mass", 0)),
+        # dnaa-03 box-binding fields (may be 0 in other studies' composites).
+        "oric_high_frac": high_frac,
+        "oric_low_frac": low_frac,
+        "oric_high_count": high_frac * 3,
+        "oric_low_count": low_frac * 8,
+    }
+
+
+def render_html(b64_png: str, title: str) -> str:
+    """Wrap a base64 PNG in an iframe-embed-friendly self-contained HTML page.
+
+    Uses the same height-clamp pattern as comparative_viz (``html,body
+    {height:Npx;overflow:hidden}``) so the dashboard's iframe insertion
+    code can pin the iframe to a known height — otherwise scrollHeight
+    measurements on a ``width:100%;height:auto`` image fail before
+    layout completes, leaving the iframe at its 200px min-height.
+
+    The image gets ``max-height: 920px`` so it scales DOWN to fit but
+    keeps its aspect ratio; centered horizontally so narrower iframes
+    don't stretch it wide-and-short.
+    """
+    body_h = 1000  # 920 image + chrome (title + subtitle + padding)
+    img_max_h = 920
+    return (
+        '<!doctype html><html><head><meta charset="utf-8">'
+        f"<title>{title}</title>"
+        f"<style>html,body{{height:{body_h}px;overflow:hidden}}"
+        "body{margin:0;padding:0;background:#fff;font-family:-apple-system,system-ui,sans-serif}"
+        ".wrap{padding:16px 22px;height:100%;box-sizing:border-box;display:flex;flex-direction:column}"
+        "h1{font-size:1.05em;margin:0 0 4px 0;color:#0f172a}"
+        ".sub{color:#6b7280;font-size:0.85em;margin-bottom:12px}"
+        f"img{{display:block;margin:0 auto;max-width:100%;max-height:{img_max_h}px;width:auto;height:auto;"
+        "border:1px solid #e5e7eb;border-radius:6px;object-fit:contain}"
+        "</style></head><body><div class='wrap'>"
+        f"<h1>{title}</h1>"
+        "<div class='sub'>Circular chromosome maps at 5 timepoints across the cell cycle, plus "
+        "replication-fork progress and mass-growth timeseries. Gold triangles = replisomes; "
+        "blue dots = RNAPs; green dot = oriC; red square = Ter. Stacked circles = replicating chromosomes.</div>"
+        f'<img alt="chromosome state" src="data:image/png;base64,{b64_png}"/>'
+        "</div></body></html>"
+    )
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--steps", type=int, default=5000,
+                    help="how many sim ticks to run (default 5000 = one emergent "
+                         "cycle on the Stage-1 glycerol cache; bumped from 600 "
+                         "per Haochen 2026-05-25 ask to cover a full cell cycle)")
+    ap.add_argument("--chunk", type=int, default=60, help="snapshot interval (default 60s)")
+    ap.add_argument("--cache-dir", default="out/cache-stage1-glycerol",
+                    help="composite cache dir (default: Stage-1 glycerol)")
+    ap.add_argument(
+        "--out",
+        default="studies/dnaa-00-parameter-foundation/viz/chromosome_state.html",
+        help="output HTML path (relative to workspace root)",
+    )
+    ap.add_argument(
+        "--spec",
+        default="v2ecoli.composites.baseline_recipes.dnaa_00_baseline_with_dnaa_readout",
+        help="composite spec id",
+    )
+    args = ap.parse_args()
+
+    core = allocate_core()
+    entry = _REGISTRY[args.spec]
+    doc = build_generator(entry, overrides={"seed": 0, "cache_dir": args.cache_dir})
+    comp = Composite({"state": doc.get("state", doc)}, core=core)
+
+    snapshots: list[dict] = []
+    snap0 = extract_snapshot(comp.state, 0.0)
+    if snap0:
+        snapshots.append(snap0)
+
+    done = 0
+    while done < args.steps:
+        n = min(args.chunk, args.steps - done)
+        try:
+            comp.run(n)
+        except Exception as e:
+            print(f"[chromosome_viz] composite stopped at {done}s: {str(e)[:80]}")
+            break
+        done += n
+        snap = extract_snapshot(comp.state, float(done))
+        if snap:
+            snapshots.append(snap)
+        # Stop on division (agents/0 removed).
+        if "0" not in (comp.state.get("agents") or {}):
+            print(f"[chromosome_viz] division at {done}s; stopping")
+            break
+
+    print(f"[chromosome_viz] captured {len(snapshots)} snapshots over {done} sim s")
+    if snapshots:
+        forks_at_end = snapshots[-1].get("fork_coords", [])
+        rnaps_at_end = snapshots[-1].get("rnap_coords", [])
+        chroms_at_end = snapshots[-1].get("n_chromosomes", 0)
+        print(f"[chromosome_viz] final state: {chroms_at_end} chromosome(s), "
+              f"{len(forks_at_end)} replisomes, {len(rnaps_at_end)} RNAPs")
+
+    title = "dnaa-00 — chromosome state across the cell cycle"
+    b64 = _plot_chromosome_state(snapshots, title=title)
+    html = render_html(b64, title)
+
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(html)
+    print(f"[chromosome_viz] wrote {out_path} ({out_path.stat().st_size:,} bytes)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Carved out of `feat/dnaa-mock-investigation-start` (#59). Three tooling improvements that benefit any v2ecoli user.

## scripts/build_condition_cache.py — new flags

  --c-period-min, --d-period-min — Stage-1 cycle-period overrides (forward-compat with a LoadSimData wiring that lives on the investigation branch)

## scripts/calibrate_dnaa_stage1.py — new file + robustness

Calibrator for dnaA Stage-1 mRNA / TE targets. Plus:

  --start-tx-factor / --start-te-factor — bootstrap from a known converged value
  --media-condition / --fixed-media / --fixture — calibrate against non-default ParCa condition
  --zero-fallback-multiplier — handle realized=0 cold-start without dividing by zero
  chunk=1 measurement — was silently undercounting by ~60× (rna_init_event_per_cistron is per-tick overwrite, not cumulative)

**Known limitation** (documented inline + in memory): with the current Option-A patch (`patch_dnaa_stage1` zeros TE + separate constitutive Step), the tx/te factors are ignored by the patch. The calibration loop is currently non-functional for Option A. Ships as a tool whose improvements are valid + forward-compatible.

## scripts/render_dnaa00_chromosome_viz.py — new file + --cache-dir flag

Multi-panel chromosome-state viz (5 timepoints, replisomes + RNAPs at real coords). Despite the name, generally applicable to any composite with full_chromosome / active_replisome / active_RNAP unique molecules.

  --steps default 3600 → 5000 (full emergent cycle on the Stage-1 glycerol cache)
  --cache-dir flag (was hardcoded "out/cache")
  --spec flag for composite id override

## Test plan

- [x] All three scripts run locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)