### PR TITLE
docs: condense README + fix baseline-viewer Pages link

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ cycle the dry-mass trajectories track to within a fraction of a percent
 (707.2 fg vs 705.3 fg at division), with division timing of ~42 min in both.
 
 **Explore the model interactively:**
-[**🔬 the baseline whole-cell composite**](https://vivarium-collective.github.io/v2ecoli/docs/baseline-viewer/?static=1&stateUrl=data/baseline.state.json&viewUrl=data/baseline_default.view.json)
+[**🔬 the baseline whole-cell composite**](https://vivarium-collective.github.io/v2ecoli/baseline-viewer/?static=1&stateUrl=data/baseline.state.json&viewUrl=data/baseline_default.view.json)
 opens the full process/store wiring in an interactive
 [bigraph-loom](https://github.com/vivarium-collective/bigraph-loom) viewer — pan
 the bigraph, expand stores, and click any process for its formal `describe()`
@@ -174,50 +174,10 @@ type system). Four concepts are enough to read the codebase:
 | **Store** | A named, schema-typed state container addressed by path (`bulk`, `listeners.mass.dry_mass`, `unique.ribosome`). | declared in the composite document |
 | **Composite** | Processes + stores + **wires** (edges from a process port to a store path), assembled into one runnable model. | `v2ecoli/composites/*.py` |
 
-A minimal sketch of a process:
-
-```python
-class MyProcess(Step):
-    def inputs(self):  return {"bulk": "bulk_array", "timestep": "float[s]"}
-    def outputs(self): return {"bulk": "bulk_array"}
-    def update(self, state, interval):
-        # read state["bulk"], compute, return only what you write
-        return {"bulk": delta}
-```
-
 **Types & units.** Project-specific types live in `v2ecoli/types/` (e.g.
 `Quantity`, `CSRMatrix`, `BulkNumpyUpdate`, `ListenerStore`). Dimensioned
 quantities at ports are `pint.Quantity`; the only place `Unum` survives is the
 upstream-interop bridge at `v2ecoli/library/unit_bridge.py`.
-
-**Composite generators.** Each architecture is a function decorated with
-`@composite_generator` (from `pbg_superpowers`). The decorator registers the
-generator under a name, with its parameters, default visualizations, and default
-emitter:
-
-```python
-@composite_generator(
-    name="baseline",
-    description="Partitioned whole-cell E. coli model — upstream-parity",
-    parameters={"seed": {"type": "integer", "default": 0}, ...},
-    emitters=[{"address": "local:ParquetEmitter", "paths": ["global_time", "bulk", "listeners"]}],
-)
-def baseline(core=None, *, seed=0, cache_dir="out/cache", config_overrides=None):
-    return { ... }   # a process-bigraph state document (a dict), not a Composite
-```
-
-Callers reach any registered architecture by name:
-`v2ecoli.build_composite("baseline", seed=42)` looks up the generator, calls it,
-and wraps the returned document in a `Composite`.
-
-**Auto-discovery.** When v2ecoli is installed alongside bigraph-schema and
-process-bigraph, its biological processes register themselves on
-`allocate_core()` — no manual `core.register_link()` calls:
-
-```python
-from process_bigraph import allocate_core
-core = allocate_core()   # core.link_registry now has v2ecoli.processes.*
-```
 
 **The `pbg_v2ecoli/` package** at the repo root is the *workspace* package the
 [vivarium-dashboard](https://github.com/vivarium-collective/vivarium-dashboard)


### PR DESCRIPTION
Two small README fixes.

**1. Fix the baseline-viewer link (was 404).** GitHub Pages serves this repo's
`docs/` folder *as* the site root, so the committed `…/v2ecoli/docs/baseline-viewer/`
URL 404s — the real URL drops `docs/`. Verified live:
`https://vivarium-collective.github.io/v2ecoli/baseline-viewer/?static=1&stateUrl=data/baseline.state.json&viewUrl=data/baseline_default.view.json`
returns 200 for index.html, the JS bundle, and both data files.

**2. Condense the architecture section.** Removed three code-block-heavy blocks
that duplicate info elsewhere:
- the minimal-process `class MyProcess` sketch,
- the `@composite_generator` example block,
- the auto-discovery (`allocate_core()`) block.

`build_composite(...)` and `@composite_generator` remain covered by the Quick
start example and the architecture table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)