### PR TITLE
fix(division): make the Division step unit-aware (units-on-ports)

### DIFF
--- a/tests/test_division_step_units.py
+++ b/tests/test_division_step_units.py
@@ -1,0 +1,47 @@
+"""Regression: the Division step must handle a pint Quantity[fg] dry_mass.
+
+Under units-on-ports, listeners.mass.dry_mass is a pint Quantity[fg]. Before
+the fix, Division.next_update did plain float arithmetic/comparison against it
+and raised DimensionalityError every tick. process-bigraph swallows exceptions
+raised inside a step's next_update, so division_threshold stayed stuck on the
+string "mass_distribution" and the structural _add/_remove split never fired —
+a bare composite.run() loop never divided.
+"""
+import numpy as np
+
+from v2ecoli.steps.division import Division
+from v2ecoli.types.quantity import ureg as units
+
+
+def _make_division():
+    d = Division.__new__(Division)
+    d.initialize({"dry_mass_inc_dict": {"minimal": units.Quantity(150.0, "fg")}})
+    return d
+
+
+def test_threshold_init_handles_quantity_dry_mass():
+    """The threshold-initialization branch must return a numeric threshold
+    (not raise) when dry_mass is a pint Quantity[fg]."""
+    d = _make_division()
+    states = {
+        "division_threshold": "mass_distribution",
+        "media_id": "minimal",
+        "listeners": {"mass": {"dry_mass": units.Quantity(400.0, "fg")}},
+    }
+    update = d.next_update(1.0, states)
+    thr = update["division_threshold"]
+    assert isinstance(thr, float)          # raised DimensionalityError before the fix
+    assert thr == 550.0                    # 400 (fg magnitude) + 150 * multiplier(=1)
+
+
+def test_division_check_handles_quantity_dry_mass():
+    """The division-check comparison (dry_mass < threshold) must not raise when
+    dry_mass is a Quantity[fg] and threshold is a plain float."""
+    d = _make_division()
+    states = {
+        "division_threshold": 760.0,       # already numeric -> check branch
+        "listeners": {"mass": {"dry_mass": units.Quantity(400.0, "fg")}},
+        "unique": {"full_chromosome": None},
+    }
+    # dry_mass (400) < threshold (760): no division, and crucially no raise.
+    assert d.next_update(1.0, states) == {}

--- a/v2ecoli/steps/division.py
+++ b/v2ecoli/steps/division.py
@@ -14,6 +14,7 @@ from bigraph_schema.schema import Overwrite, Float
 from v2ecoli.steps.base import V2Step
 from v2ecoli.types.stores import InPlaceDict
 from v2ecoli.library.schema import attrs
+from v2ecoli.library.quantity_helpers import fg_magnitude
 from v2ecoli.types.quantity import ureg as units
 
 
@@ -133,6 +134,11 @@ class Division(V2Step):
                     mass = listeners.get('mass', {})
                     if isinstance(mass, dict):
                         dry_mass = mass.get('dry_mass', 0.0)
+                # Under units-on-ports, dry_mass is a pint Quantity[fg]; coerce
+                # to a plain fg float so the arithmetic below doesn't raise a
+                # DimensionalityError (which process-bigraph silently swallows,
+                # leaving division_threshold stuck on "mass_distribution").
+                dry_mass = fg_magnitude(dry_mass)
                 return {
                     "division_threshold": (
                         dry_mass
@@ -149,8 +155,11 @@ class Division(V2Step):
             mass = listeners.get('mass', {})
             if isinstance(mass, dict):
                 dry_mass = mass.get('dry_mass', 0.0)
-
-        threshold = states.get("division_threshold", float('inf'))
+        # Coerce both sides to plain fg floats — dry_mass may be a Quantity[fg]
+        # (units-on-ports); a Quantity vs float comparison raises (and is
+        # swallowed), which would silently prevent division.
+        dry_mass = fg_magnitude(dry_mass)
+        threshold = fg_magnitude(states.get("division_threshold", float('inf')))
 
         full_chrom = states.get('unique', {}).get('full_chromosome')
         n_chromosomes = 0


### PR DESCRIPTION
## Summary

`v2ecoli/steps/division.py::Division.next_update` reads `listeners.mass.dry_mass` and does plain float arithmetic against it. Under **units-on-ports**, `dry_mass` is now a pint `Quantity[fg]`, so:

- threshold init: `dry_mass + dry_mass_inc.to(fg).magnitude * mult` → `Quantity[fg] + float` → **`DimensionalityError`**
- division check: `dry_mass < threshold` → `Quantity < float` → **raises**

process-bigraph **swallows exceptions raised inside a step's `next_update`**, so the step failed silently every tick: `division_threshold` stayed stuck on the string `"mass_distribution"`, the threshold-init branch never completed, and the structural `_add`/`_remove` split never fired. A bare `composite.run()` loop on `baseline` **never divided** — the cell grew unbounded (~1480 fg) and started extra replication rounds, even though `MarkDPeriod` set `divide=True` at t≈2528.

(Same class as the earlier `2147fca "Fix silent division failure"`; reintroduced by units-on-ports.)

## Fix

Coerce `dry_mass` (and the stored `threshold`) to plain fg floats via `fg_magnitude` before the arithmetic/comparison.

## Verification

Standalone `baseline` run now divides:
```
[t=50]  division_threshold INITIALIZED to 701.9 (was 'mass_distribution')
DIVISION at t=2501s (dry_mass=702.0 fg, threshold=701.9 fg, chromosomes=2)
  DAUGHTERS: 00 + 01
[t=2550] STRUCTURAL DIVISION: agents ['0'] -> ['00', '01']
```

Tests: new `tests/test_division_step_units.py` drives `Division.next_update` with a `Quantity[fg]` `dry_mass` — **fails before, passes after**. Existing baseline/growth/composite/workflow suites pass (those run short, before the 2501s division).

## ⚠️ Behavioral change — please review

This **reactivates a dormant code path**. Since units-on-ports landed, the `Division` step has been silently dead everywhere; division happened only via `MarkDPeriod`'s `divide` flag (consumed by the bridge / `LineageProcess`). With this fix, the `Division` step's **mass-gated structural division** is active again and fires at **~2501s (mass threshold), ~27s before** the D-period flag at 2528s.

Implications worth a careful look:
- **Baseline trajectory** past ~2500s changes (cells now actually divide structurally). Short parity/golden tests are unaffected, but anything comparing long runs should be re-baselined.
- **Lineage path**: this *also* fixes the "only gen 0 divides" symptom (fixed independently in #127) — because structural division is detected via the agents-map change, which has no `agent_id` dependency. With both merged, the lineage divides via the structural path (mass-gated, ~2501/2888s) and carries the structural `…0` daughter, rather than the divide-flag + `divide_cell(mother_snapshot)` fallback. Verified 2-gen lineage on this branch: `divided flags: [True, True]`.
- Division timing is now **mass-gated** (Division step) rather than **D-period-gated** (MarkDPeriod). If the intended trigger is the D-period, we may instead want to gate the Division step on the `divide` flag rather than have two independent triggers — flagging for a design call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)