### PR TITLE
feat(parquet): rerun-infra — flush helper + parquet→viz renderer + lint counts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,9 @@ v2ecoli/processes/parca/**/*.cpython-*.so
 **/runs.db-shm
 **/runs.db-wal
 studies/*/sims/*.subprocess.py
+studies/*/sims/parquet-rerun-*/
 studies/*/viz/
+studies/*/parquet-runs/
 reports/
 investigations/*/viz/
 .dashboard.log

--- a/scripts/lint-workspace.py
+++ b/scripts/lint-workspace.py
@@ -294,7 +294,8 @@ def main() -> None:
     status_counts = Counter(study_statuses)
     status_summary = ", ".join(f"{v} {k}" for k, v in sorted(status_counts.items()))
 
-    # Count runs (by checking for runs.db files)
+    # Count runs from both emitter paths: runs.db (sqlite history) +
+    # parquet-runs/ (per-study hive tree).
     n_active_runs = 0
     n_completed_runs = 0
     for runs_db in (WS_ROOT / "studies").glob("*/runs.db"):
@@ -314,6 +315,16 @@ def main() -> None:
                 conn.close()
         except Exception:
             pass
+    # Each studies/<slug>/parquet-runs/<run_id>/ with a success/ sentinel
+    # counts as one completed run.
+    for parquet_root in (WS_ROOT / "studies").glob("*/parquet-runs"):
+        for run_dir in parquet_root.iterdir():
+            if not run_dir.is_dir():
+                continue
+            if (run_dir / "success").exists():
+                n_completed_runs += 1
+            else:
+                n_active_runs += 1
 
     # Print summary
     ws_name = ws.get("name", "?")

