### PR TITLE
Workflow xarray emitter option

### DIFF
--- a/tests/test_workflow_xarray.py
+++ b/tests/test_workflow_xarray.py
@@ -1,0 +1,77 @@
+"""Workflow xarray-emitter wiring — unit + a cache-gated smoke."""
+import os
+
+import pytest
+
+from v2ecoli.workflow.lineage import LineageProcess, DEFAULT_XARRAY_VIEW
+from v2ecoli.workflow.meta_composite import build_meta_composite
+
+CACHE = os.environ.get("V2ECOLI_CACHE", "out/cache")
+
+
+def test_default_xarray_view_is_scalar_mass():
+    entry = DEFAULT_XARRAY_VIEW[0]
+    assert entry["root"] == ("listeners", "mass")
+    for gauge in ("dry_mass", "cell_mass", "protein_mass"):
+        assert gauge in entry["variables"]
+        assert entry["variables"][gauge][0]["path"] == gauge
+
+
+def test_is_xarray_reflects_config():
+    lp = LineageProcess.__new__(LineageProcess)
+    lp.config = {}                       # default
+    assert lp._is_xarray() is False
+    lp.config = {"emitter": "parquet"}
+    assert lp._is_xarray() is False
+    lp.config = {"emitter": "xarray"}
+    assert lp._is_xarray() is True
+
+
+def test_meta_composite_threads_emitter_config():
+    config = {
+        "experiment_id": "x", "n_init_sims": 1, "generations": 1, "variants": {},
+        "emitter": "xarray",
+        "emitter_arg": {"out_dir": "out/x/zarr",
+                        "view": [{"root": ["listeners", "mass"],
+                                  "variables": {"dry_mass": [{"path": "dry_mass", "dtype": "<f4"}]}}]},
+    }
+    node = build_meta_composite(config)["state"]["branches"]["variant=0/seed=0"]["lineage"]
+    assert node["config"]["emitter"] == "xarray"
+    assert node["config"]["emitter_arg"]["out_dir"] == "out/x/zarr"
+    # default is parquet when unspecified
+    plain = build_meta_composite({"experiment_id": "p", "n_init_sims": 1,
+                                  "generations": 1, "variants": {}})
+    assert plain["state"]["branches"]["variant=0/seed=0"]["lineage"]["config"]["emitter"] == "parquet"
+
+
+def test_ported_xarray_config_loads():
+    from v2ecoli.workflow.config import load_config_with_inheritance
+    cfg_dir = os.path.join(os.path.dirname(__file__), "..", "v2ecoli", "configs")
+    cfg = load_config_with_inheritance(os.path.join(cfg_dir, "two_generations_xarray.json"))
+    assert cfg["emitter"] == "xarray"
+    assert cfg["generations"] == 2                      # inherited from two_generations.json
+    assert cfg["emitter_arg"]["view"][0]["root"] == ["listeners", "mass"]
+
+
+@pytest.mark.skipif(not os.path.isdir(CACHE), reason=f"ParCa cache {CACHE} not present")
+def test_xarray_sweep_emits_zarr(tmp_path):
+    pytest.importorskip("xarray")
+    pytest.importorskip("zarr")
+    import xarray as xr
+    from v2ecoli.workflow.run import run_workflow
+
+    out = str(tmp_path / "zarr")
+    config = {
+        "experiment_id": "xsmoke", "n_init_sims": 1, "generations": 1,
+        "single_daughters": True, "cache_dir": CACHE, "out_dir": str(tmp_path),
+        "variants": {}, "max_duration_per_gen": 5.0, "time_step": 1.0,
+        "emitter": "xarray", "emitter_arg": {"out_dir": out},   # default mass view
+    }
+    result = run_workflow(config, max_sim_time=20.0)
+    assert result["complete"] is True
+
+    store = os.path.join(out, "xsmoke_v0_s0.zarr")
+    assert os.path.isdir(store), f"no zarr store written at {store}"
+    dt = xr.open_datatree(store, engine="zarr")
+    groups = list(dt.groups)
+    assert any("dry_mass" in g for g in groups), f"dry_mass not in {groups}"

