### PR TITLE
fix(workflow): detect MarkDPeriod divide flag for generations ≥ 1

### DIFF
--- a/tests/test_workflow_lineage.py
+++ b/tests/test_workflow_lineage.py
@@ -135,3 +135,36 @@ def test_select_carry_daughter_fallback_divides_mother_once(monkeypatch):
 def test_select_carry_daughter_none_when_nothing_to_carry():
     from v2ecoli.workflow.lineage import select_carry_daughter
     assert select_carry_daughter({"0"}, {"0": {}}, mother_snapshot=None) is None
+
+
+def test_divide_flag_detected_when_agent_id_diverges_from_inner_cell():
+    """Regression: gen 0 divides but gens >= 1 run to the duration cap.
+
+    The inner baseline composite always names its single cell "0", while
+    ``self._agent_id`` accumulates phylogeny suffixes across generations
+    ("0" -> "00" -> ...).  MarkDPeriod sets a ``divide`` flag on the inner
+    "0" cell without changing the agents map, so ``_run_until_division`` must
+    look the survivor up by the inner key (falling back to the sole agent),
+    not by ``self._agent_id``.  Before the fix it did ``agents.get("00")`` for
+    generation 1, missed the flag, and the generation never divided.
+    """
+    lp = LineageProcess.__new__(LineageProcess)
+    lp.config = {"emitter": "parquet", "single_daughters": True,
+                 "generations": 3, "max_duration_per_gen": 100.0}
+    lp.initialize(lp.config)
+    lp._agent_id = "00"          # generation >= 1: diverges from the inner "0"
+
+    class _FakeComposite:
+        # Inner composite always names its single cell "0"; MarkDPeriod has set
+        # the divide flag there without adding/removing agents.
+        state = {"agents": {"0": {"divide": True,
+                                  "listeners": {"mass": {"dry_mass": 500.0}}}}}
+
+        def run(self, interval):  # no-op; flag is already set
+            pass
+
+    lp._composite = _FakeComposite()
+    lp._gen_elapsed = 0.0
+
+    divided, _daughter, _dry_mass = lp._run_until_division(1.0)
+    assert divided is True       # False before the fix (looked up agents["00"])

--- a/v2ecoli/workflow/lineage.py
+++ b/v2ecoli/workflow/lineage.py
@@ -266,7 +266,13 @@ class LineageProcess(Process):
             divided = True
         # MarkDPeriod sets a divide flag without changing the agents map; honor it
         # too (mirrors the three-signal detection in v2ecoli/bridge.py).
-        survivor = agents_now.get(self._agent_id, {})
+        # The inner composite always names its single cell "0" (see baseline()
+        # + _emit_xarray), whereas self._agent_id accumulates phylogeny suffixes
+        # ("0" -> "00" -> ...) across generations. Look the survivor up by the
+        # inner key, falling back to the sole agent — otherwise generations >= 1
+        # never see the divide flag and run to max_duration_per_gen without
+        # dividing (matches the resilient lookups above/below).
+        survivor = agents_now.get(self._agent_id) or next(iter(agents_now.values()), {})
         if isinstance(survivor, dict) and survivor.get("divide"):
             divided = True
 


### PR DESCRIPTION
## Summary

Multi-generation lineage runs only divided generation 0; generations ≥ 1 grew to the per-generation duration cap without dividing (a fresh single-gen run of the same baseline divides fine).

Root cause is a **lookup-key bug** in `LineageProcess._run_until_division`, not process-global/carried state:

```python
survivor = agents_now.get(self._agent_id, {})   # self._agent_id: "0" → "00" → "000" ...
```

The inner baseline composite **always names its single cell `"0"`** (baseline builds `agents["0"]`; `_emit_xarray` hardcodes `"0"` with that exact comment), but `self._agent_id` is the lineage's logical phylogeny id and accumulates suffixes each generation. So:

- **gen 0** (`agent_id="0"`) → matches → `MarkDPeriod`'s `divide` flag seen → divides ✓
- **gen ≥ 1** (`agent_id="00"`, …) → `agents_now.get("00")` returns `{}` → divide flag missed → runs to `max_duration_per_gen` ✗

The neighboring lookups (mother snapshot, dry-mass cell) already use the resilient `… or next(iter(agents.values()), {})` fallback; this one didn't.

## Fix

```python
survivor = agents_now.get(self._agent_id) or next(iter(agents_now.values()), {})
```

## Evidence

Chromosome trace inside the failing run (cap raised so it *could* divide) shows `MarkDPeriod` correctly setting `divide=True` at t≈2828, but the lineage never noticing:

```
gen1 t=2750: divide=False  trig=[True, False]
gen1 t=3000: divide=True   trig=[True, True]   ← MarkDPeriod fired
divided flags: [True, False]                    ← LineageProcess missed it
```

After the fix, `run_workflow` (2 gens, basal, cap 3600): `divided flags: [True, True]` (gen 0 @2528s, gen 1 @2828s).

## Tests

- Adds `test_divide_flag_detected_when_agent_id_diverges_from_inner_cell`, which drives the **real** `_run_until_division` with `agent_id="00"`. Confirmed it **fails without the fix, passes with it** (existing tests stubbed this method, which is why the bug slipped through).
- Full workflow suite: 15 passed, 2 skipped.

## Out of scope (separate finding)

The inner `Division` step's mass-threshold path is independently broken by units-on-ports (`dry_mass` is now a pint `Quantity`, so its float arithmetic raises `DimensionalityError` every tick and is swallowed). The lineage path is unaffected because it divides via the `divide` flag, not that step — but a bare `composite.run()` loop won't divide. Left for a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)