--- a/scripts/render_study_viz.py
+++ b/scripts/render_study_viz.py
@@ -1,0 +1,60 @@
+"""Render all visualizations for a study from its parquet-runs output.
+
+Usage:
+    python scripts/render_study_viz.py <study_slug> [<study_slug> ...]
+    python scripts/render_study_viz.py --all-dnaa
+
+Reads the latest parquet run under ``studies/<slug>/parquet-runs/``, resolves
+each viz registered in ``study.yaml`` against the parquet columns, and writes
+HTML files to ``studies/<slug>/viz/``.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+os.chdir(REPO_ROOT)
+sys.path.insert(0, REPO_ROOT)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("study_slug", nargs="*",
+                   help="study slug(s) to render; e.g. dnaa-02-atp-hydrolysis")
+    p.add_argument("--all-dnaa", action="store_true",
+                   help="render all dnaa-* studies that have visualizations")
+    args = p.parse_args()
+
+    from v2ecoli.library.parquet_viz import render_study_visualizations
+
+    targets: list[str] = list(args.study_slug)
+    if args.all_dnaa:
+        import glob
+        for syaml in sorted(glob.glob("studies/dnaa-*/study.yaml")):
+            slug = syaml.split("/")[1]
+            targets.append(slug)
+    targets = list(dict.fromkeys(targets))  # de-dupe, preserve order
+    if not targets:
+        p.print_help()
+        return 2
+
+    rc = 0
+    for slug in targets:
+        print(f"\n== {slug} ==")
+        try:
+            written = render_study_visualizations(slug)
+            if not written:
+                print("  (no visualizations registered or no parquet run)")
+        except FileNotFoundError as e:
+            print(f"  skip: {e}")
+        except Exception as e:
+            print(f"  error: {e}")
+            rc = 1
+    return rc
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/v2ecoli/composites/_helpers.py
+++ b/v2ecoli/composites/_helpers.py
@@ -416,6 +416,34 @@ def parquet_emitter(*, out_dir: str | None = None,
         set_parquet_emitter_override(None)
 
 
+def flush_parquet(composite, *, success: bool = True) -> int:
+    """Flush all ParquetEmitter steps inside ``composite`` to disk.
+
+    The ``parquet_emitter()`` context manager only sets / clears the global
+    override — it never sees the composite, so it cannot trigger ``close()``
+    on the emitter step. Without an explicit flush the trailing partial
+    batch (rows after the last batch_size flush) stays in memory; only the
+    ``configuration/`` parquet lands, no ``history/`` or ``success/``.
+
+    Call this right before the runner exits its ``with parquet_emitter(...)``
+    block, after the simulation loop completes::
+
+        with parquet_emitter(out_dir=..., experiment_id=...):
+            composite = build_composite(...)
+            ... sim loop ...
+            flush_parquet(composite, success=True)
+
+    Returns the number of ParquetEmitter instances flushed (0 when the
+    [parquet] extra is not installed or the composite has no parquet
+    emitter step).
+    """
+    try:
+        from pbg_emitters import ParquetEmitter
+    except ImportError:
+        return 0
+    return ParquetEmitter.flush_all_in_composite(composite, success=success)
+
+
 # ---------------------------------------------------------------------------
 # Wiring helpers
 # ---------------------------------------------------------------------------

--- a/v2ecoli/library/parquet_viz.py
+++ b/v2ecoli/library/parquet_viz.py
@@ -1,0 +1,250 @@
+"""Render Visualization Steps from a study's parquet-runs output.
+
+The vivarium-dashboard currently reads sim data only from a SQLite emitter's
+``history`` table; its inputs_map → port resolution speaks the SQLite shape.
+When a study runs with ``parquet_emitter()`` instead of ``sqlite_emitter()``,
+the dashboard's data-resolution layer has nothing to read.
+
+This module is the parquet equivalent. Given a study slug, it:
+
+  1. Locates the latest run under ``studies/<slug>/parquet-runs/``
+  2. Loads all ``history/<run_id>/.../history/*.pq`` files into a single
+     time-sorted Polars DataFrame
+  3. For each ``visualizations[]`` entry in ``study.yaml``, resolves
+     ``inputs_map`` (dotted-path observables → parquet columns, with
+     ``.`` translated to ``__``) into a port-keyed state dict
+  4. Instantiates the Visualization subclass (resolved from ``address:
+     local:<ClassName>`` against the workspace's discovered Visualization
+     subclasses) and calls ``update(state)`` to get rendered HTML
+  5. Writes ``studies/<slug>/viz/<viz_name>.html``
+
+Multi-source vizzes (``config.sources: [sim_name_a, sim_name_b]``) are not
+yet supported — the current implementation renders the latest run only.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import pkgutil
+from pathlib import Path
+from typing import Any
+
+import polars as pl
+import yaml
+
+
+def _find_workspace_root(start: Path | None = None) -> Path:
+    """Walk up to find workspace.yaml."""
+    cur = (start or Path.cwd()).resolve()
+    while cur != cur.parent:
+        if (cur / "workspace.yaml").exists():
+            return cur
+        cur = cur.parent
+    raise RuntimeError(
+        "no workspace.yaml found walking up from "
+        f"{(start or Path.cwd()).resolve()}"
+    )
+
+
+def find_latest_parquet_run(study_slug: str,
+                            workspace_root: Path | None = None) -> Path:
+    """Return the most-recent ``studies/<slug>/parquet-runs/<run_id>/``.
+
+    Picks by directory mtime. Raises FileNotFoundError if no runs exist.
+    """
+    ws = workspace_root or _find_workspace_root()
+    parquet_root = ws / "studies" / study_slug / "parquet-runs"
+    if not parquet_root.exists():
+        raise FileNotFoundError(
+            f"no parquet-runs directory for study {study_slug!r} at {parquet_root}"
+        )
+    runs = [p for p in parquet_root.iterdir() if p.is_dir()]
+    if not runs:
+        raise FileNotFoundError(
+            f"no run directories under {parquet_root}"
+        )
+    runs.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+    return runs[0]
+
+
+def load_run_history(parquet_run_dir: Path) -> pl.DataFrame:
+    """Load all history/*.pq for one run into a single time-sorted DataFrame.
+
+    Files are named by the cumulative step number at flush time
+    (``400.pq``, ``800.pq``, ``1801.pq``, ...). Sort by step in the filename
+    so concatenation preserves time order even when the filesystem returns
+    them in arbitrary order.
+    """
+    history_root = parquet_run_dir / "history"
+    if not history_root.exists():
+        raise FileNotFoundError(
+            f"no history/ directory under {parquet_run_dir}"
+        )
+    pq_files = sorted(history_root.rglob("*.pq"),
+                      key=lambda p: int(p.stem) if p.stem.isdigit() else 0)
+    if not pq_files:
+        raise FileNotFoundError(
+            f"no .pq history files under {history_root}"
+        )
+    frames = [pl.read_parquet(p) for p in pq_files]
+    # ``diagonal_relaxed`` (not ``vertical_relaxed``) is required because the
+    # parquet history can have schema drift across batches — a listener may
+    # come and go as the cell-state shape changes tick to tick. ``diagonal``
+    # fills missing columns with nulls; ``_relaxed`` also coerces dtypes.
+    df = pl.concat(frames, how="diagonal_relaxed")
+    if "global_time" in df.columns:
+        df = df.sort("global_time")
+    return df
+
+
+def resolve_inputs_map(df: pl.DataFrame,
+                       inputs_map: dict[str, str]) -> dict[str, list[Any]]:
+    """Translate inputs_map dotted-paths to parquet columns + return values.
+
+    Parquet columns flatten the bigraph dotted path with ``__`` (vEcoli
+    convention; see USE_UINT16 / VECOLI_PARQUET_DTYPE_OVERRIDES). The
+    inputs_map uses ``.`` — translate, look up, return as a Python list.
+    Missing columns become ``None`` so partial-data vizzes still render
+    (they tolerate empty ports).
+    """
+    out: dict[str, list[Any]] = {}
+    for port, dotted_path in (inputs_map or {}).items():
+        col = dotted_path.replace(".", "__")
+        if col in df.columns:
+            out[port] = df[col].to_list()
+        else:
+            out[port] = None
+    return out
+
+
+_VIZ_CLASS_CACHE: dict[str, type] | None = None
+
+
+def _discover_visualization_classes() -> dict[str, type]:
+    """Walk v2ecoli.visualizations and collect Visualization subclasses by name.
+
+    The vivarium-dashboard's ``local:<ClassName>`` address scheme picks the
+    workspace package's Visualization classes by short name. Replicate that
+    lookup here.
+    """
+    global _VIZ_CLASS_CACHE
+    if _VIZ_CLASS_CACHE is not None:
+        return _VIZ_CLASS_CACHE
+
+    from pbg_superpowers.visualization import Visualization
+
+    pkg = importlib.import_module("v2ecoli.visualizations")
+    classes: dict[str, type] = {}
+    for _finder, name, _ispkg in pkgutil.iter_modules(pkg.__path__):
+        if name.startswith("_"):
+            continue
+        try:
+            mod = importlib.import_module(f"v2ecoli.visualizations.{name}")
+        except Exception:
+            continue
+        for cls_name, obj in inspect.getmembers(mod, inspect.isclass):
+            if obj is Visualization or not issubclass(obj, Visualization):
+                continue
+            classes[cls_name] = obj
+    _VIZ_CLASS_CACHE = classes
+    return classes
+
+
+def _resolve_address(address: str) -> type:
+    """``local:DnaAStateVisualization`` → the class object."""
+    if ":" not in address:
+        raise ValueError(f"unrecognized address {address!r} (expected scheme:name)")
+    scheme, name = address.split(":", 1)
+    if scheme != "local":
+        raise ValueError(
+            f"address scheme {scheme!r} not supported (only 'local:' for now)"
+        )
+    classes = _discover_visualization_classes()
+    if name not in classes:
+        raise KeyError(
+            f"no Visualization class named {name!r} in v2ecoli.visualizations. "
+            f"Available: {sorted(classes)}"
+        )
+    return classes[name]
+
+
+_CORE = None
+
+
+def _get_core():
+    """Lazily build a v2ecoli core for Visualization instantiation.
+
+    Step.__init__ requires a real core with ``fill(config_schema, config)``
+    so we go through v2ecoli.core.build_core. Cached because build_core is
+    relatively expensive and viz instantiation is stateless.
+    """
+    global _CORE
+    if _CORE is None:
+        from v2ecoli.core import build_core
+        _CORE = build_core()
+    return _CORE
+
+
+def _instantiate_visualization(viz_cls: type, config: dict) -> Any:
+    """Build a Visualization instance with a real v2ecoli core."""
+    return viz_cls(config=config or {}, core=_get_core())
+
+
+def render_study_visualizations(study_slug: str,
+                                workspace_root: Path | None = None,
+                                out_dir: Path | None = None
+                                ) -> list[Path]:
+    """Render every viz in ``studies/<slug>/study.yaml`` to HTML files.
+
+    Reads the latest parquet run for the study, resolves each viz's
+    inputs_map, calls the Visualization's ``update(state)``, and writes
+    ``<out_dir>/<viz_name>.html`` (default ``studies/<slug>/viz/``).
+
+    Returns the list of written file paths.
+    """
+    ws = workspace_root or _find_workspace_root()
+    study_yaml = ws / "studies" / study_slug / "study.yaml"
+    if not study_yaml.exists():
+        raise FileNotFoundError(study_yaml)
+
+    spec = yaml.safe_load(study_yaml.read_text(encoding="utf-8")) or {}
+    viz_specs = spec.get("visualizations") or []
+    if not viz_specs:
+        return []
+
+    run_dir = find_latest_parquet_run(study_slug, workspace_root=ws)
+    df = load_run_history(run_dir)
+
+    out_dir = out_dir or (ws / "studies" / study_slug / "viz")
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    written: list[Path] = []
+    for vs in viz_specs:
+        name = vs.get("name") or "viz"
+        address = vs.get("address") or ""
+        cfg = vs.get("config") or {}
+        inputs_map = cfg.get("inputs_map") or {}
+
+        try:
+            viz_cls = _resolve_address(address)
+        except (KeyError, ValueError) as e:
+            print(f"  ✗ {name}: {e}")
+            continue
+
+        state = resolve_inputs_map(df, inputs_map)
+
+        viz = _instantiate_visualization(viz_cls, cfg)
+        result = viz.update(state)
+        html = (result or {}).get("html") or ""
+        if not html:
+            # New-style Visualization that uses accumulate/render rather
+            # than update — call render() after a single accumulate(state).
+            viz.accumulate(state)
+            html = viz.render()
+
+        out_path = out_dir / f"{name}.html"
+        out_path.write_text(html, encoding="utf-8")
+        written.append(out_path)
+        print(f"  ok {name}: {out_path.relative_to(ws)} ({len(html)} chars)")
+    return written


### PR DESCRIPTION
**Status:** Draft. Carved out from `feat/dnaa-biology` per the convention in PR #59 ("infrastructure carves out into separate `main` PRs").

## Summary

Workspace-level infrastructure for **running** and **rendering** studies on the parquet-emitter path. Extracted from the dnaa-replication parquet rerun so the dnaa investigation PR (#59) stays focused on biology content.

### Changes

1. **`v2ecoli/composites/_helpers.py`** — new `flush_parquet(composite, success=True)` helper. The existing `parquet_emitter()` context manager has no composite reference, so it cannot trigger `ParquetEmitter.close()` on exit. Without an explicit flush, the trailing partial batch (rows after the last `batch_size` flush) stays in memory; only `configuration/` parquet lands, no `history/`, no `success/`. `flush_parquet` is the one-line call runners need at end-of-sim.

2. **`v2ecoli/library/parquet_viz.py`** — new module. Renders `Visualization` Steps from a study's `parquet-runs/` output:
   - Discovers latest run under `studies/<slug>/parquet-runs/`
   - Loads all `history/*.pq` with `diagonal_relaxed` concat (handles schema drift across batches as listener shape changes tick-to-tick)
   - Translates dashboard dotted-path inputs_map (`listeners.dnaA_cycle.atp_count`) to parquet columns (`listeners__dnaA_cycle__atp_count`)
   - Resolves `local:<ClassName>` addresses against discovered `v2ecoli.visualizations` classes
   - Instantiates with a v2ecoli core, calls `update(state)`, writes HTML to `studies/<slug>/viz/`

   This is the standalone substitute for the vivarium-dashboard's data resolver while the dashboard's parquet branch (`_latest_parquet_for_study`, parquet branch in `_get_emitter_mode`) is still being built upstream.

3. **`scripts/render_study_viz.py`** — CLI: `python scripts/render_study_viz.py <study_slug> [<slug> ...]` or `--all-dnaa`.

4. **`scripts/lint-workspace.py`** — count `studies/<slug>/parquet-runs/<run_id>/` alongside `runs.db` rows. A run with a `success/` sentinel counts complete; otherwise active.

5. **`.gitignore`** — `studies/*/parquet-runs/` and `studies/*/sims/parquet-rerun-*/`.

No behavior change for sqlite-emitter studies.

## Verified

End-to-end on the dnaa investigation rerun (4 studies, 9 viz HTMLs, 47–3602 rows of parquet history per study). `lint-workspace.py` reports `0 active runs, 6 completed runs` correctly counting the parquet hive.

## Test plan
- [ ] `python scripts/lint-workspace.py` runs without error and reports any pre-existing parquet runs
- [ ] `python -c "from v2ecoli.composites._helpers import flush_parquet; print(flush_parquet)"` imports cleanly
- [ ] `python -c "from v2ecoli.library.parquet_viz import render_study_visualizations; print(render_study_visualizations)"` imports cleanly
- [ ] On a workspace with at least one parquet-emitted study: `python scripts/render_study_viz.py <slug>` writes `studies/<slug>/viz/*.html` with real Plotly content (no empty-state stubs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)