--- a/tests/test_workflow_xarray.py
+++ b/tests/test_workflow_xarray.py
@@ -75,3 +75,86 @@ def test_xarray_sweep_emits_zarr(tmp_path):
     dt = xr.open_datatree(store, engine="zarr")
     groups = list(dt.groups)
     assert any("dry_mass" in g for g in groups), f"dry_mass not in {groups}"
+
+
+def test_emitter_config_threads_writer_predicate_and_codecs():
+    """Follow-up: emitter_arg.writer / transducer.predicate and per-leaf
+    unit/codecs are honored by the config builder."""
+    from v2ecoli.library.xarray_run import build_emitter_config
+    view = [{"root": ("listeners", "mass"),
+             "variables": {"dry_mass": [{"path": "dry_mass", "dtype": "<f4",
+                                         "unit": "[fg]",
+                                         "codecs": {"compressors_v3": []}}]}}]
+    cfg = build_emitter_config(
+        store_path="/tmp/x.zarr", view=view, metadata_base={"experiment_id": "t"},
+        generation=2, agent_id="00", buffer_size=7,
+        writer={"buffers_per_chunk": 5, "backend_config": {"async.concurrency": 3}},
+        predicate=[[{"subsample": {"interval": 3}}]])
+    w = cfg["writer"]
+    assert w["buffers_per_chunk"] == 5                 # user setting honored
+    assert w["backend_config"]["async.concurrency"] == 3
+    assert w["backend_config"]["format"] == 3          # default preserved on merge
+    assert w["store"] == "/tmp/x.zarr"                 # store always forced
+    assert cfg["transducer"]["predicate"] == [[{"subsample": {"interval": 3}}]]
+    assert cfg["transducer"]["buffer"]["size"] == 7
+    leaf = cfg["view"][0]["variables"]["dry_mass"][0]
+    assert leaf["unit"] == "[fg]" and "codecs" in leaf  # pass through verbatim
+    assert cfg["metadata"]["generation"] == 2 and cfg["metadata"]["agent_id"] == "00"
+
+
+@pytest.mark.skipif(not os.path.isdir(CACHE), reason=f"ParCa cache {CACHE} not present")
+def test_null_emitter_captures_only_global_time():
+    """Follow-up: on xarray runs the internal emitter is minimised so it
+    doesn't waste memory capturing full state."""
+    from process_bigraph import Composite
+    from v2ecoli.core import build_core
+    from v2ecoli.composites.baseline import baseline
+    from v2ecoli.composites._helpers import set_null_emitter_override
+
+    core = build_core()
+    set_null_emitter_override(True)
+    try:
+        doc = baseline(core=core, seed=0, cache_dir=CACHE)
+    finally:
+        set_null_emitter_override(False)
+    comp = Composite(doc, core=core)
+    comp.run(1.0)
+    em = comp.state["agents"]["0"]["emitter"]["instance"]
+    hist = getattr(em, "history", None)
+    assert hist, "null emitter captured nothing"
+    keys = set(hist[-1].keys())
+    assert "global_time" in keys
+    assert "bulk" not in keys and "listeners" not in keys  # heavy capture suppressed
+
+
+@pytest.mark.skipif(not os.path.isdir(CACHE), reason=f"ParCa cache {CACHE} not present")
+def test_xarray_sweep_emits_vector_observable(tmp_path):
+    """Follow-up: a vector observable (monomer_counts) emits with its coord
+    dimension via the view filter + output_metadata discovery."""
+    pytest.importorskip("xarray")
+    pytest.importorskip("zarr")
+    import xarray as xr
+    from v2ecoli.workflow.run import run_workflow
+
+    out = str(tmp_path / "zarr")
+    config = {
+        "experiment_id": "xvec", "n_init_sims": 1, "generations": 1,
+        "single_daughters": True, "cache_dir": CACHE, "out_dir": str(tmp_path),
+        "variants": {}, "max_duration_per_gen": 5.0, "time_step": 1.0,
+        "emitter": "xarray",
+        "emitter_arg": {"out_dir": out, "view": [
+            {"root": ["listeners"],
+             "variables": {"monomer_counts": [{"path": "monomer_counts", "dtype": "<i8"}]}}]},
+    }
+    result = run_workflow(config, max_sim_time=20.0)
+    assert result["complete"] is True
+
+    store = os.path.join(out, "xvec_v0_s0.zarr")
+    assert os.path.isdir(store), f"no zarr store at {store}"
+    dt = xr.open_datatree(store, engine="zarr")
+    groups = [g for g in dt.groups if g.endswith("monomer_counts")]
+    assert groups, f"monomer_counts not in {list(dt.groups)}"
+    node = dt[groups[0]].to_dataset()
+    # at least one variable carries a non-time dimension > 1 (the vector coord)
+    assert any(any(s > 1 for s in v.shape) for v in node.data_vars.values()), \
+        {k: v.shape for k, v in node.data_vars.items()}

