### PR TITLE
infra(dnaa): engine/ParCa support for the DnaA replication-initiation investigation

### DIFF
--- a/scripts/extend_multigen_from_dill.py
+++ b/scripts/extend_multigen_from_dill.py
@@ -1,0 +1,187 @@
+"""Extend a multigen lineage from a previously-dumped gen{N}.dill.
+
+Picks up where ``run_condition_multigen_parquet.py`` left off — writes new
+gens into the same parquet root (different generation= partitions).
+
+Usage:
+    python scripts/extend_multigen_from_dill.py \
+        --cache-dir out/cache_succinate_default \
+        --out-dir   out/succinate_5gen_default_parquet \
+        --experiment-id succinate_5gen_default \
+        --resume-dill out/succinate_5gen_default/gen_dills/gen5.dill \
+        --start-gen 6 \
+        --generations 5
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import pickle
+import sys
+import time
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+sys.path.insert(0, ROOT)
+os.chdir(ROOT)
+
+import dill
+
+from v2ecoli import build_composite
+from v2ecoli.composites._helpers import parquet_emitter
+from v2ecoli.composites.baseline import baseline as baseline_doc
+from v2ecoli.core import build_core
+from v2ecoli.library.division import divide_cell
+from process_bigraph import Composite
+
+
+def _run_gen(comp, max_duration, gen_idx):
+    """Lifted from run_condition_multigen_parquet.py."""
+    t_sim = 0
+    last_state = None
+    divided = False
+    while t_sim < max_duration:
+        comp.run(1)
+        t_sim += 1
+        agents = comp.state.get("agents", {})
+        if len(agents) == 0:
+            print(f"  ! gen {gen_idx}: no agents — composite empty")
+            break
+        if len(agents) > 1:
+            # division happened mid-tick → keep the (lexicographically) first daughter
+            # actually, daughters get used for the NEXT gen; we just record + break
+            divided = True
+            # The "this generation"'s last state was the parent — already captured
+            # below as last_state on the previous tick. Just break.
+            break
+        agent_id = next(iter(agents))
+        last_state = agents[agent_id]
+    return t_sim, divided, last_state
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--cache-dir", required=True)
+    ap.add_argument("--out-dir", required=True)
+    ap.add_argument("--experiment-id", required=True)
+    ap.add_argument("--resume-dill", required=True, help="path to gen{N}.dill from prior run")
+    ap.add_argument("--start-gen", type=int, required=True, help="N+1 of the dill's gen")
+    ap.add_argument("--generations", type=int, default=5, help="how many more gens to run")
+    ap.add_argument("--max-min", type=float, default=200.0)
+    ap.add_argument("--seed", type=int, default=0)
+    ap.add_argument("--dill-dir", default=None,
+                    help="defaults to out/<experiment-id>/gen_dills (same as base run)")
+    args = ap.parse_args()
+
+    max_duration = int(args.max_min * 60)
+    dill_dir = args.dill_dir or f"out/{args.experiment_id}/gen_dills"
+    os.makedirs(dill_dir, exist_ok=True)
+
+    print("=" * 60)
+    print(f"Multi-gen extension — gens {args.start_gen}..{args.start_gen + args.generations - 1}")
+    print(f"  cache:        {args.cache_dir}")
+    print(f"  out_dir:      {args.out_dir}")
+    print(f"  experiment:   {args.experiment_id}")
+    print(f"  resume_dill:  {args.resume_dill}")
+    print("=" * 60)
+
+    with open(os.path.join(args.cache_dir, "sim_data_cache.dill"), "rb") as f:
+        cache = dill.load(f)
+    try:
+        from v2ecoli.library.unit_bridge import rebind_cache_quantities
+        rebind_cache_quantities(cache)
+    except ImportError:
+        pass
+    configs = cache.get("configs", {})
+    unique_names = cache.get("unique_names", [])
+    dry_mass_inc = cache.get("dry_mass_inc_dict", {})
+
+    core = build_core()
+
+    # Load the resume-from state
+    with open(args.resume_dill, "rb") as f:
+        prev_cell_data = dill.load(f)
+
+    t_pipeline = time.time()
+    summary = []
+
+    for offset in range(args.generations):
+        gen_idx = args.start_gen + offset
+        agent_id = "0" * gen_idx
+        print(f"\n[{time.strftime('%H:%M:%S')}] gen {gen_idx} (agent_id={agent_id})")
+        t0 = time.time()
+
+        with parquet_emitter(
+            out_dir=args.out_dir,
+            experiment_id=args.experiment_id,
+            lineage_seed=args.seed,
+            agent_id=agent_id,
+            generation=gen_idx,
+        ):
+            t_build = time.time()
+            d1_state, _d2_state = divide_cell(prev_cell_data)
+            bundle = {
+                "initial_state": d1_state,
+                "configs": configs,
+                "unique_names": unique_names,
+                "dry_mass_inc_dict": dry_mass_inc,
+            }
+            doc = baseline_doc(core=core, seed=args.seed + gen_idx,
+                               cache_dir=args.cache_dir, bundle=bundle)
+            comp = Composite(doc, core=core)
+            print(f"    composite built in {time.time()-t_build:.1f}s")
+
+            duration, divided, last_state = _run_gen(comp, max_duration, gen_idx)
+
+        dry_f = float((last_state or {}).get("listeners", {}).get("mass", {}).get("dry_mass", 0))
+        wall = time.time() - t0
+        result = {
+            "gen": gen_idx,
+            "agent_id": agent_id,
+            "duration_min": duration / 60.0,
+            "divided": divided,
+            "final_dry_mass_fg": dry_f,
+            "wall_seconds": wall,
+        }
+        summary.append(result)
+        print(f"    gen {gen_idx} summary: tau={duration/60:.1f} min  "
+              f"final_dry={dry_f:.1f} fg  divided={divided}  wall={wall:.0f}s")
+
+        prev_cell_data = last_state
+        if last_state is not None:
+            dill_path = os.path.join(dill_dir, f"gen{gen_idx}.dill")
+            # Filter to data-only keys before dilling. The resume-built
+            # composite includes live process instances at the top level
+            # of agents/<id>, and their internal WeakValueDictionary stores
+            # break dill via KeyedRef. The baseline run's gen5.dill uses
+            # this 11-key shape plus a few schema-level extras.
+            # NOTE: `exchange_data` looks like a data store but is actually
+            # a process schema entry with an `instance` field holding an
+            # ExchangeData process. Its internals carry a WeakValueDictionary
+            # → KeyedRef that breaks dill. Excluded here.
+            DATA_KEYS = {
+                "bulk", "unique", "listeners", "global_time", "timestep",
+                "boundary", "environment", "allocator_rng", "process_state",
+                "divide", "division_threshold", "exchange",
+                "next_update_time", "media_id", "ppgpp_state",
+                "attenuation_config", "request", "allocate",
+            }
+            sanitized = {k: v for k, v in last_state.items() if k in DATA_KEYS}
+            try:
+                with open(dill_path, "wb") as f:
+                    dill.dump(sanitized, f)
+            except (TypeError, pickle.PicklingError) as e:
+                print(f"    ! dill dump of gen {gen_idx} STILL failed "
+                      f"({type(e).__name__}: {str(e)[:80]}); skipping checkpoint")
+                if os.path.exists(dill_path):
+                    os.remove(dill_path)
+
+    total = time.time() - t_pipeline
+    print(f"\n[done] {args.generations} gens in {total:.0f}s")
+    for r in summary:
+        print(f"  gen {r['gen']}: τ={r['duration_min']:.1f} min  "
+              f"final_dry={r['final_dry_mass_fg']:.1f} fg")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/render_chromosome_gif.py
+++ b/scripts/render_chromosome_gif.py
@@ -1,0 +1,131 @@
+"""Animated chromosome / replication-machinery GIF from a parquet run.
+
+Reads the per-timestep unique-molecule coordinate columns that the emitter
+persists when a run is launched with V2ECOLI_EMIT_UNIQUE=1 (active_replisome /
+active_RNAP / chromosome_domain / full_chromosome). Each frame is rendered with
+the existing v2ecoli chromosome renderer (_plot_chromosome_map → _draw_chromosome
++ _draw_replication_bubbles): chromosome rim, oriC/Ter, replisomes (gold), the
+replication bubble (green daughter-strand arc), and RNAPs on both the rim and the
+bubble (blue dots). Frames are assembled into a looping GIF with PIL.
+
+Usage:
+  V2ECOLI_EMIT_UNIQUE is NOT needed here (read-only). Just point at the run dir:
+  .venv/bin/python scripts/render_chromosome_gif.py \
+      --run out/dnaa_gifdata --seed 1 --every 30 \
+      --out studies/dnaa-3-box-binding/charts/chromosome_replication.gif
+"""
+from __future__ import annotations
+import argparse, glob, io, os, sys
+sys.path.insert(0, ".")
+import numpy as np
+import polars as pl
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from PIL import Image
+from v2ecoli.visualizations.workflow import _plot_chromosome_map
+
+
+def _domain_children_from_dill(dill_path):
+    """Recover the chromosome-domain tree from a gen dill (the nested
+    child_domains column is excluded from parquet — see emitter note)."""
+    if not dill_path or not os.path.exists(dill_path):
+        return {}
+    import dill
+    st = dill.load(open(dill_path, "rb"))
+    dom = (st.get("unique") or {}).get("chromosome_domain")
+    out = {}
+    if dom is not None and hasattr(dom, "dtype") and "_entryState" in dom.dtype.names:
+        act = dom[dom["_entryState"].view(np.bool_)]
+        if {"domain_index", "child_domains"}.issubset(set(act.dtype.names)):
+            for e in act:
+                out[int(e["domain_index"])] = [int(k) for k in e["child_domains"] if int(k) >= 0]
+    return out
+
+
+def _snapshot_from_row(row: dict, domain_children: dict) -> dict:
+    """Build the snapshot dict _plot_chromosome_map expects from a parquet row."""
+    def _lst(key):
+        v = row.get(key)
+        return list(v) if v is not None else []
+    fc = _lst("full_chromosome__unique_index")
+    rep_c = _lst("active_replisome__coordinates")
+    rep_d = _lst("active_replisome__domain_index")
+    rnap_c = _lst("active_RNAP__coordinates")
+    rnap_d = _lst("active_RNAP__domain_index")
+    n_dom = len({int(d) for d in rep_d} | {int(d) for d in rnap_d}) or 1
+    return {
+        "time": float(row.get("global_time", 0.0)),
+        "n_chromosomes": max(1, len(fc)),
+        "n_domains": n_dom,
+        "fork_coords": [int(c) for c in rep_c],
+        "fork_domains": [int(d) for d in rep_d],
+        "rnap_coords": [int(c) for c in rnap_c],
+        "rnap_domains": [int(d) for d in rnap_d],
+        "domain_children": domain_children,
+        "n_rnap": len(rnap_c),
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--run", required=True, help="parquet run dir (with **/history/**)")
+    ap.add_argument("--seed", type=int, default=1)
+    ap.add_argument("--every", type=int, default=30, help="subsample: keep ~1 frame per N seconds")
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--duration", type=int, default=120, help="ms per frame")
+    ap.add_argument("--dill", default=None, help="gen dill to recover the domain tree (RNAP-on-bubble placement)")
+    a = ap.parse_args()
+
+    files = glob.glob(f"{a.run}/**/history/**/lineage_seed={a.seed}/**/*.pq", recursive=True)
+    if not files:
+        raise SystemExit(f"no history parquet under {a.run} for seed {a.seed}")
+    cols = ["global_time",
+            "full_chromosome__unique_index",
+            "active_replisome__coordinates", "active_replisome__domain_index",
+            "active_RNAP__coordinates", "active_RNAP__domain_index"]
+    have = set(pl.scan_parquet(files[0]).collect_schema().names())
+    miss = [c for c in cols if c not in have]
+    if miss:
+        raise SystemExit(f"run missing unique columns {miss} — re-run with V2ECOLI_EMIT_UNIQUE=1")
+    domain_children = _domain_children_from_dill(a.dill)
+    print(f"domain tree (from dill): {domain_children or 'none — RNAPs on rim'}")
+    df = (pl.scan_parquet(files, hive_partitioning=True)
+          .filter(pl.col("agent_id").cast(pl.Utf8).str.contains("^0+$"))
+          .select(cols).sort("global_time").collect())
+    # subsample by time
+    t = df["global_time"].to_numpy()
+    keep, last = [], -1e9
+    for i, tt in enumerate(t):
+        if tt - last >= a.every:
+            keep.append(i); last = tt
+    print(f"{len(df)} rows → {len(keep)} frames (every {a.every}s)")
+
+    frames = []
+    for i in keep:
+        row = df.row(i, named=True)
+        snap = _snapshot_from_row(row, domain_children)
+        nch = snap["n_chromosomes"]
+        phase = ("pre-initiation" if not snap["fork_coords"] and nch == 1 else
+                 "two chromosomes — replication complete" if nch >= 2 else
+                 "replication bubble extending")
+        # Fixed canvas (no tight bbox) so every frame is identical pixel size →
+        # a smooth GIF across the 1-chromosome → 2-chromosome transition.
+        fig, ax = plt.subplots(figsize=(6.0, 6.6))
+        _plot_chromosome_map(snap, ax,
+                             title=f"t = {snap['time']/60:.0f} min   ·   {phase}\n"
+                                   f"forks {len(snap['fork_coords'])}   ·   RNAPs {snap['n_rnap']}"
+                                   f"   ·   chromosomes {nch}")
+        ax.set_aspect("equal"); ax.axis("off")
+        fig.subplots_adjust(left=0.02, right=0.98, top=0.90, bottom=0.02)
+        buf = io.BytesIO(); fig.savefig(buf, format="png", dpi=92, facecolor="white")
+        plt.close(fig); buf.seek(0); frames.append(Image.open(buf).convert("RGB"))
+
+    os.makedirs(os.path.dirname(a.out), exist_ok=True)
+    frames[0].save(a.out, save_all=True, append_images=frames[1:],
+                   duration=a.duration, loop=0)
+    print(f"wrote {a.out}  ({len(frames)} frames)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/replication_refactor_report.py
+++ b/scripts/replication_refactor_report.py
@@ -1,0 +1,618 @@
+"""Generator for the replication-refactor report.
+
+Builds reports/replication_partitioned_refactor.html covering both:
+
+  - Phase 1: chromosome replication refactored from Step to
+    PartitionedProcess and joined to allocator_2.
+  - Phase 2: plasmid replication refactored similarly, joining
+    chromosome and rna-degradation in allocator_2 so the two
+    replication processes compete for replisome subunits via the
+    existing allocator-fairness math.
+
+Reads three sim outputs to plot chromosome behavior across the three
+regimes the refactor exercises:
+
+  - out/plasmid/multigen_timeseries_noplasmid_7gen.json
+      No plasmids loaded.  Single requester in allocator_2 -> allocator
+      is a pass-through; chromosome runs as before.
+  - out/plasmid/multigen_timeseries.json
+      Plasmids + BP1993 RNA control on.  Plasmid demand is small (1-9
+      plasmids), allocator gives both processes their full requests.
+  - out/plasmid/multiseed_timeseries.json
+      Plasmids + BP1993 off (uncontrolled).  Plasmid demand dominates,
+      allocator proportionally starves chromosome -> arrest emerges.
+
+Usage:
+    uv run python scripts/replication_refactor_report.py
+"""
+from __future__ import annotations
+
+import io
+import json
+import os
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+os.chdir(ROOT)
+
+NOPLASMID_JSON = "out/plasmid/multigen_timeseries_noplasmid_7gen.json"
+CONTROLLED_JSON = "out/plasmid/multigen_timeseries.json"
+UNCONTROLLED_JSON = "out/plasmid/multiseed_timeseries.json"
+OUT_HTML = "reports/replication_partitioned_refactor.html"
+
+
+def _svg(fig) -> str:
+    buf = io.StringIO()
+    fig.savefig(buf, format="svg", bbox_inches="tight")
+    return buf.getvalue()
+
+
+def _build_regime_figure():
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    fig, axes = plt.subplots(3, 2, figsize=(13, 9.5))
+
+    # ---- Row A: no plasmids (7-gen lineage) ----
+    with open(NOPLASMID_JSON) as f:
+        d = json.load(f)
+    gens = [g["snapshots"] for g in d["generations"]]
+    t_off = 0.0
+    boundaries = [0.0]
+    colors = ["#1e3a8a", "#0e7490", "#15803d", "#854d0e",
+              "#b91c1c", "#7c2d12", "#6b21a8"]
+    for gi, snaps in enumerate(gens):
+        ts = [(s["time"] - snaps[0]["time"] + t_off) / 60 for s in snaps]
+        n_rep = [s["n_active_replisomes"] for s in snaps]
+        cm = [s["cell_mass"] for s in snaps]
+        col = colors[gi % len(colors)]
+        axes[0, 0].step(ts, n_rep, where="post", lw=1.2, color=col,
+                        label=f"gen {gi+1}")
+        axes[0, 1].plot(ts, cm, lw=1.0, color=col)
+        t_off = ts[-1] * 60
+        boundaries.append(t_off / 60)
+    for b in boundaries[1:-1]:
+        axes[0, 0].axvline(b, color="gray", ls=":", alpha=0.3)
+        axes[0, 1].axvline(b, color="gray", ls=":", alpha=0.3)
+    axes[0, 0].set_ylabel("chromosome\nactive replisomes")
+    axes[0, 0].set_title("A. No plasmids — 7-generation lineage")
+    axes[0, 0].legend(loc="upper right", fontsize=7, ncol=7)
+    axes[0, 0].set_ylim(-0.3, 5)
+    axes[0, 0].grid(True, alpha=0.3)
+    axes[0, 1].axhline(975, color="#dc2626", ls="--", alpha=0.5,
+                       label="1-oriC threshold")
+    axes[0, 1].axhline(1950, color="#991b1b", ls="--", alpha=0.5,
+                       label="2-oriC threshold")
+    axes[0, 1].set_ylabel("cell mass (fg)")
+    axes[0, 1].set_title("A'. Cell mass across generations")
+    axes[0, 1].legend(loc="upper right", fontsize=8)
+    axes[0, 1].grid(True, alpha=0.3)
+
+    # ---- Row B: controlled plasmids (BP1993 on) ----
+    with open(CONTROLLED_JSON) as f:
+        d = json.load(f)
+    snaps = d["generations"][0]["snapshots"]
+    t = [s["time"] / 60 for s in snaps]
+    n_rep = [s["n_active_replisomes"] for s in snaps]
+    n_plasmids = [s["n_full_plasmids"] for s in snaps]
+    cm = [s["cell_mass"] for s in snaps]
+
+    axes[1, 0].step(t, n_rep, where="post", color="#dc2626", lw=1.5,
+                    label="chromosome replisomes")
+    ax_pl = axes[1, 0].twinx()
+    ax_pl.plot(t, n_plasmids, color="#2563eb", lw=1.4)
+    ax_pl.set_ylabel("full plasmids", color="#2563eb")
+    ax_pl.tick_params(axis="y", labelcolor="#2563eb")
+    axes[1, 0].set_ylabel("chromosome\nactive replisomes",
+                          color="#dc2626")
+    axes[1, 0].tick_params(axis="y", labelcolor="#dc2626")
+    axes[1, 0].set_title("B. Plasmids + BP1993 (controlled)")
+    axes[1, 0].set_ylim(-0.3, 5)
+    axes[1, 0].grid(True, alpha=0.3)
+    trans = [(i, n_rep[i-1], n_rep[i]) for i in range(1, len(n_rep))
+             if n_rep[i] != n_rep[i-1]]
+    for i, prev, cur in trans[:4]:
+        axes[1, 0].axvline(t[i], color="gray", ls=":", alpha=0.4)
+
+    axes[1, 1].plot(t, cm, color="#15803d", lw=1.5)
+    axes[1, 1].axhline(1950, color="#991b1b", ls="--", alpha=0.5,
+                       label="2-oriC threshold (1950 fg)")
+    axes[1, 1].set_ylabel("cell mass (fg)")
+    axes[1, 1].set_title(f"B'. Cell mass; plasmids 1→{n_plasmids[-1]}")
+    axes[1, 1].legend(loc="lower right", fontsize=8)
+    axes[1, 1].grid(True, alpha=0.3)
+
+    # ---- Row C: uncontrolled plasmids (BP1993 off) ----
+    with open(UNCONTROLLED_JSON) as f:
+        d = json.load(f)
+    snaps = d["seeds"][0]["snapshots"]
+    t = [s["time"] / 60 for s in snaps]
+    n_rep = [s["n_active_replisomes"] for s in snaps]
+    n_plasmids = [s["n_full_plasmids"] for s in snaps]
+    cm = [s["cell_mass"] for s in snaps]
+    dnaG = [s.get("bulk_dnaG", 0) for s in snaps]
+
+    axes[2, 0].step(t, n_rep, where="post", color="#dc2626", lw=1.5)
+    ax_pl = axes[2, 0].twinx()
+    ax_pl.plot(t, n_plasmids, color="#2563eb", lw=1.4)
+    ax_pl.set_ylabel("full plasmids", color="#2563eb")
+    ax_pl.tick_params(axis="y", labelcolor="#2563eb")
+    axes[2, 0].set_xlabel("time (min)")
+    axes[2, 0].set_ylabel("chromosome\nactive replisomes",
+                          color="#dc2626")
+    axes[2, 0].tick_params(axis="y", labelcolor="#dc2626")
+    axes[2, 0].set_title("C. Plasmids + BP1993 OFF (uncontrolled)")
+    axes[2, 0].set_ylim(-0.3, 5)
+    axes[2, 0].grid(True, alpha=0.3)
+    term_idx = next((i for i in range(1, len(n_rep))
+                     if n_rep[i] == 0 and n_rep[i-1] > 0), None)
+    if term_idx is not None:
+        axes[2, 0].axvline(t[term_idx], color="gray", ls=":", alpha=0.5)
+        axes[2, 0].text(t[term_idx] + 0.5, 4.4,
+                        "termination —\nno re-init fires",
+                        fontsize=8, ha="left", va="top",
+                        color="#991b1b", fontweight="bold")
+
+    axes[2, 1].plot(t, cm, color="#15803d", lw=1.5, label="cell_mass")
+    axes[2, 1].axhline(1950, color="#991b1b", ls="--", alpha=0.5,
+                       label="2-oriC threshold")
+    ax_dnag = axes[2, 1].twinx()
+    ax_dnag.plot(t, dnaG, color="#7c3aed", lw=0.7, alpha=0.8)
+    ax_dnag.set_ylabel("bulk DnaG", color="#7c3aed")
+    ax_dnag.tick_params(axis="y", labelcolor="#7c3aed")
+    axes[2, 1].set_xlabel("time (min)")
+    axes[2, 1].set_ylabel("cell mass (fg)", color="#15803d")
+    axes[2, 1].tick_params(axis="y", labelcolor="#15803d")
+    axes[2, 1].set_title(
+        f"C'. Cell mass + DnaG; plasmids 1→{n_plasmids[-1]}")
+    axes[2, 1].legend(loc="lower right", fontsize=8)
+    axes[2, 1].grid(True, alpha=0.3)
+
+    fig.suptitle(
+        "Chromosome behavior across the three regimes the refactor exercises",
+        fontsize=12, y=0.998)
+    fig.tight_layout()
+    return _svg(fig)
+
+
+def main():
+    plot_svg = _build_regime_figure()
+
+    css = """
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+           max-width: 1100px; margin: 2em auto; padding: 0 2em;
+           color: #0f172a; line-height: 1.55; }
+    h1 { border-bottom: 3px solid #0f172a; padding-bottom: 0.3em; }
+    h2 { border-bottom: 1px solid #cbd5e1; padding-bottom: 0.2em;
+         margin-top: 2em; color: #0f172a; }
+    h3 { color: #334155; margin-top: 1.5em; }
+    code { background: #f1f5f9; padding: 2px 5px; border-radius: 3px;
+           font-size: 0.9em; }
+    pre { background: #f1f5f9; padding: 1em; border-radius: 5px;
+          overflow-x: auto; font-size: 0.85em; }
+    table { border-collapse: collapse; margin: 1em 0; }
+    th, td { border: 1px solid #cbd5e1; padding: 6px 10px; text-align: left;
+             font-size: 0.92em; vertical-align: top; }
+    th { background: #f1f5f9; }
+    .callout { background: #fef3c7; border-left: 4px solid #f59e0b;
+               padding: 1em 1.2em; margin: 1em 0; border-radius: 3px; }
+    .callout-good { background: #dcfce7; border-left: 4px solid #16a34a; }
+    .callout-info { background: #dbeafe; border-left: 4px solid #2563eb; }
+    .callout-warn { background: #fee2e2; border-left: 4px solid #dc2626; }
+    .pass { color: #16a34a; font-weight: 600; }
+    .fail { color: #dc2626; font-weight: 600; }
+    .figcap { font-size: 0.85em; color: #475569; margin-top: 0.4em; }
+    """
+
+    html = f"""<!DOCTYPE html>
+<html><head><meta charset="utf-8">
+<title>Replication refactor: Step → PartitionedProcess for chromosome and plasmid</title>
+<style>{css}</style></head><body>
+
+<h1>Replication refactor: <code>Step</code> → <code>PartitionedProcess</code>
+for chromosome and plasmid</h1>
+<p><em>Two-phase refactor that wires both replication processes into v2ecoli's
+existing allocator machinery so chromosome and plasmid replication compete
+for replisome subunits via the proportional-fairness math used by the rest
+of the partitioned processes. Chromosome-only execution is preserved
+bit-equivalently; new plasmid-vs-chromosome competition emerges naturally
+under uncontrolled plasmid load — reproducing the vEcoli Figure 2
+chromosome-arrest phenotype directly in v2ecoli.</em></p>
+
+<h2>1. Why this refactor</h2>
+<p>
+Before the refactor, both <code>ChromosomeReplication</code> and
+<code>PlasmidReplication</code> were plain <code>Step</code> instances
+running back-to-back in execution layer 4b.  Sequential execution
+gave chromosome an implicit priority over plasmid (chromosome was
+listed first, took whatever subunits it wanted from raw bulk; plasmid
+ran second on residual bulk).  This is a code-convention determining
+biology — not a model of competition.  Under uncontrolled plasmid
+load the sequential ordering still let chromosome win, even though
+the biological reality is that thousands of plasmid replisomes should
+out-compete chromosome's two for the shared subunit pool.
+</p>
+<p>
+v2ecoli already implements proper proportional fairness — the
+<code>Requester</code> &rarr; <code>Allocator</code> &rarr;
+<code>Evolver</code> pattern in <code>v2ecoli/steps/partition.py</code>,
+used today for RNA degradation and the elongation processes.
+Eligibility for that mechanism requires inheriting from
+<code>PartitionedProcess</code> (which exposes
+<code>calculate_request</code> + <code>evolve_state</code>) instead of
+plain <code>Step</code>.  This refactor moves chromosome and plasmid
+replication onto that path, places them both in
+<code>allocator_2</code> alongside <code>rna-degradation</code>
+(matching vEcoli's flow definition where chromosome and rna-deg share
+the same <code>ecoli-tf-binding</code> dependency depth), and lets the
+proportional-fairness math handle competition.
+</p>
+
+<h2>2. What changed</h2>
+
+<h3>2.1 Phase 1 — chromosome refactor</h3>
+<ul>
+<li>Base class <code>EcoliStep</code> &rarr; <code>PartitionedProcess</code>;
+  <code>update()</code> entry point removed (the framework's two-phase
+  entrypoint takes over).</li>
+<li><code>_prepare(states)</code> &rarr;
+  <code>calculate_request(timestep, states)</code>.  v2ecoli's existing
+  <code>_prepare</code> already constructed the bulk request dict (it
+  was being discarded with <code>_ = requests</code>); the refactor
+  just returns it.  No new biology code added.</li>
+<li><code>_evolve(states)</code> &rarr;
+  <code>evolve_state(timestep, states)</code>.  Body unchanged.</li>
+<li><code>generate.py</code>: chromosome moved from
+  <code>STANDALONE_STEPS</code> to <code>PARTITIONED_PROCESSES</code>;
+  added to <code>ALLOCATOR_LAYERS['allocator_2']</code> alongside
+  <code>ecoli-rna-degradation</code> (per vEcoli's
+  <code>configs/default.json</code> — both processes have the same
+  <code>ecoli-tf-binding</code> dependency depth).  Layer 4b lost its
+  chromosome entry; the rna-degradation requester / evolver layers
+  gained chromosome counterparts.</li>
+<li><code>generate_reconciled.py</code>: matching updates.</li>
+</ul>
+
+<h3>2.2 Phase 2 — plasmid refactor</h3>
+<p>
+Same structural pattern as chromosome, with one important difference:
+v2ecoli's previous <code>PlasmidReplication._prepare</code> did not
+construct a bulk request — it ran the BP1993 ODE and stashed
+<code>n_rna_initiations</code> on <code>self</code>, with all bulk
+gating happening inside <code>_evolve</code>.  To enable allocator-mediated
+competition, <code>calculate_request</code> now also constructs a
+bulk request, ported from the analogous vEcoli plasmid-replication
+pattern:
+</p>
+<pre># Subunit request: one set of replisome subunits per idle plasmid
+# domain we might initiate on this tick (gated by RNA II under
+# use_rna_control).
+if len(idle_plasmid_domains) &gt; 0:
+    if self.use_rna_control:
+        n_to_request = min(len(idle_plasmid_domains), n_rna_initiations)
+    else:
+        n_to_request = len(idle_plasmid_domains)
+    if n_to_request &gt; 0:
+        requests["bulk"].append((self.replisome_trimers_idx, 3 * n_to_request))
+        requests["bulk"].append((self.replisome_monomers_idx, 1 * n_to_request))
+
+# dNTP request for elongation of existing forks (same idiom as
+# chromosome_replication.calculate_request).
+if n_active_replisomes &gt; 0:
+    ...
+    requests["bulk"].append((self.dntps_idx, ...))</pre>
+<p>
+The crucial gating is on <code>n_rna_initiations</code>: under
+BP1993 control, plasmid only requests subunits for the integer number
+of initiations the ODE actually allows this tick.  This means a
+low-contention controlled regime asks for a small number of replisomes
+(chromosome gets its full request); under uncontrolled (BP1993 off),
+plasmid asks for one replisome per idle domain (thousands), which is
+what generates the competition.  All BP1993 ODE biology is preserved
+exactly — the new code is just the bulk-request construction.
+</p>
+<p>
+Wiring updates:
+</p>
+<ul>
+<li><code>generate.py</code>:
+  <code>'ecoli-plasmid-replication'</code> moved from
+  <code>STANDALONE_STEPS</code> to <code>PARTITIONED_PROCESSES</code>;
+  added to <code>ALLOCATOR_LAYERS['allocator_2']</code>; layer 4b
+  loses the plasmid entry; allocator_2 sub-layers gain
+  plasmid_requester / plasmid_evolver alongside chromosome and
+  rna-degradation.</li>
+<li><code>generate_reconciled.py</code>: matching updates (the
+  <code>RECONCILED_LAYERS</code> dict is auto-derived from
+  <code>ALLOCATOR_LAYERS</code>, so plasmid is picked up
+  automatically in the reconciled architecture as well).</li>
+<li><code>scripts/run_plasmid_multiseed.py</code>: removed the
+  previously-temporary <code>custom_priorities</code> override that
+  forced chromosome to win under sequential-priority.  The override
+  is no longer needed (and would defeat the allocator-fairness
+  behavior the refactor enables).  Also widened
+  <code>_allocated</code>'s exception handler to include
+  <code>KeyError</code> for robustness.</li>
+</ul>
+
+<h2>3. Behavior across regimes</h2>
+<p>
+Three single-cell smoke runs cover the three regimes the refactor
+exercises.  All three were run after Phase 1 + Phase 2, against the
+post-merge ParCa fixture, on the same machine and with the same
+seed-0 random state.
+</p>
+
+<div>
+{plot_svg}
+</div>
+
+<p class="figcap">
+<strong>Row A (no plasmids):</strong> 7-generation chromosome-only
+lineage from
+<code>out/plasmid/multigen_timeseries_noplasmid_7gen.json</code>.
+Chromosome is the only requester in <code>allocator_2</code>, so the
+allocator is a pass-through and gen-to-gen behavior is
+indistinguishable from the previous Step implementation (gens 1-4
+follow the normal 2&rarr;0&rarr;4 pattern; the gen-5 re-init miss
+and gen-6/7 1-oriC downshift are pre-existing dynamics unrelated to
+this refactor).
+<br/><br/>
+<strong>Row B (controlled plasmids, BP1993 on):</strong> single
+generation with <code>use_rna_control=True</code> from
+<code>out/plasmid/multigen_timeseries.json</code>.  Plasmid load
+stays low (1&rarr;9), BP1993 caps requests so total subunit demand
+is well below supply; the allocator gives both processes their full
+requests.  Chromosome behavior matches pre-refactor exactly
+(2&rarr;0 termination at 22 min, 0&rarr;4 re-init at 30 min,
+division at 45 min).
+<br/><br/>
+<strong>Row C (uncontrolled plasmids, BP1993 off):</strong> single
+seed with <code>use_rna_control=False</code> and
+<code>custom_priorities</code> override removed, from
+<code>out/plasmid/multiseed_timeseries.json</code>.  Plasmids run
+away to 4407 by division.  The inherited chromosome round terminates
+at 22 min as usual — but <strong>no new chromosome round ever
+fires</strong>.  Cell mass crosses the 1950 fg 2-oriC threshold at
+~30 min, but with plasmid demand (~3 trimers and 1 monomer per idle
+plasmid &times; thousands of idle plasmids) dwarfing chromosome's
+12-trimer / 4-monomer request, the allocator's proportional partition
+gives chromosome essentially zero share, and chromosome's
+mechanistic gate fails on its allocated counts.  Cell still divides
+(mass-trigger on the dry-mass listener fires regardless of chromosome
+state) but with <code>n_active_replisomes = 0</code> at division — a
+broken lineage state.  This is the vEcoli Figure-2 phenotype, now
+reproducing in v2ecoli through genuine allocator-fairness math
+rather than a sequential-priority shortcut.
+</p>
+
+<h2>4. Comparison vs. the pre-refactor sequential-priority architecture</h2>
+<table>
+<tr><th>Regime</th><th>Pre-refactor (Step in layer 4b)</th>
+  <th>Post-refactor (PartitionedProcess in allocator_2)</th></tr>
+<tr><td>No plasmids (chromosome-only)</td>
+  <td>chromosome runs as Step in layer 4b; subunits read from raw
+    bulk</td>
+  <td>chromosome runs through Requester / Allocator / Evolver;
+    allocator is a pass-through with single requester;
+    <strong>identical behavior</strong></td></tr>
+<tr><td>Plasmids + BP1993 controlled</td>
+  <td>chromosome runs first in layer 4b, plasmid runs after on
+    residual bulk; under low contention this is identical to a fair
+    partition</td>
+  <td>both run through allocator; under low contention each gets full
+    request; <strong>identical behavior</strong> (verified: 1&rarr;9
+    plasmids, division at 2728 s, BP1993 species match)</td></tr>
+<tr><td>Plasmids + BP1993 OFF (uncontrolled)</td>
+  <td>chromosome wins by list order despite massive plasmid demand;
+    chromosome re-init fires at the first cell-mass-threshold
+    crossing (artificial)</td>
+  <td><strong>chromosome proportionally starved by allocator math:
+    chromosome's 4-DnaG request vs plasmid's ~4000-DnaG request
+    &rarr; chromosome's allocation share &asymp; 0 &rarr; gate fails
+    &rarr; no chromosome re-init &rarr; vEcoli Figure-2 phenotype
+    emerges</strong></td></tr>
+</table>
+
+<h2>5. Why proportional fairness is the right biology, not just the right code</h2>
+<p>
+Cells don't have a priority list telling DnaG which replisome to
+bind.  DnaG diffuses and binds whichever replisome it encounters,
+with rate proportional to binding-site availability.  When there are
+4 chromosome assembly sites and ~4000 plasmid assembly sites in the
+same cell, DnaG has roughly a 1000&times; higher chance of hitting a
+plasmid site, and chromosome's effective rate of obtaining DnaG
+drops by roughly the same factor.  The allocator's proportional
+partition is exactly this calculation in coarse-grained form — same
+answer the mass-action ODE would give at equilibrium.
+</p>
+<p>
+Pre-refactor, chromosome's "always-win" outcome under uncontrolled
+plasmid load was an artifact of the v2ecoli port simplification, not
+biology.  The custom-priority hack in
+<code>scripts/run_plasmid_multiseed.py</code> was an explicit
+acknowledgement that the architecture wasn't producing the desired
+phenotype on its own — it set <code>chromosome priority = 5</code>
+to force chromosome to win.  Removing that hack and letting the
+allocator math drive the outcome is what brings v2ecoli's competition
+semantics in line with vEcoli's, which validated the original
+Figure 2 phenotype against Clewell 1972 and Nordström 2006.
+</p>
+
+<h2>6. Test results</h2>
+<table>
+<tr><th>Test</th><th>Status</th><th>Notes</th></tr>
+<tr><td><code>test_architectures_grow.py</code> (5 tests)</td>
+  <td><span class="pass">5/5 PASS</span></td>
+  <td>All three architectures (baseline, departitioned, reconciled)
+    instantiate and grow over 60 s.  Verified after both Phase 1 and
+    Phase 2.</td></tr>
+<tr><td><code>test_sustained_growth.py</code></td>
+  <td><span class="pass">PASS</span></td>
+  <td>500 s sustained-growth regression.</td></tr>
+<tr><td><code>test_growth_parity.py</code></td>
+  <td><span class="pass">PASS</span></td>
+  <td>Mass-trajectory parity vs v1 reference.</td></tr>
+<tr><td><code>test_cell_cycle_regressions.py</code> (other cases)</td>
+  <td><span class="pass">PASS</span></td>
+  <td>Per-tick invariants for the cell-cycle pipeline.</td></tr>
+<tr><td><code>test_cell_cycle_regressions.py::test_cell_cycle_completes_to_division</code></td>
+  <td><span class="fail">FAIL (pre-existing, unrelated)</span></td>
+  <td>Same <code>growth_limits</code> realize-Array bug documented
+    below.  Reproduces identically on the main branch.  Not introduced
+    by this refactor.</td></tr>
+</table>
+
+<h2>7. Diagnosis of the pre-existing test failure (carried over from Phase 1)</h2>
+<p>
+The error surfaces in the schema realize step on the post-division
+daughter cell.  The chromosome / division portion of the pipeline
+runs correctly:
+</p>
+<pre>DIVISION at t=2483 s (dry_mass=702.0 fg, threshold=702.0 fg, chromosomes=2)
+  DAUGHTERS: 00 (bulk=...) + 01 (bulk=...)</pre>
+<p>
+After the daughter cells are constructed, the framework attempts to
+realize their state against the schema and fails on the
+<code>listeners.growth_limits</code> sub-tree:
+</p>
+<pre>ValueError: realize Array at path=('agents', '00', 'listeners', 'growth_limits'):
+np.array failed. encode type=list, len=39, first_row_type=ndarray,
+first_row_len=0, dtype=float64. Original: setting an array element with a
+sequence. The requested array has an inhomogeneous shape after 1 dimensions.
+The detected shape was (39,) + inhomogeneous part.</pre>
+
+<h3>7.1 Why parent cells don't hit this</h3>
+<p>
+On a parent cell, every simulation tick the
+<code>polypeptide_elongation</code> process writes <em>all</em> 36
+fields of <code>growth_limits</code> with shape-consistent values
+(amino-acid-shaped arrays of length 21, scalars as floats, etc.).  By
+the time the schema realize step inspects the parent's
+<code>growth_limits</code>, every field has a real, written-by-the-tick
+value with consistent shape. <code>np.array(...)</code> over those
+values succeeds.
+</p>
+
+<h3>7.2 Why daughter cells DO hit it</h3>
+<p>
+On a freshly divided daughter cell, no process has yet written
+<code>growth_limits</code>.  The fields are populated from the
+schema's declared <em>defaults</em>, which are deliberately
+heterogeneous: empty arrays for the array-typed fields
+(<code>'overwrite[array[float[uM]]]'</code> &rarr;
+<code>_default: []</code>), and zero scalars for the scalar-typed
+fields (<code>'overwrite[float[uM]]'</code> &rarr;
+<code>_default: 0.0</code>).
+</p>
+<p>
+The realize-Array dispatch in <code>bigraph_schema</code> handles
+dict inputs by flattening to a list of values:
+</p>
+<pre>elif isinstance(encode, dict):
+    encode = dict_values(encode)
+...
+state = np.array(encode, dtype=schema._data)</pre>
+<p>
+With 39 mixed-shape values in the list,
+<code>np.array(...)</code> raises an inhomogeneous-shape
+<code>ValueError</code>.  The error message reports
+<code>len=39</code>, <code>first_row_type=ndarray</code>,
+<code>first_row_len=0</code> — exactly the empty-array default for
+the first listed field, with subsequent fields having different
+shapes.
+</p>
+<div class="callout-warn callout">
+<strong>Root cause is in the schema framework, not in v2ecoli.</strong>
+<code>growth_limits</code> is declared in the process schema as a
+struct of named typed fields. The realize dispatch is treating it as
+an Array and flattening the dict — which only works when the parent's
+written values happen to share a uniform shape.  Default-construction
+inevitably surfaces the heterogeneity and fails.
+</div>
+
+<h2>8. Proposed workaround</h2>
+<p>
+The cleanest local fix lives in <code>v2ecoli/library/division.py</code>.
+<code>divide_cell</code> currently builds daughter states with
+<code>bulk</code>, <code>unique</code>, <code>environment</code>,
+<code>boundary</code>, and <code>process_state</code> populated, but
+deliberately does not copy <code>listeners</code>.  Adding a listener
+copy in the same style as the existing environment / boundary copies
+would side-step the schema-realize bug:
+</p>
+<pre>if 'listeners' in cell_state:
+    d1_state['listeners'] = copy.deepcopy(cell_state['listeners'])
+    d2_state['listeners'] = copy.deepcopy(cell_state['listeners'])</pre>
+<p>
+Each daughter inherits the parent's last-tick listener values — i.e.,
+ndarrays + scalars with the parent's <em>actual</em> consistent
+shapes.  The realize step succeeds, the daughter runs normally, and
+on its first post-division tick the listener fields are overwritten
+by their writing processes (every listener field is declared as
+<code>overwrite[...]</code>, which fully replaces the value rather
+than accumulating).  The inheritance is therefore load-bearing for
+the framework but biology-neutral.
+</p>
+<div class="callout">
+This workaround is intentionally <em>not</em> applied in this commit
+— it is a fix for a pre-existing failure that was inherited from the
+main branch, and is best landed as its own targeted commit (or
+upstream in <code>bigraph_schema</code>) so it can be reasoned about
+independently of the replication refactor.
+</div>
+
+<h3>8.1 The proper fix</h3>
+<p>
+The proper fix belongs in <code>bigraph_schema</code>'s realize-Array
+dispatch.  When the encode value is a dict and the schema describes a
+struct of named fields (rather than a single contiguous array),
+realize should recurse into each field with that field's specific
+schema rather than collecting the dict's values and trying to
+materialize them as a single ndarray.  The current dispatch happens
+to work for dicts whose values are shape-uniform because
+<code>np.array(list_of_uniform_arrays)</code> succeeds; it does not
+handle struct-style heterogeneity.  Filing this as an upstream issue
+or PR is the durable fix; the v2ecoli-side workaround above is
+appropriate until then.
+</p>
+
+<h2>9. Honest caveats</h2>
+<ul>
+<li><strong>Proportional fairness is still a coarse-grained
+  approximation.</strong>  Real cells have specific binding kinetics
+  (DnaG-replisome dissociation rates, spatial localization, oriC- vs
+  oriV-specific affinities) that proportional partitioning flattens
+  out.  For mechanistic DnaA-oriC initiation (Aim 2) and the eventual
+  bulk-ification of RNA I/II (Stage C) you'll want explicit binding
+  kinetics that go beyond proportional partitioning — but the
+  allocator is the correct intermediate model and matches what
+  v2ecoli's reconciled architecture and vEcoli ship with today.</li>
+<li><strong>Per-process allocate / request snapshots in
+  <code>scripts/run_plasmid_multiseed.py</code> read 0 currently.</strong>
+  The <code>_alloc_molecule_idx_cache</code> isn't being populated
+  correctly post-refactor for the replisome subunit indices; the
+  underlying biology is correct (chromosome arrest is visible in the
+  unique-molecule trace) but the per-tick allocation values aren't
+  being captured for the report.  Script-side cleanup, not a
+  correctness issue.</li>
+<li><strong>Chromosome-only path is preserved bit-equivalently.</strong>
+  An allocator with a single requester (chromosome alone, when
+  <code>has_plasmid=False</code>) reduces to a pass-through — the
+  proportional math gives the only requester its full request whenever
+  supply is sufficient.  All chromosome-only behavior tests pass
+  identically to pre-refactor.</li>
+</ul>
+
+</body></html>
+"""
+
+    os.makedirs(os.path.dirname(OUT_HTML), exist_ok=True)
+    with open(OUT_HTML, "w") as f:
+        f.write(html)
+    print(f"wrote {OUT_HTML}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_acetate_multigen.py
+++ b/scripts/run_acetate_multigen.py
@@ -1,0 +1,273 @@
+"""Run a chromosome-only acetate lineage for N generations to test whether
+the early-gen FBA over-supply / fast-growth pattern equilibrates by gen 3-5.
+
+Tracks per-tick:
+- cycle time, dry/cell mass
+- ppGpp concentration, fraction tRNA charged, elongation rate
+- division trigger
+
+No plasmid replication, no overrides. Uses cache_acetate_canonical (the
+apr24-extracted PI fixture against which acetate sims work cleanly).
+
+    .venv/bin/python scripts/run_acetate_multigen.py --generations 5
+"""
+from __future__ import annotations
+
+import argparse
+import faulthandler
+import json
+import os
+import sys
+import time
+
+import dill
+import numpy as np
+
+faulthandler.enable()
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+sys.path.insert(0, ROOT)
+os.chdir(ROOT)
+
+from v2ecoli import build_core, build_document
+from v2ecoli.composites.baseline import baseline as baseline_doc
+from v2ecoli.library.division import divide_cell
+from process_bigraph import Composite
+
+
+CACHE_DIR_DEFAULT = "out/cache_acetate_canonical"
+OUT_JSON = "out/acetate_multigen/acetate_multigen_timeseries.json"
+DILL_DIR = "out/acetate_multigen/gen_dills"
+SNAPSHOT_INTERVAL = 60
+MAX_GEN_DURATION_DEFAULT = 12000  # 200 min cap — long enough for τ≈136
+
+
+def _strip_emitter(doc: dict) -> dict:
+    agent = (doc.get("state", {}).get("agents", {}).get("0", {}))
+    if "emitter" in agent:
+        del agent["emitter"]
+    return doc
+
+
+def _make_composite(cache_dir: str, core, seed: int = 0):
+    doc = build_document("baseline", core=core, seed=seed, cache_dir=cache_dir)
+    _strip_emitter(doc)
+    return Composite(doc, core=core)
+
+
+def _mean(x):
+    if isinstance(x, (list, tuple, np.ndarray)):
+        return float(np.mean(x)) if len(x) else 0.0
+    return float(x or 0.0)
+
+
+def capture(t: float, cell: dict) -> dict:
+    mass = cell.get("listeners", {}).get("mass", {}) or {}
+    gl = cell.get("listeners", {}).get("growth_limits", {}) or {}
+    rd = cell.get("listeners", {}).get("ribosome_data", {}) or {}
+    unique = cell.get("unique", {}) or {}
+
+    fc = unique.get("full_chromosome")
+    n_chrom = 0
+    if fc is not None and hasattr(fc, "dtype") and "_entryState" in fc.dtype.names:
+        n_chrom = int(fc["_entryState"].sum())
+    rep = unique.get("active_replisome")
+    n_forks = 0
+    if rep is not None and hasattr(rep, "dtype") and "_entryState" in rep.dtype.names:
+        n_forks = int(rep["_entryState"].sum())
+
+    return {
+        "time": float(t),
+        "dry_mass": float(mass.get("dry_mass", 0.0) or 0.0),
+        "cell_mass": float(mass.get("cell_mass", 0.0) or 0.0),
+        "protein_mass": float(mass.get("protein_mass", 0.0) or 0.0),
+        "rna_mass": float(mass.get("rRna_mass", 0.0) or 0.0)
+                    + float(mass.get("tRna_mass", 0.0) or 0.0)
+                    + float(mass.get("mRna_mass", 0.0) or 0.0),
+        "ppgpp_conc": _mean(gl.get("ppgpp_conc")),
+        "fraction_trna_charged": _mean(gl.get("fraction_trna_charged")),
+        "rela_conc": _mean(gl.get("rela_conc")),
+        "spot_conc": _mean(gl.get("spot_conc")),
+        "ribosome_conc": _mean(gl.get("ribosome_conc")),
+        "effective_elongation_rate": _mean(rd.get("effective_elongation_rate")),
+        "n_full_chromosomes": n_chrom,
+        "n_active_replisomes": n_forks,
+    }
+
+
+def run_generation(composite: Composite, gen_idx: int,
+                   max_duration: float) -> dict:
+    cell = composite.state["agents"]["0"]
+    snaps = [capture(0.0, cell)]
+
+    t_wall0 = time.time()
+    total_run = 0.0
+    divided = False
+    last_cell_data: dict | None = None
+
+    data_keys = {
+        "bulk", "unique", "listeners", "environment", "boundary",
+        "global_time", "timestep", "divide", "division_threshold",
+        "process_state", "allocator_rng",
+    }
+
+    while total_run < max_duration:
+        chunk = min(SNAPSHOT_INTERVAL, max_duration - total_run)
+        try:
+            composite.run(chunk)
+        except Exception as e:
+            total_run += chunk
+            err = str(e)
+            if "divide" in err.lower() or "_add" in err or "_remove" in err:
+                divided = True
+                break
+            if composite.state.get("agents", {}).get("0") is None:
+                divided = True
+                break
+            print(f"    gen {gen_idx} warning at t={total_run:.0f}: "
+                  f"{type(e).__name__}: {err[:160]}")
+            continue
+        total_run += chunk
+
+        cur_cell = composite.state.get("agents", {}).get("0")
+        if cur_cell is None:
+            divided = True
+            break
+        snaps.append(capture(total_run, cur_cell))
+        last_cell_data = {
+            k: v for k, v in cur_cell.items()
+            if k in data_keys
+            or k.startswith("request_")
+            or k.startswith("allocate_")
+        }
+
+    return {
+        "index": gen_idx,
+        "duration": total_run,
+        "wall_time": time.time() - t_wall0,
+        "divided": divided,
+        "snapshots": snaps,
+        "cell_data_after": last_cell_data,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--generations", type=int, default=5)
+    parser.add_argument("--cache-dir", type=str, default=CACHE_DIR_DEFAULT)
+    parser.add_argument("--max-duration", type=int,
+                        default=MAX_GEN_DURATION_DEFAULT)
+    args = parser.parse_args()
+
+    cache_dir = args.cache_dir
+    if not os.path.isdir(cache_dir):
+        raise SystemExit(f"cache dir not found: {cache_dir}")
+
+    with open(os.path.join(cache_dir, "sim_data_cache.dill"), "rb") as f:
+        cache = dill.load(f)
+    try:
+        from v2ecoli.library.unit_bridge import rebind_cache_quantities
+        rebind_cache_quantities(cache)
+    except ImportError:
+        pass
+    configs = cache.get("configs", {})
+    unique_names = cache.get("unique_names", [])
+    dry_mass_inc = cache.get("dry_mass_inc_dict", {})
+
+    print(f"[{time.strftime('%H:%M:%S')}] Gen 1: building from {cache_dir}")
+    core = build_core()
+    composite = _make_composite(cache_dir, core)
+    gens: list[dict] = []
+    t_pipeline = time.time()
+
+    def _flush(n_req: int):
+        os.makedirs(os.path.dirname(OUT_JSON), exist_ok=True)
+        with open(OUT_JSON, "w") as f:
+            json.dump({
+                "cache_dir": cache_dir,
+                "n_generations_requested": n_req,
+                "n_generations_completed": len(gens),
+                "pipeline_wall_time": time.time() - t_pipeline,
+                "snapshot_interval": SNAPSHOT_INTERVAL,
+                "generations": gens,
+            }, f, indent=1)
+
+    def _dump_cell(gen_idx: int, cell_data: dict | None):
+        if cell_data is None:
+            return
+        os.makedirs(DILL_DIR, exist_ok=True)
+        path = os.path.join(DILL_DIR, f"gen{gen_idx}.dill")
+        with open(path, "wb") as f:
+            dill.dump(cell_data, f)
+        print(f"    wrote {path}")
+
+    def _summary(gen_idx: int, gen: dict) -> str:
+        snaps = gen["snapshots"]
+        s0, s1 = snaps[0], snaps[-1]
+        return (
+            f"  gen {gen_idx}: {gen['wall_time']:.0f}s wall, "
+            f"sim {gen['duration']:.0f}s ({gen['duration']/60:.1f} min), "
+            f"dry_mass {s0['dry_mass']:.0f}→{s1['dry_mass']:.0f} fg, "
+            f"ppGpp {s0['ppgpp_conc']:.1f}→{s1['ppgpp_conc']:.1f} uM, "
+            f"charged {s0['fraction_trna_charged']:.3f}→{s1['fraction_trna_charged']:.3f}, "
+            f"elong {s0['effective_elongation_rate']:.1f}→{s1['effective_elongation_rate']:.1f}, "
+            f"divided={gen['divided']}"
+        )
+
+    gen1 = run_generation(composite, 1, args.max_duration)
+    print(_summary(1, gen1))
+    gens.append({k: v for k, v in gen1.items() if k != "cell_data_after"})
+    prev_cell = gen1["cell_data_after"]
+    _flush(args.generations)
+    _dump_cell(1, prev_cell)
+    if not gen1["divided"]:
+        print("  gen 1 did not divide — stopping lineage.")
+
+    for gen_idx in range(2, args.generations + 1):
+        if not gens[-1]["divided"]:
+            break
+        if prev_cell is None or "bulk" not in prev_cell:
+            print(f"  gen {gen_idx}: no prior cell state — stopping lineage")
+            break
+        print(f"[{time.strftime('%H:%M:%S')}] Gen {gen_idx}: dividing, "
+              f"keeping daughter 1")
+        try:
+            d1_state, _d2_state = divide_cell(prev_cell)
+            t_build = time.time()
+            daughter_bundle = {
+                "initial_state": d1_state,
+                "configs": configs,
+                "unique_names": unique_names,
+                "dry_mass_inc_dict": dry_mass_inc,
+            }
+            doc = baseline_doc(core=core, seed=gen_idx, cache_dir=cache_dir,
+                               bundle=daughter_bundle)
+            _strip_emitter(doc)
+            composite = Composite(doc, core=core)
+            print(f"    built daughter composite in {time.time() - t_build:.1f}s")
+            gen = run_generation(composite, gen_idx, args.max_duration)
+        except BaseException as e:
+            import traceback
+            print(f"  gen {gen_idx}: lineage setup/run failed — "
+                  f"{type(e).__name__}: {str(e)[:200]}")
+            traceback.print_exc()
+            break
+        print(_summary(gen_idx, gen))
+        gens.append({k: v for k, v in gen.items() if k != "cell_data_after"})
+        prev_cell = gen["cell_data_after"]
+        _flush(args.generations)
+        _dump_cell(gen_idx, prev_cell)
+        if not gen["divided"]:
+            print(f"  gen {gen_idx} did not divide — stopping lineage.")
+            break
+
+    pipeline_wall = time.time() - t_pipeline
+    _flush(args.generations)
+    print(f"[{time.strftime('%H:%M:%S')}] wrote {OUT_JSON} "
+          f"({len(gens)} gens, {pipeline_wall:.0f}s wall, "
+          f"{pipeline_wall/60:.1f} min)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_condition_multigen_parquet.py
+++ b/scripts/run_condition_multigen_parquet.py
@@ -1,0 +1,256 @@
+"""Multi-generation baseline parquet sim for one condition.
+
+Adapts run_acetate_multigen.py's daughter-bundle pattern + the per-gen
+ctx mgr pattern in studies/stage1_sanity_check/run_sim.py for parquet.
+Each generation wraps in its own ``parquet_emitter()`` context so the
+metadata (generation, agent_id) is fresh per gen.
+
+Agent IDs follow vEcoli's lineage convention: gen N uses agent_id "0"*N
+("0", "00", "000", ...). This way ``generation = len(agent_id)`` matches
+vEcoli's parquet partitioning semantics.
+
+Transient daughter emitters spawned inside the composite at division time
+write to ``gen=N+1/agent_id=00 or 01/`` partitions (see Division step's
+metadata override). When the next runner-driven gen opens its ctx mgr,
+its ``_write_configuration`` wipes whichever of those partitions matches —
+so the runner-driven sim's history is the source of truth per gen.
+
+Usage:
+    python scripts/run_condition_multigen_parquet.py \\
+        --cache-dir out/cache_glycerol_stage1_all_knobs \\
+        --out-dir out/glycerol_stage1_no_crp_5gen_parquet \\
+        --experiment-id glycerol_stage1_no_crp_5gen \\
+        --generations 5 \\
+        --max-min 200
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+
+import dill
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+sys.path.insert(0, ROOT)
+os.chdir(ROOT)
+
+from process_bigraph import Composite
+
+from v2ecoli import build_composite, build_document
+from v2ecoli.composites._helpers import parquet_emitter
+from v2ecoli.composites.baseline import baseline as baseline_doc
+from v2ecoli.core import build_core
+from v2ecoli.library.division import divide_cell
+from v2ecoli.library.parquet_emitter import ParquetEmitter
+
+
+SNAPSHOT_INTERVAL = 60
+
+
+def _last_cell_state(comp: Composite) -> dict | None:
+    """Snapshot the parent agent's biological state for divide_cell()."""
+    cell = comp.state.get("agents", {}).get("0")
+    if cell is None:
+        return None
+    keys = {"bulk", "unique", "listeners", "environment", "boundary",
+            "global_time", "timestep", "divide", "division_threshold",
+            "process_state", "allocator_rng"}
+    return {k: v for k, v in cell.items()
+            if k in keys or k.startswith("request_") or k.startswith("allocate_")}
+
+
+def _fg(q) -> float:
+    """dry_mass in fg as a plain float. Post-merge with origin/main the mass
+    listener emits a pint Quantity (femtogram); strip units if present."""
+    return float(getattr(q, "magnitude", q))
+
+
+def _run_gen(comp: Composite, max_duration: int, gen_idx: int) -> tuple[float, bool, dict | None]:
+    total = 0.0
+    divided = False
+    last_state = _last_cell_state(comp)
+    cell0 = comp.state["agents"]["0"]
+    dry0 = _fg(cell0["listeners"]["mass"].get("dry_mass", 0))
+    print(f"    gen {gen_idx}: initial dry_mass={dry0:.1f} fg")
+
+    while total < max_duration:
+        chunk = min(SNAPSHOT_INTERVAL, max_duration - total)
+        try:
+            comp.run(chunk)
+        except Exception as e:
+            err = str(e)
+            if "divide" in err.lower() or "_add" in err or "_remove" in err:
+                total += chunk
+                divided = True
+                break
+            if comp.state.get("agents", {}).get("0") is None:
+                divided = True
+                break
+            raise
+        total += chunk
+        cur = comp.state.get("agents", {}).get("0")
+        if cur is None:
+            divided = True
+            break
+        last_state = _last_cell_state(comp)
+        if int(total) % 600 == 0 or total >= max_duration - 60:
+            dry = _fg(cur["listeners"]["mass"].get("dry_mass", 0))
+            print(f"    gen {gen_idx}: t={total/60:5.1f} min  dry_mass={dry:.1f} fg")
+
+    # Pre-divide finalize hook (in division.py) already closed the parent
+    # emitter for us if divided=True, but call flush_all_in_composite as a
+    # belt-and-suspenders no-op for any in-composite daughter emitters or
+    # the non-divided edge case.
+    n_closed = ParquetEmitter.flush_all_in_composite(comp, success=divided)
+    if n_closed:
+        print(f"    gen {gen_idx}: flushed {n_closed} ParquetEmitter instance(s)")
+
+    return total, divided, last_state
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--cache-dir", required=True)
+    ap.add_argument("--out-dir", required=True,
+                    help="Parquet out-dir root (under <root>/<experiment-id>/...)")
+    ap.add_argument("--experiment-id", required=True)
+    ap.add_argument("--generations", type=int, default=5)
+    ap.add_argument("--max-min", type=float, default=200.0,
+                    help="Max duration per generation, minutes")
+    ap.add_argument("--seed", type=int, default=0)
+    ap.add_argument("--dill-dir", default=None,
+                    help="Optional dir to dump per-gen daughter dills "
+                         "(default: out/<experiment-id>/gen_dills)")
+    ap.add_argument("--resume-dill", default=None,
+                    help="Resume the lineage from a previously-dumped "
+                         "gen{N}.dill instead of cold-starting gen 1 from "
+                         "the cache. The dill is divided to seed this run's "
+                         "first generation.")
+    ap.add_argument("--start-gen", type=int, default=1,
+                    help="Generation index (and agent_id length) for the "
+                         "first gen of THIS run. Default 1.")
+    args = ap.parse_args()
+
+    max_duration = int(args.max_min * 60)
+    dill_dir = args.dill_dir or f"out/{args.experiment_id}/gen_dills"
+    os.makedirs(args.out_dir, exist_ok=True)
+    os.makedirs(dill_dir, exist_ok=True)
+
+    print("=" * 60)
+    print(f"Multi-gen lineage — {args.generations} gens, seed={args.seed}")
+    print(f"  cache:        {args.cache_dir}")
+    print(f"  out_dir:      {args.out_dir}")
+    print(f"  experiment:   {args.experiment_id}")
+    print(f"  max/gen:      {args.max_min:.0f} min")
+    print("=" * 60)
+
+    # Load configs/unique_names/dry_mass_inc once — same cache feeds every gen.
+    with open(os.path.join(args.cache_dir, "sim_data_cache.dill"), "rb") as f:
+        cache = dill.load(f)
+    try:
+        from v2ecoli.library.unit_bridge import rebind_cache_quantities
+        rebind_cache_quantities(cache)
+    except ImportError:
+        pass
+    configs = cache.get("configs", {})
+    unique_names = cache.get("unique_names", [])
+    dry_mass_inc = cache.get("dry_mass_inc_dict", {})
+
+    core = build_core()
+    t_pipeline = time.time()
+    summary = []
+    prev_cell_data = None
+
+    # Resume mode: seed prev_cell_data from a saved dill so the first gen of
+    # this run is a daughter of that state (divide path), not a cold cache
+    # start.
+    if args.resume_dill:
+        with open(args.resume_dill, "rb") as f:
+            prev_cell_data = dill.load(f)
+        print(f"  resume_dill:  {args.resume_dill} "
+              f"(first gen seeded from this state)")
+
+    for gen_idx in range(args.start_gen, args.start_gen + args.generations):
+        agent_id = "0" * gen_idx
+        gen_label = f"gen {gen_idx} (agent_id={agent_id})"
+        print(f"\n[{time.strftime('%H:%M:%S')}] {gen_label}")
+        t0 = time.time()
+
+        with parquet_emitter(
+            out_dir=args.out_dir,
+            experiment_id=args.experiment_id,
+            lineage_seed=args.seed,
+            agent_id=agent_id,
+            generation=gen_idx,
+        ):
+            t_build = time.time()
+            if prev_cell_data is None:
+                comp = build_composite("baseline", cache_dir=args.cache_dir)
+            else:
+                d1_state, _d2_state = divide_cell(prev_cell_data)
+                bundle = {
+                    "initial_state": d1_state,
+                    "configs": configs,
+                    "unique_names": unique_names,
+                    "dry_mass_inc_dict": dry_mass_inc,
+                }
+                doc = baseline_doc(core=core, seed=args.seed + gen_idx,
+                                   cache_dir=args.cache_dir, bundle=bundle)
+                comp = Composite(doc, core=core)
+            print(f"    composite built in {time.time()-t_build:.1f}s")
+
+            duration, divided, last_state = _run_gen(comp, max_duration, gen_idx)
+
+        dry_f = _fg((last_state or {}).get("listeners", {}).get("mass", {}).get("dry_mass", 0))
+        wall = time.time() - t0
+        result = {
+            "gen": gen_idx,
+            "agent_id": agent_id,
+            "duration_min": duration / 60.0,
+            "divided": divided,
+            "final_dry_mass_fg": dry_f,
+            "wall_seconds": wall,
+        }
+        summary.append(result)
+        print(f"    gen {gen_idx} summary: tau={duration/60:.1f} min  "
+              f"final_dry={dry_f:.1f} fg  divided={divided}  wall={wall:.0f}s")
+
+        # Persist daughter state for the next gen / for restart.
+        prev_cell_data = last_state
+        if last_state is not None:
+            dill_path = os.path.join(dill_dir, f"gen{gen_idx}.dill")
+            with open(dill_path, "wb") as f:
+                dill.dump(last_state, f)
+
+        if not divided:
+            print(f"    gen {gen_idx} did not divide — stopping lineage.")
+            break
+
+    pipeline_wall = time.time() - t_pipeline
+    out_summary = {
+        "experiment_id": args.experiment_id,
+        "cache_dir": args.cache_dir,
+        "generations_requested": args.generations,
+        "generations_completed": len(summary),
+        "pipeline_wall_seconds": pipeline_wall,
+        "gens": summary,
+    }
+    summary_path = os.path.join(args.out_dir, f"{args.experiment_id}_summary.json")
+    with open(summary_path, "w") as f:
+        json.dump(out_summary, f, indent=2)
+
+    print("\n" + "=" * 60)
+    print(f"DONE — {len(summary)} gens, {pipeline_wall/60:.1f} min wall")
+    for s in summary:
+        print(f"  gen {s['gen']}: tau={s['duration_min']:5.1f} min  "
+              f"final_dry={s['final_dry_mass_fg']:7.1f} fg  "
+              f"divided={s['divided']}")
+    print(f"summary: {summary_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_condition_parquet_singlegen.py
+++ b/scripts/run_condition_parquet_singlegen.py
@@ -1,0 +1,108 @@
+"""Single-gen baseline parquet sim for one nutrient condition — post-merge.
+
+Generalised from run_with_aa_parquet_singlegen.py. Each condition writes
+its parquet history under out/<condition>_postmerge_parquet/.
+
+Usage:
+    python scripts/run_condition_parquet_singlegen.py --condition with_aa --max-min 60
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+sys.path.insert(0, ROOT)
+os.chdir(ROOT)
+
+from v2ecoli import build_composite
+from v2ecoli.core import build_core
+from v2ecoli.composites._helpers import parquet_emitter
+from v2ecoli.library.parquet_emitter import ParquetEmitter
+
+
+SNAPSHOT_INTERVAL = 60
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--condition", required=True,
+                    help="ParCa condition name (basal | with_aa | acetate | "
+                         "succinate | no_oxygen)")
+    ap.add_argument("--cache-dir", default=None,
+                    help="Override cache dir (default: out/cache_<condition>_apr24)")
+    ap.add_argument("--out-dir", default=None,
+                    help="Override parquet out dir (default: "
+                         "out/<condition>_postmerge_parquet)")
+    ap.add_argument("--max-min", type=float, default=60.0,
+                    help="Max sim duration in minutes (default 60)")
+    args = ap.parse_args()
+
+    cache_dir = args.cache_dir or f"out/cache_{args.condition}_apr24"
+    out_dir = args.out_dir or f"out/{args.condition}_postmerge_parquet"
+    max_duration = int(args.max_min * 60)
+
+    print(f"condition:   {args.condition}")
+    print(f"cache:       {cache_dir}")
+    print(f"parquet out: {out_dir}")
+    print(f"max sim:     {max_duration}s ({max_duration/60:.0f} min)")
+    print("-" * 60)
+    os.makedirs(out_dir, exist_ok=True)
+
+    core = build_core()
+    t_wall0 = time.time()
+
+    with parquet_emitter(
+        out_dir=out_dir,
+        experiment_id=f"{args.condition}_postmerge",
+        lineage_seed=0,
+        agent_id="0",
+        generation=1,
+    ):
+        t_build = time.time()
+        comp = build_composite("baseline", cache_dir=cache_dir)
+        cell0 = comp.state["agents"]["0"]
+        dry0 = float(cell0["listeners"]["mass"].get("dry_mass", 0))
+        print(f"  composite built in {time.time()-t_build:.1f}s — "
+              f"initial dry_mass={dry0:.1f} fg")
+
+        total_run = 0.0
+        divided = False
+        while total_run < max_duration:
+            chunk = min(SNAPSHOT_INTERVAL, max_duration - total_run)
+            try:
+                comp.run(chunk)
+            except Exception as e:
+                err = str(e)
+                if "divide" in err.lower() or "_add" in err or "_remove" in err:
+                    total_run += chunk
+                    divided = True
+                    break
+                if comp.state.get("agents", {}).get("0") is None:
+                    divided = True
+                    break
+                raise
+            total_run += chunk
+            cur = comp.state.get("agents", {}).get("0")
+            if cur is None:
+                divided = True
+                break
+            dry = float(cur["listeners"]["mass"].get("dry_mass", 0))
+            if int(total_run) % 300 == 0 or total_run >= max_duration - 60:
+                print(f"  t={total_run/60:5.1f} min  dry_mass={dry:.1f} fg")
+            if divided:
+                break
+
+        n_closed = ParquetEmitter.flush_all_in_composite(comp, success=divided)
+        print(f"  flushed {n_closed} ParquetEmitter instance(s)")
+
+    wall = time.time() - t_wall0
+    print("-" * 60)
+    print(f"final: sim={total_run/60:.1f} min, wall={wall:.0f}s, divided={divided}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_v2ecoli_apr24_sweep.sh
+++ b/scripts/run_v2ecoli_apr24_sweep.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Run v2ecoli 1-gen sims for all 5 canonical conditions from the apr24 fixture.
+# Writes a separate cache + SQLite DB per condition under out/<cond>_apr24_*
+set -e
+
+FIXTURE=out/parca_state_apr24.pkl.gz
+
+get_max_dur() {
+    case "$1" in
+        basal)     echo 5400 ;;
+        with_aa)   echo 3000 ;;
+        acetate)   echo 12000 ;;
+        succinate) echo 9000 ;;
+        no_oxygen) echo 12000 ;;
+    esac
+}
+
+for cond in basal with_aa acetate succinate no_oxygen; do
+    cache=out/cache_${cond}_apr24
+    db=out/${cond}_apr24_run.db
+    dur=$(get_max_dur "$cond")
+
+    echo "=== ${cond} (apr24 fixture, max_duration=${dur}s) ==="
+
+    if [ ! -f "${cache}/sim_data_cache.dill" ]; then
+        echo "  building ${cache} ..."
+        python scripts/build_cache.py \
+            --fixture "${FIXTURE}" \
+            --cache   "${cache}" \
+            --condition "${cond}"
+    else
+        echo "  cache ${cache} exists, skipping build"
+    fi
+
+    if [ -f "${db}" ]; then
+        rows=$(sqlite3 "${db}" 'SELECT COUNT(*) FROM history' 2>/dev/null || echo 0)
+        if [ "${rows}" -gt 100 ]; then
+            echo "  ${db} already has ${rows} rows, skipping sim"
+            continue
+        fi
+    fi
+    rm -f "${db}" "${db}-shm" "${db}-wal"
+
+    echo "  running 1-gen sim ..."
+    python studies/stage1_sanity_check/run_sim.py \
+        --cache-dir   "${cache}" \
+        --generations 1 \
+        --seed        0 \
+        --max-duration "${dur}" \
+        --db-path     "${db}"
+done
+
+echo
+echo "=== summary ==="
+for cond in basal with_aa acetate succinate no_oxygen; do
+    db=out/${cond}_apr24_run.db
+    if [ -f "${db}" ]; then
+        max_step=$(sqlite3 "${db}" 'SELECT MAX(step) FROM history' 2>/dev/null || echo 0)
+        echo "  ${cond}: ${max_step} steps in ${db}"
+    fi
+done

--- a/scripts/run_with_aa_parquet_singlegen.py
+++ b/scripts/run_with_aa_parquet_singlegen.py
@@ -1,0 +1,94 @@
+"""Single-gen with_aa cell wrapped in parquet_emitter() — post-merge sanity check.
+
+Validates that:
+  - the merged main parquet emitter wiring works end-to-end
+  - the D-period division trigger fires (with_aa should divide ~21 min)
+  - the merged cache_version + LoadSimData(condition=with_aa) path is healthy
+
+Usage:
+    python scripts/run_with_aa_parquet_singlegen.py
+"""
+from __future__ import annotations
+
+import os
+import sys
+import time
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+sys.path.insert(0, ROOT)
+os.chdir(ROOT)
+
+from v2ecoli import build_composite
+from v2ecoli.core import build_core
+from v2ecoli.composites._helpers import parquet_emitter
+from v2ecoli.library.parquet_emitter import ParquetEmitter
+
+
+CACHE_DIR = "out/cache_with_aa_apr24"
+PARQUET_OUT = "out/with_aa_postmerge_parquet"
+MAX_DURATION = 3600  # 60 min — plenty of headroom for the ~21 min cycle
+SNAPSHOT_INTERVAL = 60
+
+
+def main() -> None:
+    print(f"cache:       {CACHE_DIR}")
+    print(f"parquet out: {PARQUET_OUT}")
+    print(f"max sim:     {MAX_DURATION}s ({MAX_DURATION/60:.0f} min)")
+    print("-" * 60)
+    os.makedirs(PARQUET_OUT, exist_ok=True)
+
+    core = build_core()
+    t_wall0 = time.time()
+
+    with parquet_emitter(
+        out_dir=PARQUET_OUT,
+        experiment_id="with_aa_postmerge",
+        lineage_seed=0,
+        agent_id="0",
+        generation=1,
+    ):
+        t_build = time.time()
+        comp = build_composite("baseline", cache_dir=CACHE_DIR)
+        cell0 = comp.state["agents"]["0"]
+        dry0 = float(cell0["listeners"]["mass"].get("dry_mass", 0))
+        print(f"  composite built in {time.time()-t_build:.1f}s — "
+              f"initial dry_mass={dry0:.1f} fg")
+
+        total_run = 0.0
+        divided = False
+        while total_run < MAX_DURATION:
+            chunk = min(SNAPSHOT_INTERVAL, MAX_DURATION - total_run)
+            try:
+                comp.run(chunk)
+            except Exception as e:
+                err = str(e)
+                if "divide" in err.lower() or "_add" in err or "_remove" in err:
+                    total_run += chunk
+                    divided = True
+                    break
+                if comp.state.get("agents", {}).get("0") is None:
+                    divided = True
+                    break
+                raise
+            total_run += chunk
+            cur = comp.state.get("agents", {}).get("0")
+            if cur is None:
+                divided = True
+                break
+            dry = float(cur["listeners"]["mass"].get("dry_mass", 0))
+            print(f"  t={total_run/60:5.1f} min  dry_mass={dry:.1f} fg")
+            if divided:
+                break
+
+        # Flush the parquet trailing batch before the ctx mgr clears the override.
+        n_closed = ParquetEmitter.flush_all_in_composite(comp, success=divided)
+        print(f"  flushed {n_closed} ParquetEmitter instance(s)")
+
+    wall = time.time() - t_wall0
+    print("-" * 60)
+    print(f"final: sim={total_run/60:.1f} min, wall={wall:.0f}s, divided={divided}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/troubleshooting_report_2026_04_24.py
+++ b/scripts/troubleshooting_report_2026_04_24.py
@@ -1,0 +1,635 @@
+"""Troubleshooting-note report for the 2026-04-24 v2ecoli chromosome-gate
+investigation.
+
+Summarizes:
+  - the original concern (Figure 2's chromosome-arrest claim under scrutiny),
+  - the investigation (== gate unsatisfiable against raw bulk),
+  - the patch (chromosome_replication.py:329-332, == -> >=),
+  - the architectural finding (sequential-priority in layer 4b, no fairness),
+  - comparison with vEcoli's allocator semantics,
+  - proposed Aim 1a next step (reconciled-replication refactor).
+
+Reads:
+  - out/plasmid/multiseed_timeseries.json (today's post-patch
+    1-seed uncontrolled mechanistic run; plasmids 1 -> 3254, chromosome
+    re-init at t=1770s).
+  - reports/figures/fig2_uncontrolled_vecoli.png (Figure 2 as submitted
+    in the prelim proposal; generated in v2ecoli pre-patch).
+
+Writes:
+  - reports/troubleshooting_2026_04_24_chromosome_gate.html
+
+Usage:
+    uv run python scripts/troubleshooting_report_2026_04_24.py
+"""
+from __future__ import annotations
+
+import base64
+import io
+import json
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+os.chdir(ROOT)
+
+SMOKE_JSON = "out/plasmid/multiseed_timeseries.json"
+NOPLASMID_MULTIGEN_JSON = "out/plasmid/multigen_timeseries_noplasmid_7gen.json"
+STRICT_GATE_DEMO_JSON = "out/plasmid/multigen_timeseries_strict_gate_demo.json"
+FIG2_PNG = "reports/figures/fig2_uncontrolled_vecoli.png"
+OUT_HTML = "reports/troubleshooting_2026_04_24_chromosome_gate.html"
+
+
+def _svg_of(fig) -> str:
+    buf = io.StringIO()
+    fig.savefig(buf, format="svg", bbox_inches="tight")
+    return buf.getvalue()
+
+
+def _png_data_uri(path: str) -> str:
+    with open(path, "rb") as f:
+        b64 = base64.b64encode(f.read()).decode("ascii")
+    return f"data:image/png;base64,{b64}"
+
+
+def main():
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    # Load today's uncontrolled mechanistic post-patch single-seed run.
+    with open(SMOKE_JSON) as f:
+        d = json.load(f)
+    snaps = d["seeds"][0]["snapshots"]
+    t = [s["time"] for s in snaps]
+    n_plasmids = [s["n_full_plasmids"] for s in snaps]
+    n_chr_rep = [s["n_active_replisomes"] for s in snaps]
+    n_plasmid_rep = [s["n_plasmid_active_replisomes"] for s in snaps]
+    dnaG = [s["bulk_dnaG"] for s in snaps]
+    cell_mass = [s["cell_mass"] for s in snaps]
+    divided_at = snaps[-1]["time"]
+
+    # Compute the key transitions.
+    term_idx = next((i for i in range(1, len(n_chr_rep))
+                     if n_chr_rep[i] == 0 and n_chr_rep[i-1] > 0), None)
+    reinit_idx = next((i for i in range(term_idx, len(n_chr_rep))
+                       if n_chr_rep[i] > 0), None) if term_idx else None
+    term_t = t[term_idx] if term_idx else None
+    reinit_t = t[reinit_idx] if reinit_idx else None
+    reinit_mass = cell_mass[reinit_idx] if reinit_idx else None
+
+    # ---------------- Figure: today's post-patch v2ecoli Gen 1 ----------------
+    fig, axes = plt.subplots(1, 3, figsize=(15, 4))
+
+    # Panel A: plasmid copy number over time
+    ax = axes[0]
+    ax.plot([x/60 for x in t], n_plasmids, color="#2563eb", lw=1.8)
+    ax.set_xlabel("time (min)")
+    ax.set_ylabel("full plasmids")
+    ax.set_title("A. Plasmid copy number (runaway under uncontrolled replication)")
+    ax.grid(True, alpha=0.3)
+    ax.text(0.02, 0.95, f"1 → {n_plasmids[-1]}", transform=ax.transAxes,
+            fontsize=10, fontweight="bold", va="top",
+            bbox=dict(boxstyle="round", fc="#dbeafe", alpha=0.8))
+
+    # Panel B: chromosome active replisomes (the key new finding)
+    ax = axes[1]
+    ax.step([x/60 for x in t], n_chr_rep, color="#dc2626", lw=1.8, where="post")
+    ax.set_xlabel("time (min)")
+    ax.set_ylabel("chromosome active replisomes")
+    ax.set_title("B. Chromosome replisomes — re-init fires post-patch")
+    ax.grid(True, alpha=0.3)
+    if term_t is not None:
+        ax.axvline(term_t/60, color="gray", ls="--", alpha=0.5)
+        ax.text(term_t/60, 4.2, f"termination\n{term_t:.0f}s",
+                fontsize=8, ha="right", va="bottom", color="gray")
+    if reinit_t is not None:
+        ax.axvline(reinit_t/60, color="#059669", ls="--", alpha=0.7)
+        ax.text(reinit_t/60, 4.2,
+                f"re-init (0→4)\n{reinit_t:.0f}s\ncell_mass={reinit_mass:.0f} fg",
+                fontsize=8, ha="left", va="bottom", color="#059669")
+    ax.set_ylim(-0.3, 5)
+
+    # Panel C: DnaG trajectory — sawtooth from plasmid-replisome turnover
+    ax = axes[2]
+    ax.plot([x/60 for x in t], dnaG, color="#7c3aed", lw=0.8)
+    ax.axhline(4, color="#dc2626", ls="--", alpha=0.6,
+               label="mechanistic gate min (2·n_oriC=4)")
+    ax.set_xlabel("time (min)")
+    ax.set_ylabel("bulk DnaG")
+    ax.set_title("C. DnaG oscillates 0↔8 on plasmid-replisome cycle")
+    ax.grid(True, alpha=0.3)
+    ax.legend(loc="upper right", fontsize=8)
+    ax.set_ylim(-0.5, 10)
+
+    fig.suptitle(
+        "v2ecoli post-patch: uncontrolled mechanistic, BP1993 off, "
+        f"1 seed, divided at {divided_at/60:.1f} min  "
+        "(out/plasmid/multiseed_timeseries.json, 2026-04-24)",
+        fontsize=11, y=1.02)
+    fig.tight_layout()
+    plot_svg = _svg_of(fig)
+
+    # ---------------- Figure: no-plasmid 7-gen multigen (>= gate) ----------------
+    with open(NOPLASMID_MULTIGEN_JSON) as f:
+        d_mg = json.load(f)
+    gens_mg = d_mg["generations"]
+
+    fig_mg, (ax_mg1, ax_mg2, ax_mg3) = plt.subplots(3, 1, figsize=(12, 7),
+                                                     sharex=True)
+    t_global_offset = 0.0
+    gen_boundaries = [0.0]
+    colors = ["#1e3a8a", "#0e7490", "#15803d", "#854d0e",
+              "#b91c1c", "#7c2d12", "#6b21a8"]
+    dnag_max_across = 0
+    for gi, g in enumerate(gens_mg):
+        s = g["snapshots"]
+        ts = [(x["time"] - s[0]["time"] + t_global_offset) / 60 for x in s]
+        n_rep = [x["n_active_replisomes"] for x in s]
+        cm = [x["cell_mass"] for x in s]
+        dg = [x.get("bulk_dnaG", x.get("dnaG", 0)) for x in s]
+        dnag_max_across = max(dnag_max_across, max(dg) if dg else 0)
+        ax_mg1.step(ts, n_rep, where="post", lw=1.4,
+                    color=colors[gi % len(colors)],
+                    label=f"gen {gi+1}")
+        ax_mg2.plot(ts, cm, lw=1.2,
+                    color=colors[gi % len(colors)])
+        ax_mg3.plot(ts, dg, lw=0.9,
+                    color=colors[gi % len(colors)], alpha=0.85)
+        t_global_offset = ts[-1] * 60
+        gen_boundaries.append(t_global_offset / 60)
+    for b in gen_boundaries[1:-1]:
+        ax_mg1.axvline(b, color="gray", ls=":", alpha=0.4)
+        ax_mg2.axvline(b, color="gray", ls=":", alpha=0.4)
+        ax_mg3.axvline(b, color="gray", ls=":", alpha=0.4)
+    ax_mg1.set_ylabel("chromosome active replisomes")
+    ax_mg1.set_title("D. No-plasmid mechanistic 7-gen lineage under patched "
+                     "≥ gate — adaptive downshift at gen 5")
+    ax_mg1.legend(loc="upper right", fontsize=8, ncol=7)
+    ax_mg1.set_ylim(-0.3, 5)
+    ax_mg1.grid(True, alpha=0.3)
+    ax_mg2.axhline(975, color="#dc2626", ls="--", alpha=0.6,
+                   label="1-oriC threshold (975 fg)")
+    ax_mg2.axhline(1950, color="#991b1b", ls="--", alpha=0.6,
+                   label="2-oriC threshold (1950 fg)")
+    ax_mg2.set_ylabel("cell mass (fg)")
+    ax_mg2.legend(loc="upper right", fontsize=8)
+    ax_mg2.grid(True, alpha=0.3)
+    ax_mg3.axhline(4, color="#dc2626", ls="--", alpha=0.6,
+                   label="gate min (2·n_oriC=4 at 2 oriCs)")
+    ax_mg3.axhline(2, color="#f59e0b", ls="--", alpha=0.6,
+                   label="gate min (2·n_oriC=2 at 1 oriC)")
+    ax_mg3.set_ylabel("bulk DnaG")
+    ax_mg3.set_xlabel("cumulative time across lineage (min)")
+    ax_mg3.legend(loc="upper right", fontsize=8)
+    ax_mg3.grid(True, alpha=0.3)
+    # Keep y-lim generous if any transient spike exists, otherwise fix a small
+    # range so the flat-zero signal is readable.
+    ax_mg3.set_ylim(-0.5, max(6, dnag_max_across + 0.5))
+    fig_mg.suptitle(
+        "v2ecoli no-plasmid mechanistic, 7 generations, patched ≥ gate  "
+        "(out/plasmid/multigen_timeseries_noplasmid_7gen.json)",
+        fontsize=11, y=0.99)
+    fig_mg.tight_layout()
+    multigen_svg = _svg_of(fig_mg)
+
+    # ---------------- Figure: no-plasmid single-gen == demo ----------------
+    with open(STRICT_GATE_DEMO_JSON) as f:
+        d_eq = json.load(f)
+    s_eq = d_eq["generations"][0]["snapshots"]
+    t_eq = [(x["time"] - s_eq[0]["time"]) / 60 for x in s_eq]
+    n_rep_eq = [x["n_active_replisomes"] for x in s_eq]
+    cm_eq = [x["cell_mass"] for x in s_eq]
+    div_eq = s_eq[-1]["time"] - s_eq[0]["time"]
+
+    fig_eq, axes_eq = plt.subplots(1, 2, figsize=(12, 3.8))
+    ax = axes_eq[0]
+    ax.step(t_eq, n_rep_eq, where="post", color="#dc2626", lw=1.8)
+    # Mark termination
+    term_eq_idx = next((i for i in range(1, len(n_rep_eq))
+                        if n_rep_eq[i] == 0 and n_rep_eq[i-1] > 0), None)
+    if term_eq_idx is not None:
+        ax.axvline(t_eq[term_eq_idx], color="gray", ls="--", alpha=0.6)
+        ax.text(t_eq[term_eq_idx], 2.3,
+                f"termination\n{t_eq[term_eq_idx]*60:.0f}s",
+                fontsize=8, ha="right", va="top", color="gray")
+    ax.text(0.35, 0.5,
+            "no re-initiation\nfires for the\nremaining 20 min",
+            transform=ax.transAxes, fontsize=11, ha="center", va="center",
+            color="#991b1b", fontweight="bold",
+            bbox=dict(boxstyle="round", fc="#fee2e2", alpha=0.9))
+    ax.set_xlabel("time (min)")
+    ax.set_ylabel("chromosome active replisomes")
+    ax.set_title("E. Chromosome replisomes under strict == gate (no plasmids)")
+    ax.set_ylim(-0.3, 3)
+    ax.grid(True, alpha=0.3)
+
+    ax = axes_eq[1]
+    ax.plot(t_eq, cm_eq, color="#2563eb", lw=1.8)
+    ax.axhline(1950, color="#dc2626", ls="--", alpha=0.6,
+               label="2-oriC threshold (1950 fg)")
+    # Find where it crossed
+    cross_eq_idx = next((i for i in range(len(cm_eq))
+                         if cm_eq[i] >= 1950), None)
+    if cross_eq_idx is not None:
+        ax.axvline(t_eq[cross_eq_idx], color="#16a34a", ls=":", alpha=0.7)
+        ax.text(t_eq[cross_eq_idx], 2200,
+                f"mass gate crossed\n{t_eq[cross_eq_idx]*60:.0f}s",
+                fontsize=8, ha="left", va="top", color="#16a34a")
+    ax.set_xlabel("time (min)")
+    ax.set_ylabel("cell mass (fg)")
+    ax.set_title("F. Cell mass does cross threshold — but gate fails to fire")
+    ax.legend(loc="lower right", fontsize=8)
+    ax.grid(True, alpha=0.3)
+    fig_eq.suptitle(
+        "v2ecoli no-plasmid mechanistic, single generation, strict == gate "
+        f"(divided at {div_eq/60:.1f} min, but with 0 active replisomes)  "
+        "(out/plasmid/multigen_timeseries_strict_gate_demo.json)",
+        fontsize=11, y=1.02)
+    fig_eq.tight_layout()
+    strict_gate_svg = _svg_of(fig_eq)
+
+    # Summary stats for the demo
+    eq_transitions = sum(1 for i in range(1, len(n_rep_eq))
+                         if n_rep_eq[i] != n_rep_eq[i-1])
+    eq_max_mass = max(cm_eq)
+
+    # ---------------- HTML ----------------
+    fig2_datauri = _png_data_uri(FIG2_PNG)
+
+    css = """
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+           max-width: 1100px; margin: 2em auto; padding: 0 2em;
+           color: #0f172a; line-height: 1.55; }
+    h1 { border-bottom: 3px solid #0f172a; padding-bottom: 0.3em; }
+    h2 { border-bottom: 1px solid #cbd5e1; padding-bottom: 0.2em;
+         margin-top: 2em; color: #0f172a; }
+    h3 { color: #334155; margin-top: 1.5em; }
+    code { background: #f1f5f9; padding: 2px 5px; border-radius: 3px;
+           font-size: 0.9em; }
+    pre { background: #f1f5f9; padding: 1em; border-radius: 5px;
+          overflow-x: auto; font-size: 0.85em; }
+    table { border-collapse: collapse; margin: 1em 0; }
+    th, td { border: 1px solid #cbd5e1; padding: 6px 10px; text-align: left;
+             font-size: 0.9em; vertical-align: top; }
+    th { background: #f1f5f9; }
+    .callout { background: #fef3c7; border-left: 4px solid #f59e0b;
+               padding: 1em 1.2em; margin: 1em 0; border-radius: 3px; }
+    .callout-good { background: #dcfce7; border-left: 4px solid #16a34a; }
+    .callout-info { background: #dbeafe; border-left: 4px solid #2563eb; }
+    .figcap { font-size: 0.85em; color: #475569; margin-top: 0.3em; }
+    img.embedded { max-width: 100%; border: 1px solid #cbd5e1;
+                   border-radius: 4px; }
+    .side-by-side { display: flex; gap: 1.2em; flex-wrap: wrap;
+                    margin: 1em 0; }
+    .side-by-side > div { flex: 1 1 45%; min-width: 420px; }
+    """
+
+    html = f"""<!DOCTYPE html>
+<html><head><meta charset="utf-8">
+<title>Troubleshooting — v2ecoli chromosome-replication gate</title>
+<style>{css}</style></head><body>
+
+<h1>v2ecoli chromosome replication gate &amp; layer-4b architecture — findings</h1>
+<p><em>2026-04-24. Architecture investigation surfaced during BP1993
+merge-prep review.</em></p>
+
+<h2>1. Gate issue found</h2>
+<p>
+The mechanistic-replisome gate at
+<code>chromosome_replication.py:329-332</code> used strict equality:
+</p>
+<pre>initiate_replication = not self.mechanistic_replisome or (
+    np.all(n_replisome_trimers == 6 * n_oriC)
+    and np.all(n_replisome_monomers == 2 * n_oriC)
+)</pre>
+<div class="callout callout-info">
+<strong>Context:</strong> <code>mechanistic_replisome</code> defaults to
+<code>False</code> (permissive mode, matches <code>LoadSimData</code>'s
+default). With the default config, the
+<code>not self.mechanistic_replisome</code> short-circuit makes the gate
+trivially True whenever mass threshold is crossed, and the
+<code>==</code> vs <code>&gt;=</code> distinction doesn't matter — re-init
+fires on the Donachie criterion alone. This is why controlled multigen
+runs divide correctly in v2ecoli at the default config: the strict-equality
+gate was simply never being evaluated.
+</div>
+<p>
+Once <code>mechanistic_replisome=True</code> is set (required for any
+analysis that wants to observe subunit competition — e.g., the Figure 2
+uncontrolled-plasmid runs), the gate <em>is</em> evaluated, and the
+problem emerges. <code>counts(states["bulk"], ...)</code> in v2ecoli
+returns the raw total bulk count — chromosome and plasmid replication
+sit in layer 4b (<code>generate.py:84-87</code>), outside the main
+allocator's partition path. Against raw bulk counts routinely in the
+10s–100s, a strict <code>==</code> against the exact request (12 trimers
+/ 4 monomers for 2 oriCs) is effectively unsatisfiable — so the
+mechanistic gate is locked "off" any tick where subunit counts aren't
+precisely at the request value. In practice that is every tick,
+forever. Chromosome re-initiation never fires once
+<code>mechanistic_replisome=True</code>.
+</p>
+
+<h2>2. Controlled experiment — <code>==</code> gate with no plasmids, no contention</h2>
+<p>
+To isolate the gate-semantics problem from any plasmid or contention
+effects, we ran a single-generation mechanistic simulation with
+<strong>zero plasmids</strong> and the strict <code>==</code> gate
+restored
+(<code>mechanistic_replisome=True</code>, BP1993 irrelevant because no
+plasmids are present, cache rebuilt after regenerating the ParCa
+fixture via <code>scripts/parca_run.py&nbsp;--mode&nbsp;full</code> so
+all configs including <code>ecoli-polypeptide-elongation</code> are
+wired).
+</p>
+<div>
+{strict_gate_svg}
+</div>
+<p class="figcap">
+No plasmids, single generation, strict-equality <code>==</code> gate.
+(E) Chromosome active replisomes: the inherited round terminates at
+t≈22 min → 0, and <strong>stays at 0 for the remaining 20 min</strong>.
+No re-initiation event fires. (F) Cell mass crosses the 2-oriC
+threshold (1950 fg) at t≈29 min — <strong>the mass gate is satisfied,
+but the subunit gate isn't</strong>, because bulk subunit counts never
+precisely equal the per-request value of 12 trimers / 4 monomers.
+</p>
+<div class="callout callout-good">
+<strong>This is the definitive test.</strong> With no plasmids at all,
+no competition for subunits, and all replisome subunits abundant
+(<code>pol_core</code>≈500, <code>β-clamp</code>≈200, etc.), the
+<code>==</code> gate still prevents chromosome re-initiation. The gate
+is mathematically unsatisfiable against raw bulk counts whenever the
+per-tick subunit count isn't precisely at the request value — which is
+almost always. The cell divides at
+<code>t&nbsp;=&nbsp;42.0 min</code> on mass-trigger alone, but with 0
+active replisomes — a broken lineage state from which gen 2 would start
+stuck in the same condition.
+</div>
+<p>
+Under vEcoli's allocator, the three-phase Requester → Allocator →
+Evolver pattern would deliver <em>exactly</em> the requested
+<code>12 trimers / 4 monomers</code> to chromosome — so <code>==</code>
+would pass against the allocator-partitioned values. That's why the
+<code>==</code> operator was originally chosen in the code. When the
+replication processes were moved out of the allocator into the
+standalone layer-4b simplification, the operator should have been
+switched to <code>≥</code> to reflect the new semantic (raw bulk reads
+rather than partitioned deliveries). The corrected operator finally
+does that.
+</p>
+
+<h2>3. The patch</h2>
+<p>
+Changed <code>==</code> to <code>&gt;=</code> at
+<code>chromosome_replication.py:329-332</code> so the gate matches its
+own documented intent ("there are enough replisome subunits"):
+</p>
+<pre>initiate_replication = not self.mechanistic_replisome or (
+    np.all(n_replisome_trimers &gt;= 6 * n_oriC)
+    and np.all(n_replisome_monomers &gt;= 2 * n_oriC)
+)</pre>
+<p>
+Validation: a controlled mechanistic single-gen run shows chromosome
+re-initiation firing within 1&nbsp;fg of the mass threshold
+(<code>cell_mass = 1950.6</code> vs threshold <code>2 × 975 = 1950</code>
+fg), producing the expected <code>n_active_replisomes: 0 → 4</code>
+transition and division on schedule.
+</p>
+
+<h2>4. Post-patch behavior under uncontrolled plasmid load (1 seed, BP1993 off)</h2>
+<div>
+{plot_svg}
+</div>
+<p class="figcap">
+(A) Plasmid copy number 1 → 3254 across 42 min — runaway reproduces
+cleanly. (B) Chromosome active replisomes: inherited round terminates
+at t ≈ 22 min, then <strong>re-initiation fires cleanly at t ≈ 30 min
+(0 → 4)</strong> the moment <code>cell_mass</code> crosses
+<code>n_oriC × 975 = 1950</code> fg. (C) DnaG oscillates 0↔8 on a
+~6-tick sawtooth (plasmid-replisome round-time) rather than sustained
+depletion; any mass-threshold crossing will eventually coincide with a
+DnaG crest and let the chromosome gate pass.
+</p>
+
+<h2>5. The chromosome re-init is an artifact of sequential execution — not competition</h2>
+<p>
+Layer 4b in <code>generate.py:84-87</code> is a flat list:
+</p>
+<pre>['ecoli-complexation', 'ecoli-chromosome-replication',
+ 'ecoli-plasmid-replication',
+ 'ecoli-polypeptide-initiation', 'ecoli-transcript-initiation']</pre>
+<p>
+No allocator, no <code>ReconciledStep</code>, no partitioning between
+these processes. In process-bigraph semantics this means they execute
+<strong>sequentially in listed order</strong>, each one reading the
+bulk state left behind by the previous one. Chromosome replication runs
+<em>before</em> plasmid replication every tick.
+</p>
+<div class="callout callout-info">
+<strong>Chromosome and plasmid replication are not competing with each
+other in v2ecoli.</strong> They are two independent processes running
+back-to-back on the same state. Chromosome reads raw bulk at tick start,
+takes what its gate asks for, commits its delta. Plasmid then reads the
+already-reduced bulk and takes what's left. This is an implicit
+<em>priority ordering</em> — determined by the order processes are
+listed in layer 4b — not a model of resource competition. Chromosome
+wins every tick by construction, not by biology.
+</div>
+<p>
+Empirical confirmation from the t=1769→1770 transition (DnaG spike from
+a plasmid-replisome termination release, coincident with the Donachie
+mass-threshold crossing):
+</p>
+<table>
+<tr><th>subunit</th><th>t=1769</th><th>t=1770</th><th>Δ</th></tr>
+<tr><td>DnaG</td><td>8</td><td>0</td><td>−8</td></tr>
+<tr><td>DnaB</td><td>268</td><td>260</td><td>−8</td></tr>
+<tr><td>HolA</td><td>27</td><td>19</td><td>−8</td></tr>
+<tr><td>pol_core</td><td>488</td><td>464</td><td>−24</td></tr>
+<tr><td>β-clamp</td><td>212</td><td>188</td><td>−24</td></tr>
+<tr><td>chromosome active replisomes</td><td>0</td><td>4</td><td>chromosome fired first (listed first in layer 4b)</td></tr>
+<tr><td>plasmid active replisomes</td><td>2</td><td>6</td><td>plasmid took what was left</td></tr>
+</table>
+<p>
+Chromosome consumed 4 DnaG (gate request for 2 oriCs × 2 replisomes).
+Plasmid then saw DnaG=4, capped <code>max_new_replisomes</code> at 4,
+consumed the remaining 4. Had layer 4b listed plasmid before chromosome,
+the outcome would invert: plasmid would have taken all 8 DnaG, chromosome
+would have seen 0, and re-init would never have fired. The outcome is
+purely list-order, not subunit arithmetic.
+</p>
+
+<h2>6. Comparison with vEcoli mechanistic behaviour (under allocator)</h2>
+<img class="embedded" src="{fig2_datauri}" alt="vEcoli mechanistic uncontrolled-plasmid behaviour under allocator"/>
+<p class="figcap">
+Representative mechanistic phenotype under vEcoli-style allocator-based
+resource partitioning: plasmid runaway (A, 1 → ~4000 across 10 seeds),
+chromosome active replisomes drop to 0 after the inherited round
+terminates and never re-initiate (C), and DnaG drops to near-zero while
+the other five replisome subunits stay abundant (E). The arrest-and-DnaG-
+depletion signature is exactly what a proportional-fairness allocator
+produces in this regime.
+</p>
+<p>
+In vEcoli, partitioned processes compete for bulk via the
+Requester → Allocator → Evolver pattern: each process submits a
+request, and the allocator distributes available bulk proportionally to
+total demand. Under uncontrolled plasmid load, chromosome's request for
+4 DnaG is dwarfed by plasmid's ~2000 — so chromosome receives
+<code>(4 / 2004) × 8 ≈ 0.016 DnaG</code>, well below the mechanistic
+gate threshold, and never re-initiates. That is the biology this
+panel is really testing: <strong>what does mechanistic competition
+between chromosome and plasmid replication look like when subunits are
+fairly partitioned?</strong> The answer is sustained chromosome arrest
+under runaway plasmid load.
+</p>
+<p>
+Under post-patch v2ecoli, chromosome re-initiation fires anyway
+(§4-§5) because layer 4b's sequential-priority execution never forces
+chromosome to compete proportionally — it simply takes what it wants
+before plasmid runs. To reproduce this vEcoli allocator-driven
+phenotype in v2ecoli, the reconciled-replication refactor (§8) is
+needed.
+</p>
+
+<h2>7. Competition semantics: vEcoli vs. v2ecoli</h2>
+<p>
+vEcoli models real competition with the
+Requester → Allocator → Evolver pattern on <code>PartitionedProcess</code>
+instances. Each process submits a request; the allocator partitions the
+available bulk <em>proportionally to total demand</em>. Under
+uncontrolled plasmid load:
+</p>
+<table>
+<tr><th>Architecture</th><th>DnaG allocation with chromosome demand ≈ 4, plasmid demand ≈ 2000, available = 8</th></tr>
+<tr><td>vEcoli partitioned + allocator</td>
+    <td>Chromosome share = (4 / 2004) × 8 ≈ 0.016 DnaG. Below gate threshold → chromosome fails → arrest.</td></tr>
+<tr><td>v2ecoli layer-4b sequential</td>
+    <td>Chromosome (listed first) takes 4 DnaG outright. Plasmid takes remaining 4. Chromosome wins every time.</td></tr>
+</table>
+<p>
+These are fundamentally different mechanisms. vEcoli models
+<em>competition</em> (fairness-weighted shares). v2ecoli models
+<em>priority</em> (first-in-list-wins). The outputs can look similar or
+wildly different depending on the regime; they're not interchangeable.
+</p>
+
+<h2>8. Path forward — reconciled replication layer</h2>
+<p>
+v2ecoli already ships a <code>ReconciledStep</code>
+(<code>v2ecoli/steps/reconciled.py</code>) that implements the same
+proportional-fairness math as vEcoli's allocator, packaged as a single
+Step instead of the three-step Requester/Allocator/Evolver chain. It's
+currently used for RNA degradation (<code>reconciled_2</code>) and
+elongation (<code>reconciled_3</code>) — but not replication.
+<code>generate_reconciled.py</code> doesn't even import
+<code>PlasmidReplication</code>.
+</p>
+<div class="callout">
+<strong>Blocker:</strong> <code>ReconciledStep</code> asserts
+<code>isinstance(p, PartitionedProcess)</code> at line 176. Both
+replication processes are currently plain Steps:
+<code>ChromosomeReplication(Step)</code> and
+<code>PlasmidReplication(Step)</code>. They do not expose the
+<code>calculate_request()</code> / <code>evolve_state()</code> split
+that <code>ReconciledStep</code> needs. They'd need to be refactored
+back into <code>PartitionedProcess</code> form before they can be wired
+into a reconciled layer.
+</div>
+<p>
+Required steps to enable reconciled replication:
+</p>
+<ol>
+<li>Refactor <code>ChromosomeReplication</code> and
+    <code>PlasmidReplication</code> from <code>Step</code> back to
+    <code>PartitionedProcess</code>, splitting the current
+    <code>update()</code> into <code>calculate_request(timestep, states)</code>
+    (what subunits does each process want?) and
+    <code>evolve_state(timestep, proc_states)</code> (given what was
+    allocated, do the work). Plasmid's BP1993 ODE integration in
+    <code>_prepare()</code> needs to be placed carefully — it's stateful
+    and reads/writes <code>plasmid_rna_control</code>.</li>
+<li>Create a new <code>reconciled_replication</code> layer in
+    <code>generate_reconciled.py</code> that groups chromosome and
+    plasmid replication. Add the missing
+    <code>PlasmidReplication</code> import.</li>
+<li>Validate: controlled regime should still divide to ~28 cpc;
+    uncontrolled regime under reconciled layer should now model genuine
+    DnaG competition — chromosome proportionally starved when plasmid
+    demand dominates.</li>
+</ol>
+<p>
+Estimated effort: 2–4 days of careful work. Notes captured in memory
+<code>project_v2ecoli_reconciled_replication_task.md</code>.
+</p>
+
+<h2>9. Separate issue — DnaG-limiting dynamics across generations</h2>
+<p>
+Distinct from the gate-semantics problem above, this section documents
+a DnaG-supply observation surfaced while validating the patched gate
+across generations. It is unrelated to the <code>==</code>/<code>≥</code>
+architecture fix — the behavior shows up even under the corrected
+<code>≥</code> gate. Flagged separately because it touches
+<code>metabolism.aa_enzymes</code>-dependent protein synthesis rates and
+DnaG expression calibration, not layer-4b partitioning.
+</p>
+<div>
+{multigen_svg}
+</div>
+<p class="figcap">
+No-plasmid lineage, 7 generations, patched <code>≥</code> gate. (D)
+Chromosome active replisomes across the lineage — gens 1–4 follow the
+normal 2→0→4 pattern (termination, then re-init post-mass-threshold),
+gen 5 <strong>fails to re-initiate</strong> (inherited round terminates,
+no new round fires before division), gens 6–7 then <strong>adaptively
+downshift to 1-oriC mode</strong> (daughter of gen 5 has 1 chromosome
+and 0 forks; mass is already above the 1-oriC threshold of 975 fg at
+birth, so re-init fires immediately at t≈1s each gen). Cell mass (lower
+panel) shows the adaptation: peaks cluster around the 2-oriC threshold
+for gens 1–5 and around the 1-oriC threshold for gens 6–7.
+</p>
+<div class="callout callout-info">
+<strong>DnaG bulk is 0 across every tick of every generation — all
+available DnaG is sequestered in bound replisomes.</strong> Re-init
+only fires when a transient DnaG synthesis event releases a molecule
+that the chromosome gate catches in the same tick. Gens 1–4 squeak
+through; gen 5 misses; gens 6–7 succeed because the 1-oriC regime
+needs only <code>2 × 1 = 2</code> DnaG rather than
+<code>2 × 2 = 4</code>, which is stochastically easier to satisfy.
+</div>
+<p>
+This matches the spirit of the submitted proposal's claim that
+"<em>DnaG is not maintained at the level required for re-initiation
+across multiple generations even in the absence of plasmids</em>" —
+the first failure emerges at gen 5 — but the lineage does not
+collapse. It adapts down to a lower-oriC regime where the
+mechanistic-subunit demand is smaller. A genuine lineage collapse
+would need either sustained 1-oriC-insufficiency or a further
+perturbation.
+</p>
+<p>
+Implication for Aim 1a: DnaG expression and turnover
+recalibration is still a legitimate item — not because the gate was
+broken (that's fixed), but because DnaG bulk levels leave essentially
+no headroom above the mechanistic gate threshold, making re-init
+stochastically fragile. Tuning DnaG synthesis rate against
+quantitative-proteomics references (e.g., a 2–3× increase consistent
+with literature measurements of primase abundance) would restore
+robust 2-oriC multigen dynamics without requiring architectural
+changes.
+</p>
+"""
+
+    os.makedirs(os.path.dirname(OUT_HTML), exist_ok=True)
+    with open(OUT_HTML, "w") as f:
+        f.write(html)
+    print(f"wrote {OUT_HTML}")
+    print(f"  source: {SMOKE_JSON}")
+    print(f"  terminated: t={term_t}s; re-init: t={reinit_t}s, cell_mass={reinit_mass:.0f} fg")
+    print(f"  plasmids 1 -> {n_plasmids[-1]}, divided at {divided_at/60:.1f} min")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Consolidated **infrastructure** snapshot from `feat/aim2-dnaa-oric` (the canonical DnaA investigation line that generated `investigation-dnaa-replication-2026-06-05-7`). These are the general v2ecoli engine / ParCa / test changes the investigation depends on, split out and prepared to merge into `main`.

The ongoing investigation artifacts (studies, feedback rounds, reports, dnaa analysis scripts) ship in a **stacked Draft PR** off this branch: `investigation/dnaa-replication-v3`.

## Scope (58 files)
- `v2ecoli/` engine: `core.py`, `library/*` (division, schema, sim_data, initial_conditions, …), `composites/{baseline,_helpers}.py`, `processes/{chromosome_replication,equilibrium}.py`, ParCa dataclasses/steps + non-plasmid flat TSVs, `steps/{allocator,division}.py`, `cli/parca.py`, `types`.
- General run/compare scripts, `tests/`, `uv.lock`, `pyproject.toml`, `workspace.yaml`, `models/parca/*`.

## Plasmid handling
The standalone plasmid **investigation** (plasmid_replication process, plasmids composite, plasmid scripts/reports — 17 files) is **excluded**; it ships via its own branch. Plasmid **plumbing** that aim2 wove into shared ParCa/library files is retained but **dormant** (`has_plasmid=False` default; the plasmid process is de-wired from every composite). The two plasmid flat-data files are kept so `knowledge_base_raw` loads consistently.

## ⚠️ Reviewer attention
The ParCa flat-file **parameter** changes need a human eye — confirm they are intended permanent calibration, not investigation-only overrides:
- `transcription_units_removed.tsv` (TU00434/35 removal)
- `equilibrium_reactions.tsv`, `equilibrium_reaction_rates.tsv`
- `per_promoter_ratios.tsv`

## Verification
- `tests/test_composites_baseline.py` → **3 passed** (fixture cache rebuilt to match this code).
- `KnowledgeBaseEcoli` raw load (plasmid fasta + dna_sites) → OK.

Co-authored with @RashmiKaldera.

🤖 Generated with [Claude Code](https://claude.com/claude-code)