### PR TITLE
ci: skip building vivarium-dashboard in test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,11 @@ jobs:
         run: uv python install 3.12.9
 
       - name: Install dependencies (PyPI only)
-        run: uv sync --extra dev || uv sync
+        # vivarium-dashboard's wheel build fails under strict hatchling; the
+        # upstream fix requires bigraph-schema>=1.4.1 (a core bump we're
+        # deferring). It isn't imported by the test suite (testpaths=tests),
+        # so skip building it here.
+        run: uv sync --extra dev --no-install-package vivarium-dashboard || uv sync --no-install-package vivarium-dashboard
 
       - name: Run fast tests (no .run() calls)
         # -n auto: pytest-xdist parallelism (~4 workers on ubuntu-latest).
@@ -67,7 +71,11 @@ jobs:
         run: uv python install 3.12.9
 
       - name: Install dependencies (PyPI only)
-        run: uv sync --extra dev || uv sync
+        # vivarium-dashboard's wheel build fails under strict hatchling; the
+        # upstream fix requires bigraph-schema>=1.4.1 (a core bump we're
+        # deferring). It isn't imported by the test suite (testpaths=tests),
+        # so skip building it here.
+        run: uv sync --extra dev --no-install-package vivarium-dashboard || uv sync --no-install-package vivarium-dashboard
 
       # Cache out/cache (initial_state.json + sim_data_cache.dill +
       # cache_version.json) across PRs. The cache key pins to the same


### PR DESCRIPTION
## Problem

The `fast-tests` / `behavior-tests` jobs fail at the **dependency-install** step (not in our tests) — building the `vivarium-dashboard` wheel:

```
hatchling.build.build_wheel → ValueError: A second file is being added to the wheel archive at the [same path]
```

The pinned `vivarium-dashboard` commit (`7c06cb2`) has a duplicate `static/templates` force-include that a **newer hatchling now rejects**. main's CI stays green only via a build-cache hit; any PR that changes `uv.lock` (e.g. #138) gets a cache miss → fresh wheel build → this failure. So it's a latent, workspace-wide breakage, not specific to any one PR.

## Why not just bump the pin

The fix exists upstream (vivarium-dashboard `cf3e1da`, "drop duplicate static/templates force-include"), but it sits on top of the `bigraph-loom` refactor + **`bigraph-schema>=1.4.1`** bump. Bumping vivarium-dashboard therefore forces a `bigraph-schema` major bump (and a new `bigraph-loom` dep) — a core change we're deferring (it would need full ParCa/parity re-validation). There's no intermediate commit with the wheel fix but the old bigraph-schema.

## Fix

`vivarium-dashboard` is **not imported by the test suite** (`testpaths = ["tests"]`; the only in-package reference is a docstring in `sqlite_run.py` — real usage is in standalone tooling scripts). So skip building it in the two test jobs:

```
uv sync --extra dev --no-install-package vivarium-dashboard || uv sync --no-install-package vivarium-dashboard
```

No version bumps, no `bigraph-schema` risk, reversible. Validated via `uv sync … --dry-run` (resolves cleanly, vivarium-dashboard excluded, no build).

## Follow-up

The real resolution is adopting the newer workspace baseline (`bigraph-schema>=1.4.1` + latest vivarium-dashboard + `bigraph-loom`) — out of scope here. Unblocks #138 (and any future lockfile-touching PR) once merged + rebased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)