--- a/v2ecoli/composites/_helpers.py
+++ b/v2ecoli/composites/_helpers.py
@@ -150,6 +150,13 @@ _EMITTER_OVERRIDE: dict | None = None
 # (parquet wins — sqlite stays available for dashboard's Simulations-DB tab).
 _PARQUET_EMITTER_OVERRIDE: dict | None = None
 
+# When True (and no parquet/sqlite override is set), the 'emitter' step
+# materialises as a minimal RAMEmitter capturing ONLY global_time — instead of
+# the default full-state RAMEmitter (bulk + chromosome + listeners, multi-MB
+# per row). Used by callers that emit out-of-band (e.g. the workflow's external
+# XArrayEmitter) and don't want the internal emitter wasting memory.
+_NULL_EMITTER_OVERRIDE: bool = False
+
 
 def set_emitter_override(config: dict | None) -> None:
     """Set the module-level SQLite emitter override. Pass None to clear."""
@@ -161,6 +168,13 @@ def set_parquet_emitter_override(config: dict | None) -> None:
     """Set the module-level Parquet emitter override. Pass None to clear."""
     global _PARQUET_EMITTER_OVERRIDE
     _PARQUET_EMITTER_OVERRIDE = config
+
+
+def set_null_emitter_override(flag: bool) -> None:
+    """Minimise the internal 'emitter' step to global_time only (see
+    ``_NULL_EMITTER_OVERRIDE``). Pass False to restore the full-state default."""
+    global _NULL_EMITTER_OVERRIDE
+    _NULL_EMITTER_OVERRIDE = bool(flag)
 
 
 import contextlib  # noqa: E402
@@ -938,6 +952,13 @@ def _get_special_step(loader, step_name, core):
             }
             cfg = {'emit': emit_schema, **override}
             instance = SQLiteEmitter(cfg, core)
+        elif _NULL_EMITTER_OVERRIDE:
+            # Minimal RAMEmitter (global_time only): the caller emits out of
+            # band (e.g. the workflow's external XArrayEmitter), so the internal
+            # emitter must not waste memory capturing full state every tick.
+            emit_schema = {'global_time': 'float'}
+            topo = {'global_time': ('global_time',)}
+            instance = RAMEmitter({'emit': emit_schema}, core)
         else:
             # In-memory RAMEmitter: no disk cost, so keep the full capture
             # (bulk + chromosome/replisome structures) for callers that

--- a/v2ecoli/configs/two_generations_xarray.json
+++ b/v2ecoli/configs/two_generations_xarray.json
@@ -1,0 +1,22 @@
+{
+    "inherit_from": ["two_generations.json"],
+    "experiment_id": "two_generations_xarray",
+    "emitter": "xarray",
+    "emitter_arg": {
+        "out_dir": "out/two_generations_xarray/zarr",
+        "transducer": {
+            "predicate": [[{"subsample": {"interval": 1}}]],
+            "buffer": {"size": 4}
+        },
+        "view": [
+            {
+                "root": ["listeners", "mass"],
+                "variables": {
+                    "dry_mass": [{"path": "dry_mass", "dtype": "<f4"}],
+                    "cell_mass": [{"path": "cell_mass", "dtype": "<f4"}],
+                    "protein_mass": [{"path": "protein_mass", "dtype": "<f4"}]
+                }
+            }
+        ]
+    }
+}

