### PR TITLE
fix(parquet): auto-flush bound composite on context exit

### DIFF
--- a/tests/test_parquet_emitter_workspace_default.py
+++ b/tests/test_parquet_emitter_workspace_default.py
@@ -32,7 +32,8 @@ def test_workspace_default_resolves_to_pbg_parquet_runs(tmp_path, monkeypatch):
         experiment_id="smoke-run",
         study_slug="dnaa-01-expression-dynamics",
         investigation_slug="dnaa-replication",
-    ) as cfg:
+    ) as emit:
+        cfg = emit.cfg
         assert cfg["out_dir"] == str(tmp_path / ".pbg" / "parquet-runs")
         assert cfg["metadata"]["study_slug"] == "dnaa-01-expression-dynamics"
         assert cfg["metadata"]["investigation_slug"] == "dnaa-replication"
@@ -49,8 +50,8 @@ def test_explicit_out_dir_preserves_backcompat(tmp_path, monkeypatch):
     target.mkdir(parents=True)
     monkeypatch.chdir(tmp_path)
 
-    with parquet_emitter(out_dir=str(target), experiment_id="legacy") as cfg:
-        assert cfg["out_dir"] == str(target)
+    with parquet_emitter(out_dir=str(target), experiment_id="legacy") as emit:
+        assert emit.cfg["out_dir"] == str(target)
 
 
 @pytest.mark.fast
@@ -79,6 +80,78 @@ def test_override_is_cleared_on_exit(tmp_path, monkeypatch):
 
 
 @pytest.mark.fast
+def test_bind_auto_flushes_on_clean_exit(tmp_path, monkeypatch):
+    """Auto-flush fires on clean exit when composite is bound. Closes
+    friction-#3 (parquet context manager couldn't enforce lifecycle).
+    Uses a stub composite + monkeypatched flush_parquet so we don't need
+    to spin up a real ParquetEmitter for the lifecycle check."""
+    (tmp_path / "workspace.yaml").write_text("name: test-ws\n")
+    monkeypatch.chdir(tmp_path)
+
+    calls = []
+    monkeypatch.setattr(_h, "flush_parquet",
+                        lambda comp, *, success=True: (calls.append(("clean", comp, success)) or 1))
+
+    stub = object()
+    with parquet_emitter(experiment_id="bind-clean") as emit:
+        emit.bind(stub)
+    assert calls == [("clean", stub, True)]
+
+
+@pytest.mark.fast
+def test_bind_auto_flushes_with_failure_on_exception(tmp_path, monkeypatch):
+    """Exception inside the with-block → auto-flush with success=False so
+    the sentinel honestly reflects the failed run."""
+    (tmp_path / "workspace.yaml").write_text("name: test-ws\n")
+    monkeypatch.chdir(tmp_path)
+
+    calls = []
+    monkeypatch.setattr(_h, "flush_parquet",
+                        lambda comp, *, success=True: (calls.append(("exc", comp, success)) or 1))
+
+    stub = object()
+    with pytest.raises(RuntimeError, match="kapow"):
+        with parquet_emitter(experiment_id="bind-exc") as emit:
+            emit.bind(stub)
+            raise RuntimeError("kapow")
+    assert calls == [("exc", stub, False)]
+
+
+@pytest.mark.fast
+def test_no_bind_no_auto_flush(tmp_path, monkeypatch):
+    """Legacy behaviour preserved: without .bind(), no auto-flush fires.
+    Callers that already invoke flush_parquet() explicitly keep working."""
+    (tmp_path / "workspace.yaml").write_text("name: test-ws\n")
+    monkeypatch.chdir(tmp_path)
+
+    calls = []
+    monkeypatch.setattr(_h, "flush_parquet",
+                        lambda comp, *, success=True: (calls.append("never") or 1))
+
+    with parquet_emitter(experiment_id="no-bind") as _emit:
+        pass
+    assert calls == []
+
+
+@pytest.mark.fast
+def test_explicit_flush_skips_auto_flush(tmp_path, monkeypatch):
+    """Calling .flush() inside the with-block sets _flushed; exit auto-flush
+    skips. Prevents a double-close."""
+    (tmp_path / "workspace.yaml").write_text("name: test-ws\n")
+    monkeypatch.chdir(tmp_path)
+
+    calls = []
+    monkeypatch.setattr(_h, "flush_parquet",
+                        lambda comp, *, success=True: (calls.append(success) or 1))
+
+    stub = object()
+    with parquet_emitter(experiment_id="explicit-flush") as emit:
+        emit.bind(stub)
+        emit.flush(success=True)
+    assert calls == [True]  # only the explicit call, no second from exit
+
+
+@pytest.mark.fast
 def test_extra_metadata_merges_through(tmp_path, monkeypatch):
     """Caller-supplied extra_metadata lands alongside the preset's keys."""
     (tmp_path / "workspace.yaml").write_text("name: test-ws\n")
