### PR TITLE
refactor: surface the math + flatten nested classes (chromosome_structure, metabolism, composites)

### DIFF
--- a/v2ecoli/composites/_helpers.py
+++ b/v2ecoli/composites/_helpers.py
@@ -44,6 +44,50 @@ from v2ecoli.processes.polypeptide_elongation import PolypeptideElongation
 FLUSH = '__unique_flush__'
 
 
+# --- Cache-driven config loader -------------------------------------------
+# Composite generators build from a cache bundle (pre-resolved configs) rather
+# than a live ParCa sim_data object. CachedConfigLoader is the small stand-in
+# they pass to step builders: it serves configs by name and exposes the few
+# sim_data attributes those builders read (unique-molecule definitions +
+# expected dry-mass increase). Previously each generator (baseline,
+# departitioned, reconciled, millard_pdmp_baseline) defined its own nested
+# _CachedLoader with a 4-level inner-class mock; this is the single flattened,
+# module-level version.
+
+class _MockUniqueMolecule:
+    def __init__(self, names):
+        self.unique_molecule_definitions = {n: {} for n in names}
+
+
+class _MockInternalState:
+    def __init__(self, names):
+        self.unique_molecule = _MockUniqueMolecule(names)
+
+
+class _MockSimData:
+    def __init__(self, unique_names, dry_mass_inc_dict):
+        self.internal_state = _MockInternalState(unique_names)
+        self.expectedDryMassIncreaseDict = dry_mass_inc_dict or {}
+
+
+class CachedConfigLoader:
+    """Serve pre-resolved configs from the cache bundle + a minimal sim_data
+    stand-in. Replaces the per-generator nested ``_CachedLoader``."""
+
+    def __init__(self, configs, unique_names, dry_mass_inc_dict,
+                 cache_dir='out/cache'):
+        self._configs = configs
+        self.unique_names = unique_names
+        self.cache_dir = cache_dir
+        self.sim_data = _MockSimData(unique_names, dry_mass_inc_dict)
+
+    def get_config_by_name(self, name):
+        try:
+            return self._configs[name]
+        except KeyError:
+            raise KeyError(f'Unknown: {name}')
+
+
 def _expand_flushes(layers):
     """Replace each FLUSH sentinel with a real [unique_update_N] sub-layer.
 

--- a/v2ecoli/composites/baseline.py
+++ b/v2ecoli/composites/baseline.py
@@ -54,6 +54,7 @@ from v2ecoli.composites._helpers import (
     _get_special_step,
     _expand_flushes,
     set_default_emitter_decl,
+    CachedConfigLoader,
     FLUSH,
     PARTITIONED_PROCESSES,
     ALL_PARTITIONED,
@@ -527,35 +528,10 @@ def baseline(core: Any = None, *, seed: int = 0, cache_dir: str = "out/cache",
         'aa_count_diff': np.zeros(21),
     })
 
-    # Create a mock loader that returns configs from the cache
-    class _CachedLoader:
-        def __init__(self, configs, unique_names, dry_mass_inc_dict, cache_dir='out/cache'):
-            self._configs = configs
-            self.unique_names = unique_names
-            self.cache_dir = cache_dir
-
-            class _SimData:
-                class _InternalState:
-                    class _UniqueMolecule:
-                        def __init__(self, names):
-                            self.unique_molecule_definitions = {
-                                n: {} for n in names}
-                    unique_molecule = None
-                    def __init__(self, names):
-                        self.unique_molecule = self._UniqueMolecule(names)
-                internal_state = None
-                expectedDryMassIncreaseDict = {}
-
-            self.sim_data = _SimData()
-            self.sim_data.internal_state = _SimData._InternalState(unique_names)
-            self.sim_data.expectedDryMassIncreaseDict = dry_mass_inc_dict or {}
-
-        def get_config_by_name(self, name):
-            if name in self._configs:
-                return self._configs[name]
-            raise KeyError(f'Unknown: {name}')
-
-    loader = _CachedLoader(configs, unique_names, dry_mass_inc_dict, cache_dir=cache_dir)
+    # Mock loader: serves cache configs + a minimal sim_data stand-in (see
+    # CachedConfigLoader in _helpers — replaces the old nested _CachedLoader).
+    loader = CachedConfigLoader(
+        configs, unique_names, dry_mass_inc_dict, cache_dir=cache_dir)
 
     # Build execution layers for the requested feature set
     execution_layers = build_execution_layers(features)

--- a/v2ecoli/composites/departitioned.py
+++ b/v2ecoli/composites/departitioned.py
@@ -34,6 +34,7 @@ from v2ecoli.composites._helpers import (
     _normalize_boundary_units,
     _make_instance,
     _get_special_step,
+    CachedConfigLoader,
     _expand_flushes,
     FLUSH,
     PARTITIONED_PROCESSES,
@@ -396,35 +397,8 @@ def departitioned(core: Any = None, *, seed: int = 0, cache_dir: str = "out/cach
     })
 
     # Mock loader
-    class _CachedLoader:
-        def __init__(self, configs, unique_names, dry_mass_inc_dict):
-            self._configs = configs
-            self.unique_names = unique_names
-
-            class _SimData:
-                class _InternalState:
-                    class _UniqueMolecule:
-                        def __init__(self, names):
-                            self.unique_molecule_definitions = {
-                                n: {} for n in names}
-                    unique_molecule = None
-                    def __init__(self, names):
-                        self.unique_molecule = self._UniqueMolecule(names)
-                internal_state = None
-                expectedDryMassIncreaseDict = {}
-
-            self.sim_data = _SimData()
-            self.sim_data.internal_state = _SimData._InternalState(
-                unique_names)
-            self.sim_data.expectedDryMassIncreaseDict = (
-                dry_mass_inc_dict or {})
-
-        def get_config_by_name(self, name):
-            if name in self._configs:
-                return self._configs[name]
-            raise KeyError(f'Unknown: {name}')
-
-    loader = _CachedLoader(configs, unique_names, dry_mass_inc_dict)
+    # Mock loader: cache configs + minimal sim_data (see _helpers.CachedConfigLoader).
+    loader = CachedConfigLoader(configs, unique_names, dry_mass_inc_dict)
 
     # Build execution layers for the default feature set
     execution_layers = build_execution_layers(DEFAULT_FEATURES)

--- a/v2ecoli/composites/millard_pdmp_baseline.py
+++ b/v2ecoli/composites/millard_pdmp_baseline.py
@@ -59,6 +59,7 @@ from v2ecoli.composites._helpers import (
     _normalize_boundary_units,
     _make_instance,
     _get_special_step,
+    CachedConfigLoader,
     _expand_flushes,
     FLUSH,
     PARTITIONED_PROCESSES,
@@ -761,34 +762,8 @@ def millard_pdmp_baseline(
     # a top-level dict, but identical wiring through 'shared/' works).
     cell_state['shared'].setdefault('central_metabolite_counts', {})
 
-    class _CachedLoader:
-        def __init__(self, configs, unique_names, dry_mass_inc_dict, cache_dir='out/cache'):
-            self._configs = configs
-            self.unique_names = unique_names
-            self.cache_dir = cache_dir
-
-            class _SimData:
-                class _InternalState:
-                    class _UniqueMolecule:
-                        def __init__(self, names):
-                            self.unique_molecule_definitions = {
-                                n: {} for n in names}
-                    unique_molecule = None
-                    def __init__(self, names):
-                        self.unique_molecule = self._UniqueMolecule(names)
-                internal_state = None
-                expectedDryMassIncreaseDict = {}
-
-            self.sim_data = _SimData()
-            self.sim_data.internal_state = _SimData._InternalState(unique_names)
-            self.sim_data.expectedDryMassIncreaseDict = dry_mass_inc_dict or {}
-
-        def get_config_by_name(self, name):
-            if name in self._configs:
-                return self._configs[name]
-            raise KeyError(f'Unknown: {name}')
-
-    loader = _CachedLoader(configs, unique_names, dry_mass_inc_dict, cache_dir=cache_dir)
+    # Mock loader: cache configs + minimal sim_data (see _helpers.CachedConfigLoader).
+    loader = CachedConfigLoader(configs, unique_names, dry_mass_inc_dict, cache_dir=cache_dir)
 
     execution_layers = build_execution_layers(features)
     flow_order = [step for layer in execution_layers for step in layer]

--- a/v2ecoli/composites/reconciled.py
+++ b/v2ecoli/composites/reconciled.py
@@ -35,6 +35,7 @@ from v2ecoli.composites._helpers import (
     _normalize_boundary_units,
     _make_instance,
     _get_special_step,
+    CachedConfigLoader,
     _expand_flushes,
     FLUSH,
     PARTITIONED_PROCESSES,
@@ -430,35 +431,8 @@ def reconciled(core: Any = None, *, seed: int = 0, cache_dir: str = "out/cache")
     })
 
     # Mock loader
-    class _CachedLoader:
-        def __init__(self, configs, unique_names, dry_mass_inc_dict):
-            self._configs = configs
-            self.unique_names = unique_names
-
-            class _SimData:
-                class _InternalState:
-                    class _UniqueMolecule:
-                        def __init__(self, names):
-                            self.unique_molecule_definitions = {
-                                n: {} for n in names}
-                    unique_molecule = None
-                    def __init__(self, names):
-                        self.unique_molecule = self._UniqueMolecule(names)
-                internal_state = None
-                expectedDryMassIncreaseDict = {}
-
-            self.sim_data = _SimData()
-            self.sim_data.internal_state = _SimData._InternalState(
-                unique_names)
-            self.sim_data.expectedDryMassIncreaseDict = (
-                dry_mass_inc_dict or {})
-
-        def get_config_by_name(self, name):
-            if name in self._configs:
-                return self._configs[name]
-            raise KeyError(f'Unknown: {name}')
-
-    loader = _CachedLoader(configs, unique_names, dry_mass_inc_dict)
+    # Mock loader: cache configs + minimal sim_data (see _helpers.CachedConfigLoader).
+    loader = CachedConfigLoader(configs, unique_names, dry_mass_inc_dict)
 
     # Build execution layers for the default feature set
     execution_layers = build_execution_layers(DEFAULT_FEATURES)

--- a/v2ecoli/processes/chromosome_structure.py
+++ b/v2ecoli/processes/chromosome_structure.py
@@ -52,9 +52,6 @@ import warnings
 from v2ecoli.library.ecoli_step import EcoliStep as Step
 # Composer removed
 # Engine removed
-
-from ecoli.processes.global_clock import GlobalClock
-from ecoli.processes.unique_update import UniqueUpdate
 # topology_registry removed
 from v2ecoli.library.schema import (
     listener_schema,

--- a/v2ecoli/processes/chromosome_structure.py
+++ b/v2ecoli/processes/chromosome_structure.py
@@ -249,32 +249,76 @@ class ChromosomeStructure(Step):
             return True
         return False
 
+    def _init_bulk_indices(self, bulk_ids):
+        """Resolve every molecule-name -> bulk-array-index map this Step uses.
+        Called once (guarded by ``self.inactive_RNAPs_idx is None``), so it
+        never runs on the per-tick path."""
+        self.fragmentBasesIdx = bulk_name_to_idx(self.fragmentBases, bulk_ids)
+        self.active_tfs_idx = bulk_name_to_idx(self.active_tfs, bulk_ids)
+        self.ribosome_30S_subunit_idx = bulk_name_to_idx(
+            self.ribosome_30S_subunit, bulk_ids)
+        self.ribosome_50S_subunit_idx = bulk_name_to_idx(
+            self.ribosome_50S_subunit, bulk_ids)
+        self.amino_acids_idx = bulk_name_to_idx(self.amino_acids, bulk_ids)
+        self.water_idx = bulk_name_to_idx(self.water, bulk_ids)
+        self.ppi_idx = bulk_name_to_idx(self.ppi, bulk_ids)
+        self.inactive_RNAPs_idx = bulk_name_to_idx(self.inactive_RNAPs, bulk_ids)
+        self.mature_rna_idx = bulk_name_to_idx(self.mature_rna_ids, bulk_ids)
+
+    def _removed_molecules_mask(self, domain_indexes, coordinates,
+                                replisome_coords_by_domain, child_domains,
+                                all_domain_indexes, mother_domain_indexes):
+        """Boolean mask of unique molecules the replication forks have passed
+        (and so must be removed from the mother strand).
+
+        For each chromosome domain:
+          * if it carries active replisomes, a molecule is removed when its
+            coordinate lies within [min, max] of those replisome coordinates
+            (>=/<= so molecules exactly at a fork are also removed);
+          * if it has no replisomes but its children are full chromosomes
+            (replication finished), every molecule on it is removed;
+          * otherwise (un-replicated / interrupted) nothing is removed.
+        """
+        mask = np.zeros_like(domain_indexes, dtype=np.bool_)
+        for domain_index in np.unique(domain_indexes):
+            if domain_index in replisome_coords_by_domain:
+                domain_replisome_coordinates = replisome_coords_by_domain[
+                    domain_index]
+                domain_mask = np.logical_and.reduce((
+                    domain_indexes == domain_index,
+                    coordinates >= domain_replisome_coordinates.min(),
+                    coordinates <= domain_replisome_coordinates.max(),
+                ))
+            else:
+                children_of_domain = child_domains[
+                    all_domain_indexes == domain_index]
+                if np.all(np.isin(children_of_domain, mother_domain_indexes)):
+                    domain_mask = domain_indexes == domain_index
+                else:
+                    continue
+            mask[domain_mask] = True
+        return mask
+
+    def _replicated_motif_attributes(self, old_coordinates, old_domain_indexes,
+                                     child_domains, all_domain_indexes):
+        """Attributes for a chromosomal motif (promoter/gene/DnaA box) after a
+        replication fork passes it: the motif is duplicated onto the two child
+        domains. Coordinates are repeated; each domain index is replaced by its
+        two child-domain indexes."""
+        new_coordinates = np.repeat(old_coordinates, 2)
+        new_domain_indexes = child_domains[
+            np.array([
+                np.where(all_domain_indexes == idx)[0][0]
+                for idx in old_domain_indexes
+            ]),
+            :,
+        ].flatten()
+        return new_coordinates, new_domain_indexes
+
     def update(self, states, interval=None):
-        # At t=0, convert all strings to indices
+        # At t=0, resolve molecule-name -> bulk-index maps (runs once).
         if self.inactive_RNAPs_idx is None:
-            self.fragmentBasesIdx = bulk_name_to_idx(
-                self.fragmentBases, states["bulk"]["id"]
-            )
-            self.active_tfs_idx = bulk_name_to_idx(
-                self.active_tfs, states["bulk"]["id"]
-            )
-            self.ribosome_30S_subunit_idx = bulk_name_to_idx(
-                self.ribosome_30S_subunit, states["bulk"]["id"]
-            )
-            self.ribosome_50S_subunit_idx = bulk_name_to_idx(
-                self.ribosome_50S_subunit, states["bulk"]["id"]
-            )
-            self.amino_acids_idx = bulk_name_to_idx(
-                self.amino_acids, states["bulk"]["id"]
-            )
-            self.water_idx = bulk_name_to_idx(self.water, states["bulk"]["id"])
-            self.ppi_idx = bulk_name_to_idx(self.ppi, states["bulk"]["id"])
-            self.inactive_RNAPs_idx = bulk_name_to_idx(
-                self.inactive_RNAPs, states["bulk"]["id"]
-            )
-            self.mature_rna_idx = bulk_name_to_idx(
-                self.mature_rna_ids, states["bulk"]["id"]
-            )
+            self._init_bulk_indices(states["bulk"]["id"])
 
         # Read unique molecule attributes
         (replisome_domain_indexes, replisome_coordinates, replisome_unique_indexes) = (
@@ -342,64 +386,18 @@ class ChromosomeStructure(Step):
             for domain_index in np.unique(replisome_domain_indexes)
         }
 
-        def get_removed_molecules_mask(domain_indexes, coordinates):
-            """
-            Computes the boolean mask of unique molecules that should be
-            removed based on the progression of the replication forks.
-            """
-            mask = np.zeros_like(domain_indexes, dtype=np.bool_)
-
-            # Loop through all domains
-            for domain_index in np.unique(domain_indexes):
-                # Domain has active replisomes
-                if domain_index in replisome_coordinates_from_domains:
-                    domain_replisome_coordinates = replisome_coordinates_from_domains[
-                        domain_index
-                    ]
-
-                    # Get mask for molecules on this domain that are out of range
-                    # It's rare but we have to remove molecules at the exact same
-                    # coordinates as the replisomes as well so that they do not break
-                    # the chromosome segment calculations if they are removed by a
-                    # different process (hence, >= and <= instead of > and <)
-                    domain_mask = np.logical_and.reduce(
-                        (
-                            domain_indexes == domain_index,
-                            coordinates >= domain_replisome_coordinates.min(),
-                            coordinates <= domain_replisome_coordinates.max(),
-                        )
-                    )
-
-                # Domain has no active replisomes
-                else:
-                    children_of_domain = child_domains[
-                        all_chromosome_domain_indexes == domain_index
-                    ]
-                    # Child domains are full chromosomes (domain has finished replicating)
-                    if np.all(np.isin(children_of_domain, mother_domain_indexes)):
-                        # Remove all molecules on this domain
-                        domain_mask = domain_indexes == domain_index
-                    # Domain has not started replication or replication was interrupted
-                    else:
-                        continue
-
-                mask[domain_mask] = True
-
-            return mask
-
-        # Build mask for molecules that should be removed
-        removed_RNAPs_mask = get_removed_molecules_mask(
-            RNAP_domain_indexes, RNAP_coordinates
-        )
-        removed_promoters_mask = get_removed_molecules_mask(
-            promoter_domain_indexes, promoter_coordinates
-        )
-        removed_genes_mask = get_removed_molecules_mask(
-            gene_domain_indexes, gene_coordinates
-        )
-        removed_DnaA_boxes_mask = get_removed_molecules_mask(
-            DnaA_box_domain_indexes, DnaA_box_coordinates
-        )
+        # Build masks for molecules the replication forks have passed (removed
+        # from the mother strand) — see _removed_molecules_mask.
+        _rm_args = (replisome_coordinates_from_domains, child_domains,
+                    all_chromosome_domain_indexes, mother_domain_indexes)
+        removed_RNAPs_mask = self._removed_molecules_mask(
+            RNAP_domain_indexes, RNAP_coordinates, *_rm_args)
+        removed_promoters_mask = self._removed_molecules_mask(
+            promoter_domain_indexes, promoter_coordinates, *_rm_args)
+        removed_genes_mask = self._removed_molecules_mask(
+            gene_domain_indexes, gene_coordinates, *_rm_args)
+        removed_DnaA_boxes_mask = self._removed_molecules_mask(
+            DnaA_box_domain_indexes, DnaA_box_coordinates, *_rm_args)
 
         # Build masks for head-on and co-directional collisions between RNAPs
         # and replication forks
@@ -590,26 +588,8 @@ class ChromosomeStructure(Step):
         # Write to listener
         update["listeners"]["rnap_data"]["n_removed_ribosomes"] = n_removed_ribosomes
 
-        def get_replicated_motif_attributes(old_coordinates, old_domain_indexes):
-            """
-            Computes the attributes of replicated motifs on the chromosome,
-            given the old coordinates and domain indexes of the original motifs.
-            """
-            # Coordinates are simply repeated
-            new_coordinates = np.repeat(old_coordinates, 2)
-
-            # Domain indexes are set to the child indexes of the original index
-            new_domain_indexes = child_domains[
-                np.array(
-                    [
-                        np.where(all_chromosome_domain_indexes == idx)[0][0]
-                        for idx in old_domain_indexes
-                    ]
-                ),
-                :,
-            ].flatten()
-
-            return new_coordinates, new_domain_indexes
+        # On fork passage, promoters/genes/DnaA boxes are duplicated onto the
+        # two child domains — see _replicated_motif_attributes.
 
         #######################
         # Replicate promoters #
@@ -633,9 +613,10 @@ class ChromosomeStructure(Step):
                 promoter_TU_indexes[removed_promoters_mask], 2
             )
             (promoter_coordinates_new, promoter_domain_indexes_new) = (
-                get_replicated_motif_attributes(
+                self._replicated_motif_attributes(
                     promoter_coordinates[removed_promoters_mask],
                     promoter_domain_indexes[removed_promoters_mask],
+                    child_domains, all_chromosome_domain_indexes,
                 )
             )
 
@@ -665,9 +646,10 @@ class ChromosomeStructure(Step):
                 gene_cistron_indexes[removed_genes_mask], 2
             )
             gene_coordinates_new, gene_domain_indexes_new = (
-                get_replicated_motif_attributes(
+                self._replicated_motif_attributes(
                     gene_coordinates[removed_genes_mask],
                     gene_domain_indexes[removed_genes_mask],
+                    child_domains, all_chromosome_domain_indexes,
                 )
             )
 
@@ -696,9 +678,10 @@ class ChromosomeStructure(Step):
 
             # Set up attributes for the replicated boxes
             (DnaA_box_coordinates_new, DnaA_box_domain_indexes_new) = (
-                get_replicated_motif_attributes(
+                self._replicated_motif_attributes(
                     DnaA_box_coordinates[removed_DnaA_boxes_mask],
                     DnaA_box_domain_indexes[removed_DnaA_boxes_mask],
+                    child_domains, all_chromosome_domain_indexes,
                 )
             )
 

--- a/v2ecoli/processes/metabolism.py
+++ b/v2ecoli/processes/metabolism.py
@@ -390,22 +390,60 @@ class Metabolism(Step):
         timestep = states.get('timestep', 1)
         return self._do_update(timestep, states)
 
+    def _init_bulk_indices(self, bulk_ids):
+        """One-time molecule-name -> bulk-array-index resolution (cold path,
+        guarded by ``self.metabolite_idx is None``)."""
+        self.metabolite_idx = bulk_name_to_idx(
+            self.model.metaboliteNamesFromNutrients, bulk_ids)
+        self.catalyst_idx = bulk_name_to_idx(self.model.catalyst_ids, bulk_ids)
+        self.kinetics_enzymes_idx = bulk_name_to_idx(
+            self.model.kinetic_constraint_enzymes, bulk_ids)
+        self.kinetics_substrates_idx = bulk_name_to_idx(
+            self.model.kinetic_constraint_substrates, bulk_ids)
+        self.aa_idx = bulk_name_to_idx(self.aa_names, bulk_ids)
+
+    def _fba_output_to_deltas(self, fba_out, metabolite_counts_init,
+                              counts_to_molar, coefficient, timestep):
+        """Convert the FBA solution into cell-state changes.
+
+        The FBA returns concentration changes / exchange fluxes (in CONC_UNITS,
+        i.e. mmol/L per timestep). This maps them back to molecule counts:
+
+          * internal metabolites: delta_count = (1/counts_to_molar) * dconc,
+            stochastically rounded and floored at zero;
+          * environmental exchange: delta_count = (1/counts_to_molar) * flux
+            (the cumulative count added to the environment store);
+          * exchange fluxes also reported in gDCW basis (flux/coefficient).
+
+        Returns (delta_metabolites_final, metabolite_counts_final,
+        delta_nutrients, converted_exchange_fluxes, reaction_fluxes).
+        """
+        delta_metabolites = (1 / counts_to_molar) * (
+            CONC_UNITS * fba_out["output_molecule_changes"]
+        )
+        metabolite_counts_final = np.fmax(
+            stochasticRound(
+                self.random_state,
+                metabolite_counts_init + delta_metabolites.magnitude,
+            ),
+            0,
+        ).astype(np.int64)
+        delta_metabolites_final = metabolite_counts_final - metabolite_counts_init
+
+        exchange_fluxes = CONC_UNITS * fba_out["external_exchange_fluxes"]
+        converted_exchange_fluxes = (
+            exchange_fluxes / coefficient).to(GDCW_BASIS).magnitude
+        delta_nutrients = (
+            ((1 / counts_to_molar) * exchange_fluxes).magnitude.astype(int)
+        )
+        reaction_fluxes = fba_out["reaction_fluxes"] / timestep
+        return (delta_metabolites_final, metabolite_counts_final,
+                delta_nutrients, converted_exchange_fluxes, reaction_fluxes)
+
     def _do_update(self, timestep, states):
-        # At t=0, convert all strings to indices
+        # At t=0, resolve molecule-name -> bulk-index maps (runs once).
         if self.metabolite_idx is None:
-            self.metabolite_idx = bulk_name_to_idx(
-                self.model.metaboliteNamesFromNutrients, states["bulk"]["id"]
-            )
-            self.catalyst_idx = bulk_name_to_idx(
-                self.model.catalyst_ids, states["bulk"]["id"]
-            )
-            self.kinetics_enzymes_idx = bulk_name_to_idx(
-                self.model.kinetic_constraint_enzymes, states["bulk"]["id"]
-            )
-            self.kinetics_substrates_idx = bulk_name_to_idx(
-                self.model.kinetic_constraint_substrates, states["bulk"]["id"]
-            )
-            self.aa_idx = bulk_name_to_idx(self.aa_names, states["bulk"]["id"])
+            self._init_bulk_indices(states["bulk"]["id"])
 
         timestep = states["timestep"]
 
@@ -546,24 +584,12 @@ class Metabolism(Step):
         # See v2ecoli/library/fba_fast.py.
         fba_out = extract_results(fba, self.fba_extract_indices)
 
-        # Internal molecule changes
-        delta_metabolites = (1 / counts_to_molar) * (
-            CONC_UNITS * fba_out["output_molecule_changes"]
-        )
-        metabolite_counts_final = np.fmax(
-            stochasticRound(
-                self.random_state, metabolite_counts_init + delta_metabolites.magnitude
-            ),
-            0,
-        ).astype(np.int64)
-        delta_metabolites_final = metabolite_counts_final - metabolite_counts_init
-
-        # Environmental changes
-        exchange_fluxes = CONC_UNITS * fba_out["external_exchange_fluxes"]
-        converted_exchange_fluxes = (exchange_fluxes / coefficient).to(GDCW_BASIS).magnitude
-        delta_nutrients = (
-            ((1 / counts_to_molar) * exchange_fluxes).magnitude.astype(int)
-        )
+        # Map the FBA solution back to molecule-count changes
+        # (see _fba_output_to_deltas for the unit conversions).
+        (delta_metabolites_final, metabolite_counts_final, delta_nutrients,
+         converted_exchange_fluxes, reaction_fluxes) = self._fba_output_to_deltas(
+            fba_out, metabolite_counts_init, counts_to_molar, coefficient,
+            timestep)
 
         # get_import_constraints is upstream Unum-native; convert constrained
         # values back to Unum at the boundary. GDCW_BASIS is a constant —
@@ -573,7 +599,6 @@ class Metabolism(Step):
             unconstrained, constrained_unum, self._gdcw_basis_unum
         )
 
-        reaction_fluxes = fba_out["reaction_fluxes"] / timestep
         update = {
             "bulk": [(self.metabolite_idx, delta_metabolites_final)],
             "environment": {


### PR DESCRIPTION
## Summary

Audit-driven simplifications that **bring the model's mathematics forward** and drop nested classes/closures. All three commits are **behavior-preserving**, each verified byte-identical over a 1600-tick baseline run that actually exercises replication, fork passage, and the per-tick FBA (genes/promoters/DnaA doubled, 2 chromosomes formed) — across cell_mass, bulk totals, listener sums, and every unique-molecule count. Fast suite: 302 passed.

## Changes

**1. Composites — flatten + dedupe the nested mock config loader**
Four generators (baseline, departitioned, reconciled, millard_pdmp_baseline) each defined their own nested `_CachedLoader` with an identical **4-level inner-class mock**. Replaced all four with a single flattened, module-level `CachedConfigLoader` in `_helpers.py`. Also removed two dead `ecoli.processes` imports from `chromosome_structure.py`. (−60 lines)

**2. `chromosome_structure.update()`: 465 → 383 lines**
Lifted two nested closures to named, documented methods that surface the chromosome math:
- `_removed_molecules_mask()` — which unique molecules the replication forks have passed (the removal criterion).
- `_replicated_motif_attributes()` — how a promoter/gene/DnaA box duplicates onto the two child domains on fork passage.
- `_init_bulk_indices()` — one-time index resolution, off the per-tick path.

**3. `metabolism._do_update()`: 238 → 214 lines**
- `_fba_output_to_deltas()` — converts the FBA solution (concentration changes / exchange fluxes, mmol/L) back to internal-metabolite count deltas, environmental exchange, and gDCW-basis fluxes, with the formulas in its docstring.
- `_init_bulk_indices()` — one-time index resolution.
(The FBA optimization itself was already factored into the model's `set_molecule_levels/bounds/targets` + `fba.solve`.)

## Verification
Byte-identical parity (1600-tick run) for each commit + fast suite 302 passed. No behavior change — pure structure/clarity.

Follow-ups from the same audit (not in this PR): `_ensure_bulk_indices` base-class helper (16 processes), per-tick type-conversion cleanup, ndarray-subclass profiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)