--- a/v2ecoli/library/xarray_run.py
+++ b/v2ecoli/library/xarray_run.py
@@ -26,7 +26,9 @@ from typing import Any, Callable
 
 import numpy as np
 
-from v2ecoli.library.xarray_emitter import XArrayEmitter
+# NB: XArrayEmitter is imported lazily inside _build_emitter — it requires the
+# [xarray] extra, but build_emitter_config (a pure dict builder) and the
+# view/coord helpers must remain importable without it (e.g. in CI fast-tests).
 
 
 #: v2ecoli observables known to be vectors/arrays.
@@ -332,7 +334,8 @@ def build_emitter_config(
     }
 
 
-def _build_emitter(*, core: Any, **kwargs) -> XArrayEmitter:
+def _build_emitter(*, core: Any, **kwargs):
+    from v2ecoli.library.xarray_emitter import XArrayEmitter  # requires [xarray]
     return XArrayEmitter(config=build_emitter_config(**kwargs), core=core)
 
 

--- a/v2ecoli/library/xarray_run.py
+++ b/v2ecoli/library/xarray_run.py
@@ -280,9 +280,8 @@ def _filter_agent_state(agent_state: dict, view: list[dict]) -> dict:
     return out
 
 
-def _build_emitter(
+def build_emitter_config(
     *,
-    core: Any,
     store_path: Path,
     view: list[dict],
     metadata_base: dict,
@@ -290,31 +289,51 @@ def _build_emitter(
     agent_id: str,
     buffer_size: int = 4,
     output_metadata: dict | None = None,
-) -> XArrayEmitter:
+    writer: dict | None = None,
+    predicate: list | None = None,
+) -> dict:
+    """Pure builder for an XArrayEmitter config dict (no IO).
+
+    ``writer`` settings (buffers_per_chunk, backend_config, ...) merge over the
+    zarr defaults — the store path is always forced. ``predicate`` overrides the
+    default subsample(1). Leaf-spec ``unit`` / ``codecs`` keys in ``view`` pass
+    through verbatim to LeafView.
+    """
     md = dict(metadata_base)
     md["agent_id"] = agent_id
     md["generation"] = generation
-    cfg = {
+    writer_cfg = {
+        "backend": "zarr",
+        "store": str(store_path),
+        "buffers_per_chunk": 1,
+        "backend_config": {"format": 3},
+    }
+    if writer:
+        merged = {**writer_cfg, **writer}
+        if isinstance(writer.get("backend_config"), dict):
+            merged["backend_config"] = {
+                **writer_cfg["backend_config"], **writer["backend_config"]}
+        merged["store"] = str(store_path)
+        writer_cfg = merged
+    return {
         "emit": {"global_time": "node"},
         "out_uri": str(store_path),
         "transducer": {
-            "predicate": [[{"subsample": {"interval": 1}}]],
+            "predicate": predicate or [[{"subsample": {"interval": 1}}]],
             "buffer": {"size": buffer_size},
         },
         "view": view,
-        "writer": {
-            "backend": "zarr",
-            "store": str(store_path),
-            "buffers_per_chunk": 1,
-            "backend_config": {"format": 3},
-        },
+        "writer": writer_cfg,
         "metadata": md,
         "metadata_keys": [],
         "metadata_validators": {},
         "output_metadata": output_metadata or {},
         "debug": False,
     }
-    return XArrayEmitter(config=cfg, core=core)
+
+
+def _build_emitter(*, core: Any, **kwargs) -> XArrayEmitter:
+    return XArrayEmitter(config=build_emitter_config(**kwargs), core=core)
 
 
 def run_multigen_xarray(

--- a/v2ecoli/workflow/lineage.py
+++ b/v2ecoli/workflow/lineage.py
@@ -111,14 +111,20 @@ class LineageProcess(Process):
         overrides = dict(self.config.get("config_overrides") or {})
 
         if self._is_xarray():
-            # External XArrayEmitter path: no internal-emitter override (the
-            # baseline emitter step falls back to RAM). The XArrayEmitter is
+            # External XArrayEmitter path. The internal baseline emitter step is
+            # minimised to global_time only (set_null_emitter_override) so it
+            # doesn't waste memory — we emit out of band. The XArrayEmitter is
             # opened lazily on the first populated emit tick (see _emit_xarray),
             # so the view can be filtered against real state — xarray is strict
             # about missing emit paths.
-            doc = baseline(core=core, seed=gen_seed,
-                           cache_dir=self.config["cache_dir"],
-                           config_overrides=overrides)
+            from v2ecoli.composites._helpers import set_null_emitter_override
+            set_null_emitter_override(True)
+            try:
+                doc = baseline(core=core, seed=gen_seed,
+                               cache_dir=self.config["cache_dir"],
+                               config_overrides=overrides)
+            finally:
+                set_null_emitter_override(False)
             self._xarray_pending = True
         else:
             from v2ecoli.composites._helpers import set_parquet_emitter_override
@@ -164,8 +170,11 @@ class LineageProcess(Process):
         arg = dict(self.config.get("emitter_arg") or {})
         raw_view = arg.get("view") or DEFAULT_XARRAY_VIEW
         raw_view = [dict(e, root=tuple(e["root"])) for e in raw_view]
-        buf = (((arg.get("transducer") or {}).get("buffer") or {}).get("size"))
+        transducer = arg.get("transducer") or {}
+        buf = ((transducer.get("buffer") or {}).get("size"))
         buf = max(3, int(buf or 4))  # transducer requires buffer.size > 2
+        predicate = transducer.get("predicate")
+        writer = arg.get("writer")
         out_dir = arg.get("out_dir") or self.config["out_dir"]
 
         wrapped = {"agents": {"0": emit_cell}}
@@ -198,7 +207,7 @@ class LineageProcess(Process):
             core=self._core, store_path=self._xarray_store, view=view,
             metadata_base=metadata_base, generation=self._generation,
             agent_id=self._agent_id, buffer_size=buf,
-            output_metadata=output_metadata)
+            output_metadata=output_metadata, writer=writer, predicate=predicate)
         self._xarray_pending = False
 
     def _emit_xarray(self, agents_now):

--- a/v2ecoli/workflow/lineage.py
+++ b/v2ecoli/workflow/lineage.py
@@ -3,9 +3,11 @@
 Wraps a baseline cell composite (the EcoliWCM embedding pattern) and runs it
 generation-by-generation, carrying a single daughter forward (vEcoli's
 ``single_daughters=true`` default). Variant overrides are applied at build
-time; each generation emits partitioned parquet with its own metadata.
-The meta-composite ticks this process via update(); it reports ``complete``
-when ``generations`` cells have been run.
+time. Each generation emits either partitioned parquet (default) or — when
+``emitter == "xarray"`` — a hive-partitioned zarr store via an external
+XArrayEmitter (the validated v2ecoli/library/xarray_run.py pattern), with
+its own metadata. The meta-composite ticks this process via update(); it
+reports ``complete`` when ``generations`` cells have been run.
 """
 
 from __future__ import annotations
@@ -40,6 +42,18 @@ def select_carry_daughter(agents_before, agents_now, mother_snapshot):
     return None
 
 
+# Default xarray view: scalar mass gauges (no vector coord arrays needed).
+# Override via emitter_arg["view"] (JSON list roots are accepted). Leaves the
+# composite doesn't emit are filtered out at open time (xarray is strict).
+DEFAULT_XARRAY_VIEW = [{
+    "root": ("listeners", "mass"),
+    "variables": {
+        name: [{"path": name, "dtype": "<f4"}]
+        for name in ("dry_mass", "cell_mass", "protein_mass", "rna_mass", "dna_mass")
+    },
+}]
+
+
 class LineageProcess(Process):
     config_schema = {
         "cache_dir": {"_type": "string", "_default": "out/cache"},
@@ -53,6 +67,12 @@ class LineageProcess(Process):
         "experiment_id": {"_type": "string", "_default": "default"},
         "out_dir": {"_type": "string", "_default": "out/workflow"},
         "max_duration_per_gen": {"_type": "float", "_default": 3600.0},
+        "time_step": {"_type": "float", "_default": 1.0},
+        # "parquet" (default) or "xarray". xarray drives an external
+        # XArrayEmitter per lineage (validated multigen pattern); the internal
+        # baseline emitter step then falls back to RAM (not read).
+        "emitter": {"_type": "string", "_default": "parquet"},
+        "emitter_arg": {"_default": {}},
     }
 
     def initialize(self, config):
@@ -64,6 +84,14 @@ class LineageProcess(Process):
         self._complete = False
         self._summaries: list[dict] = []
         self._needs_build = True      # True → call _build_generation on next tick
+        # xarray emitter state (only used when config["emitter"] == "xarray")
+        self._xarray_em = None        # live XArrayEmitter for the current gen
+        self._xarray_pending = False  # True → open on first populated emit tick
+        self._xarray_view = None      # filtered view in use for this lineage
+        self._xarray_store = None     # zarr store path (stable across gens)
+
+    def _is_xarray(self) -> bool:
+        return self.config.get("emitter", "parquet") == "xarray"
 
     def inputs(self):
         return {}
@@ -77,26 +105,39 @@ class LineageProcess(Process):
         from process_bigraph import Composite
         from v2ecoli.core import build_core
         from v2ecoli.composites.baseline import baseline, seed_mass_listener
-        from v2ecoli.composites._helpers import set_parquet_emitter_override
-        from v2ecoli.library.emitter_presets import parquet_vecoli
 
         core = build_core()
         gen_seed = (int(self.config["seed"]) + self._generation) % (2 ** 31)
-        emitter_cfg = parquet_vecoli(
-            out_dir=self.config["out_dir"],
-            experiment_id=self.config["experiment_id"],
-            variant=int(self.config["variant_index"]),
-            lineage_seed=int(self.config["lineage_seed"]),
-            agent_id=self._agent_id,
-            generation=self._generation,
-        )
-        set_parquet_emitter_override(emitter_cfg)
-        try:
-            doc = baseline(
-                core=core, seed=gen_seed, cache_dir=self.config["cache_dir"],
-                config_overrides=dict(self.config.get("config_overrides") or {}))
-        finally:
-            set_parquet_emitter_override(None)
+        overrides = dict(self.config.get("config_overrides") or {})
+
+        if self._is_xarray():
+            # External XArrayEmitter path: no internal-emitter override (the
+            # baseline emitter step falls back to RAM). The XArrayEmitter is
+            # opened lazily on the first populated emit tick (see _emit_xarray),
+            # so the view can be filtered against real state — xarray is strict
+            # about missing emit paths.
+            doc = baseline(core=core, seed=gen_seed,
+                           cache_dir=self.config["cache_dir"],
+                           config_overrides=overrides)
+            self._xarray_pending = True
+        else:
+            from v2ecoli.composites._helpers import set_parquet_emitter_override
+            from v2ecoli.library.emitter_presets import parquet_vecoli
+            emitter_cfg = parquet_vecoli(
+                out_dir=self.config["out_dir"],
+                experiment_id=self.config["experiment_id"],
+                variant=int(self.config["variant_index"]),
+                lineage_seed=int(self.config["lineage_seed"]),
+                agent_id=self._agent_id,
+                generation=self._generation,
+            )
+            set_parquet_emitter_override(emitter_cfg)
+            try:
+                doc = baseline(core=core, seed=gen_seed,
+                               cache_dir=self.config["cache_dir"],
+                               config_overrides=overrides)
+            finally:
+                set_parquet_emitter_override(None)
 
         if self._carry_state is not None:
             agent = doc["state"]["agents"]["0"]
@@ -107,7 +148,80 @@ class LineageProcess(Process):
             seed_mass_listener(agent, core)
 
         self._composite = Composite(doc, core=core)
+        self._core = core
         self._gen_elapsed = 0.0
+
+    def _open_xarray_emitter(self, emit_cell):
+        """Open an XArrayEmitter for the current generation, filtering the view
+        against ``emit_cell`` (populated state) and discovering vector coords.
+        Mirrors the validated v2ecoli/library/xarray_run.py pattern."""
+        import os
+        import shutil
+        from v2ecoli.library.xarray_run import (
+            _build_emitter, filter_view_to_existing_leaves,
+            extract_output_metadata_from_state)
+
+        arg = dict(self.config.get("emitter_arg") or {})
+        raw_view = arg.get("view") or DEFAULT_XARRAY_VIEW
+        raw_view = [dict(e, root=tuple(e["root"])) for e in raw_view]
+        buf = (((arg.get("transducer") or {}).get("buffer") or {}).get("size"))
+        buf = max(3, int(buf or 4))  # transducer requires buffer.size > 2
+        out_dir = arg.get("out_dir") or self.config["out_dir"]
+
+        wrapped = {"agents": {"0": emit_cell}}
+        view = filter_view_to_existing_leaves(wrapped, raw_view)
+        if not view:
+            warnings.warn("LineageProcess: xarray view has no leaves present in "
+                          "composite state; skipping xarray emission.")
+            self._xarray_pending = False
+            return
+        output_metadata = extract_output_metadata_from_state(wrapped, view)
+
+        if self._xarray_store is None:
+            self._xarray_store = os.path.join(
+                out_dir,
+                f"{self.config['experiment_id']}_v{int(self.config['variant_index'])}"
+                f"_s{int(self.config['lineage_seed'])}.zarr")
+        if self._generation == 0 and os.path.exists(self._xarray_store):
+            shutil.rmtree(self._xarray_store)  # fresh store for a new lineage
+        os.makedirs(out_dir, exist_ok=True)
+
+        metadata_base = {
+            "experiment_id": self.config["experiment_id"],
+            "variant": int(self.config["variant_index"]),
+            "lineage_seed": int(self.config["lineage_seed"]),
+            "time_step": float(self.config.get("time_step", 1.0)),
+            "max_duration": float(self.config["max_duration_per_gen"]),
+        }
+        self._xarray_view = view
+        self._xarray_em = _build_emitter(
+            core=self._core, store_path=self._xarray_store, view=view,
+            metadata_base=metadata_base, generation=self._generation,
+            agent_id=self._agent_id, buffer_size=buf,
+            output_metadata=output_metadata)
+        self._xarray_pending = False
+
+    def _emit_xarray(self, agents_now):
+        """Emit the inner cell's filtered state to the xarray emitter (opening
+        it lazily on the first populated tick)."""
+        emit_cell = agents_now.get("0")  # inner composite always names the cell "0"
+        if not isinstance(emit_cell, dict):
+            return
+        if self._xarray_pending and self._xarray_em is None:
+            self._open_xarray_emitter(emit_cell)
+        if self._xarray_em is None:
+            return
+        from v2ecoli.library.xarray_run import _filter_agent_state
+        payload = _filter_agent_state(emit_cell, self._xarray_view)
+        try:
+            self._xarray_em.update({
+                "time": float(self._gen_elapsed),
+                "global_time": float(self._gen_elapsed),
+                "agents": {self._agent_id: payload},
+            })
+        except Exception as e:
+            warnings.warn(f"LineageProcess: xarray emit failed at generation "
+                          f"{self._generation} t={self._gen_elapsed}: {e}")
 
     def _run_until_division(self, interval):
         """Run the internal composite for ``interval`` seconds. Returns
