### PR TITLE
xarray sweep report variant

### DIFF
--- a/scripts/sweep_report.py
+++ b/scripts/sweep_report.py
@@ -251,13 +251,34 @@ PR_HTML = """
 """.replace("{pr}", PR)
 
 
-def render_html(provenance, plot1, plot2, frac, div_rows):
-    """Assemble the standalone HTML document (pure: no IO)."""
+# Shared report CSS (single-brace; substituted verbatim, not f-string source).
+# Reused by scripts/sweep_report_xarray.py so both variants look identical.
+REPORT_CSS = """
+ body{font-family:ui-sans-serif,system-ui,-apple-system,sans-serif;max-width:1000px;margin:24px auto;padding:0 16px;color:#1f2937;line-height:1.55}
+ h1{font-size:1.5rem;margin:0 0 6px} h2{font-size:1.15rem;margin-top:2.2rem;border-bottom:1px solid #e5e7eb;padding-bottom:.3rem}
+ h3{font-size:1rem;margin-top:1.4rem}
+ .meta{color:#6b7280;font-size:.9rem} img{max-width:100%;border:1px solid #e5e7eb;border-radius:6px}
+ .provenance{background:#f8fafc;border:1px solid #e2e8f0;border-radius:8px;padding:10px 14px;margin:14px 0 20px;font-size:.85em;line-height:1.55}
+ .provenance dt{display:inline-block;min-width:120px;color:#475569;font-weight:600}
+ .provenance dd{display:inline;margin:0;font-family:ui-monospace,Menlo,monospace}
+ .provenance .row{margin:1px 0}
+ table{border-collapse:collapse;width:100%;font-size:.9rem;margin-top:.5rem}
+ th,td{border:1px solid #e5e7eb;padding:.35rem .6rem;text-align:left;vertical-align:top} th{background:#f3f4f6}
+ td.num{text-align:right;font-variant-numeric:tabular-nums;font-family:ui-monospace,Menlo,monospace}
+ .doc tr td:first-child{width:230px;white-space:nowrap}
+ pre{background:#0f172a;color:#e2e8f0;padding:.7rem .9rem;border-radius:6px;overflow-x:auto;font-size:.82rem;line-height:1.4}
+ code{background:rgba(0,0,0,.04);padding:1px 5px;border-radius:3px;font-size:.88em} pre code{background:none;padding:0}
+ .note{background:#fffbeb;border:1px solid #fde68a;border-radius:6px;padding:.6rem .9rem;font-size:.9rem;margin-top:1rem}
+ ul{font-size:.93rem} li{margin:.25rem 0}
+"""
+
+
+def provenance_banner(provenance) -> str:
+    """The shared git/run provenance banner ``<div>`` (AGENTS.md convention)."""
     dirty_badge = ('<span style="color:#dc2626;font-weight:600">  · DIRTY TREE</span>'
                    if provenance.get("git_dirty") else "")
     sha, short = provenance.get("git_sha", ""), provenance.get("git_short", "")
-    has_variant = provenance.get("n_variants", 1) > 1
-    prov = f"""<div class="provenance">
+    return f"""<div class="provenance">
   <div class="row"><dt>generated</dt><dd>{provenance.get('generated_at','')}</dd></div>
   <div class="row"><dt>git commit</dt>
     <dd><a href="{GITHUB_REPO}/commit/{sha}" style="color:#0369a1;text-decoration:none">{short}</a>
@@ -268,6 +289,13 @@ def render_html(provenance, plot1, plot2, frac, div_rows):
   <div class="row"><dt>host</dt><dd>{provenance.get('host','')} &nbsp;<span style="color:#94a3b8">{provenance.get('platform','')}, Python {provenance.get('python','')}</span></dd></div>
   <div class="row"><dt>sweep</dt><dd>{provenance.get('n_variants','?')} variant(s) &times; {provenance.get('n_seeds','?')} seed(s) &times; {provenance.get('n_gens','?')} generation(s) = {provenance.get('n_cells','?')} cells &middot; <code>{provenance.get('sweep_dir','')}</code></dd></div>
 </div>"""
+
+
+def render_html(provenance, plot1, plot2, frac, div_rows):
+    """Assemble the standalone HTML document (pure: no IO)."""
+    short = provenance.get("git_short", "")
+    has_variant = provenance.get("n_variants", 1) > 1
+    prov = provenance_banner(provenance)
 
     rows = ""
     for (v, s, g, m0, m1, t1) in div_rows:
@@ -281,24 +309,7 @@ def render_html(provenance, plot1, plot2, frac, div_rows):
 
     return f"""<!doctype html><html><head><meta charset="utf-8">
 <title>v2ecoli workflow sweep — {short or 'report'}</title>