@@ -87,8 +160,8 @@ def test_extra_metadata_merges_through(tmp_path, monkeypatch):
     with parquet_emitter(
         experiment_id="enrich",
         extra_metadata={"description": "from a tiny test", "seed_strategy": "fixed"},
-    ) as cfg:
-        meta = cfg["metadata"]
+    ) as emit:
+        meta = emit.cfg["metadata"]
         assert meta["description"] == "from a tiny test"
         assert meta["seed_strategy"] == "fixed"
         # Preset's required partition keys still present

--- a/v2ecoli/composites/_helpers.py
+++ b/v2ecoli/composites/_helpers.py
@@ -338,6 +338,42 @@ def sqlite_emitter(*, file_path: str | None = None,
         set_emitter_override(None)
 
 
+class ParquetEmitterContext:
+    """Yielded from ``parquet_emitter()``. Bind the composite via
+    :meth:`bind` so its accumulated rows flush on context exit; this
+    closes the friction-#3 hole where the context manager couldn't
+    enforce its own lifecycle correctness (only ``configuration/`` landed,
+    no ``history/`` or ``success/``).
+
+    .cfg holds the emitter config dict (back-compat with the dict that
+    pre-2026-05-28 ``parquet_emitter()`` yielded directly).
+    """
+
+    def __init__(self, cfg: dict):
+        self.cfg = cfg
+        self._composite = None
+        self._flushed = False
+
+    def bind(self, composite) -> None:
+        """Register the composite for auto-flush on context exit."""
+        self._composite = composite
+
+    def flush(self, composite=None, *, success: bool = True) -> int:
+        """Flush now. Uses the bound composite if ``composite`` is None.
+
+        Returns the number of ParquetEmitter instances flushed. Safe to
+        call multiple times — ``flush_all_in_composite`` skips already-
+        closed instances."""
+        target = composite if composite is not None else self._composite
+        if target is None:
+            raise ValueError(
+                "ParquetEmitterContext.flush(): no composite given and "
+                "none bound; call .bind(composite) first.")
+        n = flush_parquet(target, success=success)
+        self._flushed = True
+        return n
+
+
 @contextlib.contextmanager
 def parquet_emitter(*, out_dir: str | None = None,
                     experiment_id: str | None = None,
@@ -358,13 +394,28 @@ def parquet_emitter(*, out_dir: str | None = None,
     so anyone with a vEcoli analysis pipeline can point at the output dir
     directly.
 
-    Usage::
+    Usage (auto-flush — recommended, since 2026-05-28)::
 
         with parquet_emitter(experiment_id='baseline-seed0',
-                             study_slug='dnaa-01-expression-dynamics'):
+                             study_slug='dnaa-01-expression-dynamics') as emit:
             doc = baseline(cache_dir='out/cache')
             comp = Composite(doc, core=core)
+            emit.bind(comp)             # <- enables auto-flush on exit
             comp.update({}, 60.0 * 60)
+        # ParquetEmitter.close(success=True) called automatically; if an
+        # exception fired in the with-block, close(success=False) instead.
+
+    Legacy usage (still works for callers that already manage the flush)::
+
+        with parquet_emitter(...):
+            comp = ...
+            comp.update(...)
+            flush_parquet(comp, success=True)   # explicit, no .bind()
+
+    If you neither call .bind() nor flush_parquet(), the context manager
+    silently degrades to the pre-2026-05-28 behaviour: the override
+    clears but the trailing partial batch + success sentinel are lost.
+    Friction note 2026-05-27 #3 for the original incident.
 
     Storage trade-off vs ``sqlite_emitter()``: Parquet is column-oriented and
     typically 3-5x smaller on disk for v2ecoli-shaped runs (sparse arrays,
@@ -409,10 +460,24 @@ def parquet_emitter(*, out_dir: str | None = None,
             meta["investigation_slug"] = investigation_slug
         cfg["metadata"] = meta
 
+    ctx = ParquetEmitterContext(cfg)
     set_parquet_emitter_override(cfg)
+    exc_fired = False
     try:
-        yield cfg
+        yield ctx
+    except BaseException:
+        exc_fired = True
+        raise
     finally:
+        # Auto-flush if bound but not explicitly flushed. On exception,
+        # close with success=False so the sentinel honestly reflects the
+        # failed run. Swallow auto-flush errors so they can't mask the
+        # caller's original exception.
+        if ctx._composite is not None and not ctx._flushed:
+            try:
+                ctx.flush(success=not exc_fired)
+            except Exception:
+                pass
         set_parquet_emitter_override(None)
 
 


### PR DESCRIPTION
## What

Closes friction **#3** from the dnaa-biology session's 2026-05-27 parquet-rerun friction log:

> *"`parquet_emitter()` in `_helpers.py` only sets/clears the global emitter override. It never sees the composite, so it cannot call `close()` on the emitter step at context-exit. Result: rows accumulated since the last `batch_size` flush stay in memory; only the `configuration/` parquet lands on disk. No `history/`, no `success/` sentinel."*

The session's workaround was `flush_parquet(composite, success=True)` — runners had to call it explicitly before exiting the `with` block. Works, but the context manager couldn't enforce it; forgetting the call silently lost the trailing partial batch + success sentinel.

## How

`parquet_emitter()` now yields a `ParquetEmitterContext` exposing `.bind(composite)` and `.flush()`. On context exit, if a composite was bound but never explicitly flushed, auto-flush fires:

- `success=True` on clean exit
- `success=False` if an exception fired inside the `with`-block (so the sentinel honestly reflects the failed run)
- Skipped if `.flush()` was already called inside the block (no double-close)

Caller migration:

```python
# Before
with parquet_emitter(...):
    comp = build_composite(...)
    # ...sim loop...
    flush_parquet(comp, success=True)   # easy to forget

# After
with parquet_emitter(...) as emit:
    comp = build_composite(...)
    emit.bind(comp)                     # single line, enables auto-flush
    # ...sim loop...
# auto-flush on exit (success based on exception state)
```

## Why option 1 (yield-flush method) over the other two

- **Option 3 (registry walk at exit)** is fragile under parallel runs. The override is just a config dict — the context manager never stores a reference to the instantiated `ParquetEmitter`, so finding "the live instance at exit" relies on identity guesses. Two simultaneous parquet runs would clobber each other.
- **Option 2 (`run_with_parquet` helper)** is over-engineering — it duplicates composite construction logic and forces runners to refactor.
- **Option 1** is minimal and safe: opt-in by adding one line (`emit.bind(comp)`), enforced thereafter.

## Back-compat

- Yielded value changed from a `cfg` **dict** to a `ParquetEmitterContext` wrapping it as `.cfg`.
- The 6 v2ecoli runners under `.claude/worktrees/dnaa-biology/` use bare `with parquet_emitter(...):` — they don't bind the yield, so they're unaffected. They keep their existing `flush_parquet()` calls.
- The 3 places in `test_parquet_emitter_workspace_default.py` that bound `as cfg:` are updated to `as emit:` + `emit.cfg[...]`.
- Legacy callers that don't `.bind()` get exactly the pre-2026-05-28 behaviour (override clears, no flush). Migration is purely additive.

## Tests

4 new tests in `test_parquet_emitter_workspace_default.py`:

- `test_bind_auto_flushes_on_clean_exit` — clean exit + bound composite → flush(success=True)
- `test_bind_auto_flushes_with_failure_on_exception` — exception + bound composite → flush(success=False), exception re-raises
- `test_no_bind_no_auto_flush` — legacy callers preserved
- `test_explicit_flush_skips_auto_flush` — `.flush()` inside the block suppresses the exit auto-flush

**9/9 pass** in `test_parquet_emitter_workspace_default.py` + `test_sqlite_emitter_workspace_default.py` (14 total).

## Follow-ups (not in this PR)

- Migrate the 6 dnaa runners (`studies/dnaa-0*/sims/run_*.py`) from explicit `flush_parquet()` to `emit.bind()`. One-line change each, no behaviour difference but eliminates the footgun.
- `sqlite_emitter()` has the same gap (lines 259–338) but `SQLiteEmitter.__del__` unconditionally flushes, so the impact is smaller. Apply the same `.bind()` pattern there for consistency? Tracked as a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