@@ -149,6 +263,9 @@ class LineageProcess(Process):
         cell = agents_now.get(self._agent_id) or next(iter(agents_now.values()), {})
         dry_mass = float(cell.get("listeners", {}).get("mass", {}).get("dry_mass", 0.0))
 
+        if self._is_xarray():
+            self._emit_xarray(agents_now)
+
         daughter = None
         if divided:
             daughter = select_carry_daughter(agents_before, agents_now, mother_snapshot)
@@ -172,13 +289,23 @@ class LineageProcess(Process):
         if not (divided or timed_out):
             return {}
 
-        # End of this generation: flush emitter, record summary.
-        from v2ecoli.composites._helpers import flush_parquet
-        try:
-            flush_parquet(self._composite, success=True)
-        except Exception as e:
-            warnings.warn(f"LineageProcess: parquet flush failed for "
-                          f"generation {self._generation} ({self._agent_id}): {e}")
+        # End of this generation: flush/close emitter, record summary.
+        if self._is_xarray():
+            if self._xarray_em is not None:
+                try:
+                    self._xarray_em.close(success=True)
+                except Exception as e:
+                    warnings.warn(f"LineageProcess: xarray close failed for "
+                                  f"generation {self._generation}: {e}")
+                self._xarray_em = None
+            self._xarray_pending = False
+        else:
+            from v2ecoli.composites._helpers import flush_parquet
+            try:
+                flush_parquet(self._composite, success=True)
+            except Exception as e:
+                warnings.warn(f"LineageProcess: parquet flush failed for "
+                              f"generation {self._generation} ({self._agent_id}): {e}")
         self._summaries.append({
             "generation": self._generation,
             "agent_id": self._agent_id,

--- a/v2ecoli/workflow/meta_composite.py
+++ b/v2ecoli/workflow/meta_composite.py
@@ -41,6 +41,9 @@ def _lineage_node(spec: BranchSpec, config: dict[str, Any]) -> dict[str, Any]:
                 "experiment_id": config.get("experiment_id", "default"),
                 "out_dir": config.get("out_dir", "out/workflow"),
                 "max_duration_per_gen": float(config.get("max_duration_per_gen", 3600.0)),
+                "time_step": float(config.get("time_step", 1.0)),
+                "emitter": config.get("emitter", "parquet"),
+                "emitter_arg": dict(config.get("emitter_arg") or {}),
             },
             "inputs": {},
             "outputs": {


### PR DESCRIPTION
## Summary

Adds an **xarray emitter option** to the workflow sweep framework (#95). A sweep can now emit a hive-partitioned **zarr** store per lineage instead of parquet, selected in the config the same way vEcoli PR #414 does it:

```json
{
  "inherit_from": ["two_generations.json"],
  "experiment_id": "two_generations_xarray",
  "emitter": "xarray",
  "emitter_arg": {
    "out_dir": "out/two_generations_xarray/zarr",
    "transducer": { "predicate": [[{"subsample": {"interval": 1}}]], "buffer": {"size": 4} },
    "view": [ { "root": ["listeners", "mass"],
                "variables": { "dry_mass": [{"path": "dry_mass", "dtype": "<f4"}], ... } } ]
  }
}
```

`LineageProcess` drives an **external `XArrayEmitter`** (not a composite-internal step — that's how it's proven in tests and in `xarray_run.py`), reusing the validated `v2ecoli/library/xarray_run.py` helpers:
- open lazily on the first populated tick, **filtering the view** to leaves the composite actually emits (xarray is strict about missing paths) and discovering vector coord arrays;
- emit the inner cell's filtered state per chunk;
- close per generation, with a **store path stable across a lineage's generations** so they accumulate as DataTree nodes.

Default view = scalar **mass gauges** (`dry_mass / cell_mass / protein_mass / rna_mass / dna_mass`) — no vector `output_metadata` needed out of the box; override via `emitter_arg.view`. **Parquet stays the default**; that path is unchanged.

## Test plan
- [x] Unit: default view, emitter-config threading through `meta_composite`, ported config loads, `_is_xarray()`.
- [x] **Cache-gated smoke**: runs a real 1-seed × 1-gen sweep with `emitter: "xarray"` and asserts a `.zarr` store lands with `dry_mass` (`tests/test_workflow_xarray.py::test_xarray_sweep_emits_zarr`, passes locally in ~11s).
- [x] No regression: parquet smoke, meta_composite, lineage, emitter_bulk all green (18 passed).
- [ ] Requires the `[xarray]` extra (`xarray>=2026.04`, `zarr`, `zarrs`); CI fast-tests skip the smoke (no cache + importorskip), unit tests run without the extra.

## Known rough edges (follow-ups, noted in the commit)
- On xarray runs the internal baseline emitter still materializes as `RAMEmitter` (wasted memory, never read) — could be suppressed.
- `emitter_arg.writer` / per-variable `codecs` / `unit` keys aren't threaded yet (the zarr writer is fixed by `xarray_run._build_emitter`).
- Vector observables work via the view filter + coord discovery but aren't exercised by the default view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)