-<style>
- body{{font-family:ui-sans-serif,system-ui,-apple-system,sans-serif;max-width:1000px;margin:24px auto;padding:0 16px;color:#1f2937;line-height:1.55}}
- h1{{font-size:1.5rem;margin:0 0 6px}} h2{{font-size:1.15rem;margin-top:2.2rem;border-bottom:1px solid #e5e7eb;padding-bottom:.3rem}}
- h3{{font-size:1rem;margin-top:1.4rem}}
- .meta{{color:#6b7280;font-size:.9rem}} img{{max-width:100%;border:1px solid #e5e7eb;border-radius:6px}}
- .provenance{{background:#f8fafc;border:1px solid #e2e8f0;border-radius:8px;padding:10px 14px;margin:14px 0 20px;font-size:.85em;line-height:1.55}}
- .provenance dt{{display:inline-block;min-width:120px;color:#475569;font-weight:600}}
- .provenance dd{{display:inline;margin:0;font-family:ui-monospace,Menlo,monospace}}
- .provenance .row{{margin:1px 0}}
- table{{border-collapse:collapse;width:100%;font-size:.9rem;margin-top:.5rem}}
- th,td{{border:1px solid #e5e7eb;padding:.35rem .6rem;text-align:left;vertical-align:top}} th{{background:#f3f4f6}}
- td.num{{text-align:right;font-variant-numeric:tabular-nums;font-family:ui-monospace,Menlo,monospace}}
- .doc tr td:first-child{{width:230px;white-space:nowrap}}
- pre{{background:#0f172a;color:#e2e8f0;padding:.7rem .9rem;border-radius:6px;overflow-x:auto;font-size:.82rem;line-height:1.4}}
- code{{background:rgba(0,0,0,.04);padding:1px 5px;border-radius:3px;font-size:.88em}} pre code{{background:none;padding:0}}
- .note{{background:#fffbeb;border:1px solid #fde68a;border-radius:6px;padding:.6rem .9rem;font-size:.9rem;margin-top:1rem}}
- ul{{font-size:.93rem}} li{{margin:.25rem 0}}
-</style></head><body>
+<style>{REPORT_CSS}</style></head><body>
 <h1>v2ecoli workflow sweep report</h1>
 <p class="meta">Pure process-bigraph meta-composite sweep</p>
 {prov}

--- a/scripts/sweep_report_xarray.py
+++ b/scripts/sweep_report_xarray.py
@@ -1,0 +1,264 @@
+"""Self-contained HTML report for a v2ecoli workflow sweep that emitted **xarray
+/ zarr** (the parquet variant is scripts/sweep_report.py).
+
+Reads the per-lineage ``.zarr`` stores a sweep emits (``emitter: "xarray"``),
+embeds matplotlib plots as base64 PNGs, prepends the shared git/run provenance
+banner, appends the how-to-run + framework docs, and writes a latest + a
+timestamp+commit archival copy under ``reports/figures/<experiment>/`` (per
+AGENTS.md). Plots are base64-embedded so the report is portable.
+
+    .venv/bin/python scripts/sweep_report_xarray.py <sweep_dir> [--open]
+
+``<sweep_dir>`` is the directory holding the ``<exp>_v<variant>_s<seed>.zarr``
+stores (i.e. the sweep's ``emitter_arg.out_dir``). Output defaults to
+``reports/figures/<experiment_id>/sweep_report_xarray.html``.
+
+Requires the ``[xarray]`` extra (xarray + zarr) and matplotlib.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import glob
+import os
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(Path(__file__).resolve().parent))  # import the sibling
+import sweep_report as sr  # noqa: E402  (REPORT_CSS, provenance_banner, docs, ...)
+
+# Mass components captured by the default xarray view (see LineageProcess
+# DEFAULT_XARRAY_VIEW). The fraction analysis uses whichever are present.
+_FRACTION_COMPONENTS = [("protein", "protein_mass"),
+                        ("RNA", "rna_mass"),
+                        ("DNA", "dna_mass")]
+_MASS_VARS = ["dry_mass", "cell_mass", "protein_mass", "rna_mass", "dna_mass"]
+_SEED_COLORS = ["#2563eb", "#dc2626", "#059669", "#d97706", "#7c3aed", "#0891b2"]
+_VARIANT_STYLES = ["-", "--", ":", "-."]
+
+
+def discover_experiment_id(sweep_dir) -> str:
+    stores = glob.glob(os.path.join(sweep_dir, "*.zarr"))
+    for s in stores:
+        m = re.match(r"^(.*)_v\d+_s\d+\.zarr$", os.path.basename(s))
+        if m:
+            return m.group(1)
+    return "sweep"
+
+
+def load_cells(sweep_dir):
+    """Return ``{(variant, seed, gen): {var: ndarray}}`` from the .zarr stores.
+
+    Each store is one lineage. Within it, ``time_gen=N`` lives on the lineage
+    node and each mass variable is a child group holding ``generation=N`` data
+    vars (dims ``emitstep_gen=N``). Generations are 1-based as stored.
+    """
+    import numpy as np
+    import xarray as xr
+
+    cells = {}
+    for store in sorted(glob.glob(os.path.join(sweep_dir, "*.zarr"))):
+        dt = xr.open_datatree(store, engine="zarr")
+        groups = set(dt.groups)  # multi-level paths; dt.get() only sees children
+        for path in dt.groups:
+            if not re.search(r"lineage_seed=\d+$", path):
+                continue
+            v = int(re.search(r"variant=([^/]+)", path).group(1))
+            s = int(re.search(r"lineage_seed=(\d+)", path).group(1))
+            node = dt[path].to_dataset()
+            gens = sorted(int(re.search(r"time_gen=(\d+)", n).group(1))
+                          for n in node.data_vars if n.startswith("time_gen="))
+            for g in gens:
+                cell = {"time": np.asarray(node[f"time_gen={g}"]).ravel()}
+                key = f"generation={g}"
+                for var in _MASS_VARS:
+                    vpath = f"{path}/{var}"
+                    if vpath not in groups:
+                        continue
+                    ds = dt[vpath].to_dataset()
+                    if key in ds.data_vars:
+                        cell[var] = np.asarray(ds[key]).ravel()
+                cells[(v, s, g)] = cell
+    return cells
+
+
+def _plots(cells):
+    """Return (trajectory_b64, fractions_b64, frac, div_rows)."""
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    import numpy as np
+
+    variants = sorted({v for v, s, g in cells})
+    seeds = sorted({s for v, s, g in cells})
+    gens = sorted({g for v, s, g in cells})
+
+    frac, div_rows = {}, []
+    for (v, s, g), c in cells.items():
+        dry = c.get("dry_mass")
+        f = {}
+        for label, var in _FRACTION_COMPONENTS:
+            comp = c.get(var)
+            if comp is not None and dry is not None and np.all(dry > 0):
+                f[label] = float(np.mean(comp / dry))
+            else:
+                f[label] = 0.0
+        frac[(v, s, g)] = f
+        t = c.get("time")
+        div_rows.append((v, s, g,
+                         float(dry[0]) if dry is not None and len(dry) else 0.0,
+                         float(dry[-1]) if dry is not None and len(dry) else 0.0,
+                         float(t[-1]) if t is not None and len(t) else 0.0))
+
+    # Plot 1: dry-mass trajectory across generations (offset cumulatively).
+    fig, ax = plt.subplots(figsize=(9, 4.2))
+    for (v, s) in sorted({(v, s) for v, s, g in cells}):
+        offset, first = 0.0, True
+        for g in gens:
+            c = cells.get((v, s, g))
+            if not c or c.get("dry_mass") is None:
+                continue
+            t, dry = c["time"], c["dry_mass"]
+            label = (f"seed {s}" + (f" / v{v}" if len(variants) > 1 else "")) if first else None
+            ax.plot((t + offset) / 60.0, dry,
+                    color=_SEED_COLORS[seeds.index(s) % len(_SEED_COLORS)],
+                    ls=_VARIANT_STYLES[variants.index(v) % len(_VARIANT_STYLES)],
+                    lw=1.4, marker=".", label=label)
+            ax.axvline(offset / 60.0, color="#9ca3af", ls=":", lw=0.7)
+            offset += float(t[-1]) if len(t) else 0.0
+            first = False
+    ax.set_xlabel("time across lineage (min)")
+    ax.set_ylabel("dry mass (fg)")
+    ax.set_title("Multigeneration dry-mass trajectory (from zarr)")
+    ax.legend(frameon=False, fontsize=8)
+    ax.grid(alpha=0.25)
+    p1 = sr._b64(fig)
+
+    # Plot 2: mass fractions vs generation + grouped bars.
+    fig, axes = plt.subplots(1, 2, figsize=(9, 3.6))
+    for (v, s) in sorted({(v, s) for v, s, g in cells}):
+        xs = [g for g in gens if (v, s, g) in frac]
+        ys = [frac[(v, s, g)]["protein"] for g in xs]
+        axes[0].plot(xs, ys, marker="o",
+                     color=_SEED_COLORS[seeds.index(s) % len(_SEED_COLORS)],
+                     ls=_VARIANT_STYLES[variants.index(v) % len(_VARIANT_STYLES)])
+    axes[0].set_title("Protein mass fraction vs generation")
+    axes[0].set_xlabel("generation")
+    axes[0].set_ylabel("protein / dry mass")
+    axes[0].set_xticks(gens)
+    axes[0].grid(alpha=0.25)
+    width = 0.25
+    labels = [lbl for lbl, _ in _FRACTION_COMPONENTS]
+    for i, lbl in enumerate(labels):
+        vals = [np.mean([frac[k][lbl] for k in frac if k[2] == g]) for g in gens]
+        axes[1].bar(np.array(gens) + (i - 1) * width, vals, width, label=lbl)
+    axes[1].set_title("Mean mass fractions (all cells)")
+    axes[1].set_xlabel("generation")
+    axes[1].set_xticks(gens)
+    axes[1].set_yscale("log")
+    axes[1].legend(frameon=False)
+    axes[1].grid(alpha=0.25, which="both")
+    p2 = sr._b64(fig)
+    return p1, p2, frac, sorted(div_rows)
+
+
+def render_html(provenance, plot1, plot2, frac, div_rows):
+    """Assemble the standalone HTML (pure). Reuses the shared CSS / banner /
+    docs from sweep_report; labels the RNA-total fraction (not rRNA) and notes
+    the zarr source."""
+    short = provenance.get("git_short", "")
+    has_variant = provenance.get("n_variants", 1) > 1
+    prov = sr.provenance_banner(provenance)
+    labels = [lbl for lbl, _ in _FRACTION_COMPONENTS]
+
+    rows = ""
+    for (v, s, g, m0, m1, t1) in div_rows:
+        fr = frac[(v, s, g)]
+        vcell = f"<td>{v}</td>" if has_variant else ""
+        cols = "".join(f"<td class='num'>{fr[lbl]:.3f}</td>" for lbl in labels)
+        rows += (f"<tr>{vcell}<td>{s}</td><td>{g}</td><td class='num'>{m0:.0f}</td>"
+                 f"<td class='num'>{m1:.0f}</td><td class='num'>{t1:.0f}</td>{cols}</tr>")
+    vhdr = "<th>variant</th>" if has_variant else ""
+    frac_hdr = "".join(f"<th>{lbl}</th>" for lbl in labels)
+
+    body = f"""<h1>v2ecoli workflow sweep report <span class="meta">(xarray / zarr)</span></h1>
+<p class="meta">Pure process-bigraph meta-composite sweep — emitter <code>xarray</code></p>
+{prov}
+<h2>Multigeneration mass trajectory</h2>
+<img src="data:image/png;base64,{plot1}">
+<p class="meta">Read from the per-lineage zarr stores (dotted lines = generation
+boundaries). Generations are stored as <code>generation=N</code> vars under each
+mass variable, sharing one lineage node.</p>
+<h2>Mass-fraction analysis</h2>
+<img src="data:image/png;base64,{plot2}">
+<h2>Per-cell summary</h2>
+<table>
+<tr>{vhdr}<th>seed</th><th>gen</th><th>newborn (fg)</th><th>division (fg)</th><th>cycle (s)</th>{frac_hdr}</tr>
+{rows}
+</table>
+{sr.HOWTO_HTML}
+{sr.PR_HTML}
+<div class="note"><b>Source:</b> read from the sweep's hive-partitioned zarr stores
+(<code>&lt;exp&gt;_v&lt;variant&gt;_s&lt;seed&gt;.zarr</code>). Only the variables the
+sweep's xarray <code>view</code> emitted are available — the default view captures
+scalar mass gauges (<code>dry_mass / cell_mass / protein_mass / rna_mass /
+dna_mass</code>), so the fraction here is total RNA, not rRNA.</div>"""
+    return (f'<!doctype html><html><head><meta charset="utf-8">'
+            f'<title>v2ecoli workflow sweep (xarray) — {short or "report"}</title>'
+            f'<style>{sr.REPORT_CSS}</style></head><body>{body}</body></html>')
+
+
+def build_report(sweep_dir, out=None):
+    """Render the report. Returns (latest_path, archive_path)."""
+    cells = load_cells(sweep_dir)
+    if not cells:
+        raise SystemExit(f"no .zarr sweep stores found under {sweep_dir!r} "
+                         f"(expected <exp>_v<variant>_s<seed>.zarr)")
+    plot1, plot2, frac, div_rows = _plots(cells)
+    prov = sr.collect_provenance(extra={
+        "sweep_dir": sweep_dir,
+        "n_variants": len({v for v, s, g in cells}),
+        "n_seeds": len({s for v, s, g in cells}),
+        "n_gens": len({g for v, s, g in cells}),
+        "n_cells": len(cells),
+    })
+    prov["script"] = "scripts/sweep_report_xarray.py"
+    html = render_html(prov, plot1, plot2, frac, div_rows)
+
+    if out is None:
+        study = discover_experiment_id(sweep_dir).replace("_", "-")
+        out = REPO_ROOT / "reports" / "figures" / study / "sweep_report_xarray.html"
+    out = Path(out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(html, encoding="utf-8")
+
+    stamp = _dt.datetime.now().strftime("%Y%m%dT%H%M%S")
+    archive = out.with_name(f"{out.stem}_{stamp}_{prov.get('git_short') or 'nogit'}.html")
+    archive.write_bytes(out.read_bytes())
+    return out, archive
+
+
+def main():
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("sweep_dir", help="dir holding the <exp>_v<v>_s<s>.zarr stores")
+    p.add_argument("--out", default=None)
+    p.add_argument("--open", action="store_true")
+    args = p.parse_args()
+    latest, archive = build_report(args.sweep_dir, out=args.out)
+    try:
+        rel = archive.relative_to(REPO_ROOT)
+    except ValueError:
+        rel = archive  # custom --out outside the repo
+    print(f"Wrote latest  {latest}")
+    print(f"Wrote archive {archive}")
+    print(f"  commit the archive with: git add -f {rel}")
+    if args.open:
+        import subprocess
+        subprocess.run(["open", str(latest)], check=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_sweep_report_xarray.py
+++ b/tests/test_sweep_report_xarray.py
@@ -1,0 +1,81 @@
+"""Tests for scripts/sweep_report_xarray.py — pure render (CI-safe) + a
+cache-gated full build from a real xarray sweep."""
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "scripts"))
+import sweep_report_xarray as sx  # noqa: E402
+
+CACHE = os.environ.get("V2ECOLI_CACHE", "out/cache")
+
+
+def _prov(n_variants=1):
+    return {
+        "generated_at": "2026-05-30T12:00:00+00:00",
+        "git_sha": "abc1234def5678", "git_short": "abc1234d",
+        "git_branch": "feat/sweep-report-xarray", "git_dirty": True,
+        "git_last_commit_msg": "test commit", "git_last_commit_author": "Eran",
+        "git_last_commit_when": "2026-05-30 12:00:00 -0400",
+        "host": "h", "platform": "Darwin 24 arm64", "python": "3.12.0",
+        "script": "scripts/sweep_report_xarray.py", "sweep_dir": "/tmp/run",
+        "n_variants": n_variants, "n_seeds": 2, "n_gens": 2, "n_cells": 2 * n_variants * 2,
+    }
+
+
+def test_render_html_xarray_labels_rna_and_notes_zarr():
+    frac = {(0, 0, 1): {"protein": 0.47, "RNA": 0.20, "DNA": 0.02}}
+    div_rows = [(0, 0, 1, 350.0, 660.0, 2400.0)]
+    html = sx.render_html(_prov(), "PLOT1B64", "PLOT2B64", frac, div_rows)
+    # shared provenance banner + docs (reused from sweep_report)
+    assert 'class="provenance"' in html
+    assert "abc1234d" in html and "DIRTY TREE" in html
+    assert "How to run your own sweep" in html and "What this framework adds" in html
+    # xarray-specific: RNA (total) not rRNA, and the zarr source note
+    assert "<th>RNA</th>" in html and "<th>rRNA</th>" not in html
+    assert "xarray / zarr" in html and "hive-partitioned zarr" in html
+    assert "PLOT1B64" in html and "PLOT2B64" in html
+    assert "0.470" in html
+
+
+def test_variant_column_only_when_multiple_variants():
+    frac = {(0, 0, 1): {"protein": 0.47, "RNA": 0.20, "DNA": 0.02}}
+    div_rows = [(0, 0, 1, 350.0, 660.0, 2400.0)]
+    assert "<th>variant</th>" not in sx.render_html(_prov(1), "a", "b", frac, div_rows)
+    assert "<th>variant</th>" in sx.render_html(_prov(2), "a", "b", frac, div_rows)
+
+
+def test_discover_experiment_id_parses_store_name(tmp_path):
+    (tmp_path / "two_generations_xarray_v0_s1.zarr").mkdir()
+    (tmp_path / "two_generations_xarray_v0_s0.zarr").mkdir()
+    assert sx.discover_experiment_id(str(tmp_path)) == "two_generations_xarray"
+
+
+@pytest.mark.skipif(not os.path.isdir(CACHE), reason=f"ParCa cache {CACHE} not present")
+def test_build_report_from_real_xarray_sweep(tmp_path):
+    pytest.importorskip("xarray")
+    pytest.importorskip("zarr")
+    from v2ecoli.workflow.run import run_workflow
+
+    zarr_dir = str(tmp_path / "zarr")
+    config = {
+        "experiment_id": "xrep", "n_init_sims": 1, "generations": 1,
+        "single_daughters": True, "cache_dir": CACHE, "out_dir": str(tmp_path),
+        "variants": {}, "max_duration_per_gen": 5.0, "time_step": 1.0,
+        "emitter": "xarray", "emitter_arg": {"out_dir": zarr_dir},
+    }
+    assert run_workflow(config, max_sim_time=20.0)["complete"] is True
+
+    cells = sx.load_cells(zarr_dir)
+    assert cells, "no cells loaded from zarr"
+    # one lineage, generation 1, with dry_mass present
+    (v, s, g) = next(iter(cells))
+    assert "dry_mass" in cells[(v, s, g)]
+
+    out = tmp_path / "report.html"
+    latest, archive = sx.build_report(zarr_dir, out=str(out))
+    assert latest.exists() and archive.exists()
+    html = latest.read_text()
+    assert 'class="provenance"' in html and "xarray / zarr" in html
+    assert "data:image/png;base64" in html


### PR DESCRIPTION
## Summary

Adds **`scripts/sweep_report_xarray.py`** — a zarr-reading variant of the sweep HTML report (the parquet one is `scripts/sweep_report.py`), for sweeps that emit with `"emitter": "xarray"`.

It reads the per-lineage `.zarr` stores and renders the **same-style standalone report**: git/run **provenance banner**, multigeneration dry-mass trajectory, mass-fraction analysis, per-cell table, embedded how-to-run + framework docs, and a **latest + timestamp/commit archive** copy under `reports/figures/<experiment>/` (per AGENTS.md).

```
.venv/bin/python scripts/sweep_report_xarray.py <zarr_dir> --open
```

### How it reads the zarr
Each store is one lineage (`/experiment_id/variant=V/lineage_seed=S/`). `time_gen=N` lives on the lineage node; each mass variable is a child group holding `generation=N` data vars (dims `emitstep_gen=N`). The report reports whichever mass gauges the sweep's `view` emitted — the default view captures **total RNA**, so the fraction column is labelled `RNA` (not `rRNA`).

### Shared-component refactor
Extracted `REPORT_CSS` + `provenance_banner()` from `sweep_report.py` so both report variants share the banner / CSS / docs. Behaviour is unchanged (render output is substring-identical; the existing `test_sweep_report.py` stays green).

## Test plan
- [x] Pure render: RNA label (not rRNA) + zarr source note + shared provenance banner + docs — **CI-safe** (no `[xarray]` needed; the module imports xarray lazily inside the loader).
- [x] Store-name parsing (`discover_experiment_id`) + variant-column logic.
- [x] **Cache-gated full build**: runs a real xarray sweep, loads the zarr, builds the report, asserts the provenance banner + plots land.
- [x] No regression: `test_sweep_report.py` (parquet) + `test_workflow_xarray.py` + parquet smoke — 19 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)