### PR TITLE
feat: lift framework improvements out of investigation branches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,15 +21,23 @@ v2ecoli/processes/parca/**/*.cpython-*.so
 # study-test-results/, default-baseline/, …) so the dashboard's
 # dirty-tree gate stops blocking Install / Workstream Commit on its own
 # writes.
+.venv
 .pbg/
+# schemas under .pbg/schemas/ are source — keep them tracked
+!.pbg/schemas/
 **/runs.db
 **/runs.db-shm
 **/runs.db-wal
+investigations/*/runs.db
+investigations/*/.run.lock
 studies/*/sims/*.subprocess.py
 studies/*/sims/parquet-rerun-*/
 studies/*/viz/
 studies/*/parquet-runs/
 reports/
+# dashboard re-render targets (regenerated on demand by /api/render)
+reports/assets/*
+!reports/assets/.keep
 investigations/*/viz/
 .dashboard.log
 

--- a/tests/test_composites_baseline.py
+++ b/tests/test_composites_baseline.py
@@ -15,11 +15,12 @@ def test_baseline_function_is_registered():
 
 @pytest.mark.fast
 def test_baseline_function_signature():
-    """The generator function takes (core, *, seed, cache_dir, config_overrides)."""
+    """The generator takes (core, *, seed, cache_dir, config_overrides, bundle)."""
     import inspect
     from v2ecoli.composites.baseline import baseline
     sig = inspect.signature(baseline)
-    assert set(sig.parameters) == {"core", "seed", "cache_dir", "config_overrides"}
+    assert set(sig.parameters) == {
+        "core", "seed", "cache_dir", "config_overrides", "bundle"}
 
 
 @pytest.mark.sim

--- a/v2ecoli/composites/baseline.py
+++ b/v2ecoli/composites/baseline.py
@@ -398,7 +398,8 @@ def _get_step_config(loader, step_name, core, process_cache=None, master_seed=0)
     ],
 )
 def baseline(core: Any = None, *, seed: int = 0, cache_dir: str = "out/cache",
-             config_overrides: dict | None = None) -> dict:
+             config_overrides: dict | None = None,
+             bundle: dict | None = None) -> dict:
     """Build the process-bigraph state document for the baseline architecture.
 
     Migrated from ``v2ecoli/generate.py:build_document`` +
@@ -414,6 +415,10 @@ def baseline(core: Any = None, *, seed: int = 0, cache_dir: str = "out/cache",
         seed: Random seed for stochastic initialisation.
         cache_dir: Path to the ParCa cache directory (must contain
             ``initial_state.json`` and ``sim_data_cache.dill``).
+        bundle: optional pre-loaded cache bundle (as returned by
+            ``load_cache_bundle``). When given, the cache is not re-read from
+            ``cache_dir`` — lets callers building many composites from the same
+            cache (ensembles, sweeps) load it once and reuse it.
 
     Returns:
         Process-bigraph document dict with keys ``state``,
@@ -422,7 +427,8 @@ def baseline(core: Any = None, *, seed: int = 0, cache_dir: str = "out/cache",
     if core is None:
         core = build_core()
 
-    bundle = load_cache_bundle(cache_dir)
+    if bundle is None:
+        bundle = load_cache_bundle(cache_dir)
     initial_state = bundle["initial_state"]
     configs = bundle["configs"]
     if config_overrides:


### PR DESCRIPTION
Generic infrastructure that was carried inside investigation PRs but benefits every workspace — lifted onto `main` so it's not gated behind biology-specific work.

- **`baseline(bundle=…)`** — optional pre-loaded cache bundle param; callers building many composites from one cache (ensembles, sweeps) load it once instead of re-reading `cache_dir` each time. *(from #99 / dnaa-replication)*
- **`.gitignore`** — general runtime-artifact patterns: `.venv`, `reports/assets/*` (+`.keep`), `investigations/*/runs.db` + `.run.lock`, and keep `.pbg/schemas/` tracked. *(from #69 / multiscale-bioprocess)*

### Deliberately NOT lifted (after diffing each candidate vs current main)
- **#99 MarkDPeriod `divide`-flag fix** — already on `main`.
- **#69 `ci.yml`** — adds `baseline_population`/`baseline_time_varying_env` to the CI smoke list; those composites don't exist on `main`, so it'd break CI. Stays with the bioreactor PR.
- **#100 jump-process modes / likelihood collector** and **#99 `dnaa_succinate` viz** — investigation-specific science, not framework.

> Note: the investigation branches are stale relative to `main` (they predate the recent emitter merges), so most of their apparent "framework" delta was either already on main or entangled with being behind — this PR carries only the genuinely-novel, general bits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)