### PR TITLE
Native process-bigraph Analyses: abstraction + runner + 5 vEcoli ports

### DIFF
--- a/docs/superpowers/notes/2026-06-08-analyses-parity-findings.md
+++ b/docs/superpowers/notes/2026-06-08-analyses-parity-findings.md
@@ -90,3 +90,26 @@ API-compatible with vEcoli's (it is the same class, fork-evolved in sync).
 | **D — `active_RNAP`** | `len(listeners__rnap_data__active_rnap_unique_indexes)` as an extra derived column (DuckDB: `array_length(...)` or `len(...)`). |
 
 Shims A–D can all be encapsulated in a thin `read_outputs_v2` adapter function in the ported modules (or in a shared helper imported by Tasks 5–7), keeping the main analysis logic unchanged.
+
+---
+
+## CORRECTION (2026-06-08, during Task 6) — sim_data ↔ parquet pairing
+
+The reference parquet `out/compare_harness/v2_sim/parquet/two_generations/` was
+generated with **`out/workflow/simData.cPickle`** (2820 `base_reaction_ids`), **not**
+`out/kb/simData.cPickle` (2821). The two differ: their `base_reaction_ids` diverge at
+index 133 (not a tail drop), though their `bulk_data["id"]` arrays are byte-identical
+(16321 each). Consequences:
+
+- **Use `out/workflow/simData.cPickle` for all smoke tests** against this parquet
+  (Tasks 7–10), and as the paired sim_data generally.
+- ptools_rxns aligns FBA fluxes 1:1 with `base_reaction_ids` (the listener emits one
+  flux per id, in order) and now **asserts** `len(base_reaction_ids) == flux_width`,
+  failing loudly on a mismatched sim_data instead of truncating. The earlier
+  truncation against the 2821-id sim_data would have mislabeled ~2687 reactions.
+- ptools_rna / ptools_proteins are **bulk/RNA-based**; bulk ids are identical across
+  the two sim_datas, so they're unaffected by the reaction-count mismatch.
+- The runner's `resolve_sim_data` must return the sim_data **paired** with the sweep.
+  For a real dashboard sweep the paired parca output is co-located; the compare_harness
+  layout is a test artifact where the paired sim_data is `out/workflow/simData.cPickle`
+  (handle in Task 10).

--- a/docs/superpowers/notes/2026-06-08-analyses-parity-findings.md
+++ b/docs/superpowers/notes/2026-06-08-analyses-parity-findings.md
@@ -113,3 +113,18 @@ index 133 (not a tail drop), though their `bulk_data["id"]` arrays are byte-iden
   For a real dashboard sweep the paired parca output is co-located; the compare_harness
   layout is a test artifact where the paired sim_data is `out/workflow/simData.cPickle`
   (handle in Task 10).
+
+---
+
+## SYSTEMIC FINDING (2026-06-08, during Task 8) — wholecell ↔ matplotlib 3.10
+
+The vendored `wholecell` plotting utilities (e.g. `wholecell.utils.voronoi_plot_main`)
+have several incompatibilities with the installed matplotlib 3.10:
+- `Polygon(xy, True)` — `closed` is now keyword-only;
+- `_add_labels` / `_compute_error` recurse on `[label, site]` leaf pairs (list-vs-pair bug).
+
+`mass_fraction_voronoi` works around these with import-time monkeypatches scoped to the
+voronoi module. This will recur across MANY of the ~43 plot ports in the bulk-port spec.
+**Recommendation for Spec 2:** centralize a single `wholecell` compat shim (one module,
+applied once) or fix `wholecell` upstream, rather than per-analysis monkeypatches. Treat
+this as a known plot-port prerequisite.

--- a/docs/superpowers/notes/2026-06-08-analyses-parity-findings.md
+++ b/docs/superpowers/notes/2026-06-08-analyses-parity-findings.md
@@ -1,0 +1,92 @@
+# Analyses Parity Findings — 2026-06-08
+
+Discovery task: confirm what `sim_data` attributes and parquet columns the five
+proving-set analyses require, and whether they exist in v2ecoli's outputs.
+
+Reference parquet:
+`out/compare_harness/v2_sim/parquet/two_generations/history/experiment_id=two_generations/variant=0/lineage_seed=0/generation=0/agent_id=0/800.pq`
+
+Reference sim_data pickle: `out/kb/simData.cPickle`
+
+---
+
+## 1. Parquet columns — present / missing
+
+### Present (all five analyses can use these directly)
+
+| Column | Used by |
+|---|---|
+| `listeners__rna_counts__full_mRNA_counts` | ptools_rna, ptools_rxns (default), ptools_proteins (default) |
+| `listeners__fba_results__base_reaction_fluxes` | ptools_rxns, central_carbon_metabolism_scatter |
+| `listeners__mass__rna_mass` | mass_fraction_voronoi |
+| `listeners__mass__protein_mass` | mass_fraction_voronoi |
+| `listeners__mass__tRna_mass` | mass_fraction_voronoi |
+| `listeners__mass__rRna_mass` | mass_fraction_voronoi |
+| `listeners__mass__mRna_mass` | mass_fraction_voronoi |
+| `listeners__mass__dna_mass` | mass_fraction_voronoi |
+| `listeners__mass__smallMolecule_mass` | mass_fraction_voronoi |
+| `listeners__mass__cell_mass` | central_carbon_metabolism_scatter |
+| `listeners__mass__dry_mass` | central_carbon_metabolism_scatter |
+
+### Missing — require shims
+
+| vEcoli column | v2ecoli equivalent | Notes |
+|---|---|---|
+| `bulk` | `bulk__id` + `bulk__count` | v2ecoli splits the struct into two parallel arrays. The ptools analyses call `np.stack(output_df["bulk"].values)` to get an `(n_timepoints, n_bulk_molecules)` matrix. Shim: join on `sim_data.internal_state.bulk_molecules.bulk_data["id"]` to produce the positionally-ordered count array. **Key constraint**: `bulk__id` order in the parquet may not match `sim_data` bulk order, so the shim must reindex. |
+| `listeners__unique_molecule_counts__active_ribosome` | `list_sum(listeners__ribosome_data__n_ribosomes_per_transcript)` | v2ecoli has no `unique_molecule_counts` listener. `n_ribosomes_per_transcript` is a per-transcript count array; its sum per row = active ribosome count. Verified: sum ≈ 14 857 at one timestep — plausible. |
+| `listeners__unique_molecule_counts__oriC` | `listeners__replication_data__number_of_oric` | Direct scalar replacement; same semantics. Verified present (value = 2 at one timestep). |
+| `listeners__unique_molecule_counts__active_RNAP` | `len(listeners__rnap_data__active_rnap_unique_indexes)` | `active_rnap_unique_indexes` is an `INTEGER[]`; its length per row = number of active RNAPs. Verified: 870 at one timestep — plausible. |
+
+---
+
+## 2. sim_data attributes — present / missing
+
+All probed attributes are **present**. v2ecoli's `SimulationDataEcoli` object is
+API-compatible with vEcoli's (it is the same class, fork-evolved in sync).
+
+| Attribute path | Status | Used by |
+|---|---|---|
+| `process.transcription.rna_data` | OK | ptools_rna |
+| `process.transcription.rna_maturation_stoich_matrix` | OK | ptools_rna |
+| `process.transcription.mature_rna_data` | OK | ptools_rna |
+| `process.transcription.uncharged_trna_names` | OK | ptools_rna |
+| `process.transcription.charged_trna_names` | OK | ptools_rna |
+| `process.complexation.get_monomers` | OK | ptools_rna, ptools_proteins |
+| `internal_state.bulk_molecules.bulk_data` | OK | ptools_rna, ptools_proteins |
+| `molecule_groups.s50_23s_rRNA` | OK | ptools_rna |
+| `molecule_groups.s30_16s_rRNA` | OK | ptools_rna |
+| `molecule_groups.s50_5s_rRNA` | OK | ptools_rna |
+| `process.metabolism.base_reaction_ids` | OK | ptools_rxns |
+| `process.translation.monomer_data` | OK | ptools_proteins |
+| `molecule_groups.replisome_monomer_subunits` | OK | ptools_proteins |
+| `molecule_groups.replisome_trimer_subunits` | OK | ptools_proteins |
+| `molecule_ids.s30_full_complex` | OK | ptools_proteins |
+| `molecule_ids.s50_full_complex` | OK | ptools_proteins |
+| `molecule_ids.full_RNAP` | OK | ptools_proteins |
+| `constants.n_avogadro` | OK | mass_fraction_voronoi |
+| `getter.get_masses` | OK | mass_fraction_voronoi |
+| `getter.get_mass` | OK | mass_fraction_voronoi |
+| `constants.cell_density` | OK | central_carbon_metabolism_scatter |
+
+---
+
+## 3. Per-analysis verdict
+
+| Analysis | Scale | Verdict | Notes |
+|---|---|---|---|
+| `ptools_rna` | single | **port with shims A+B** | Needs `bulk` shim (A) and `unique_molecule_counts__active_ribosome` shim (B). All sim_data attributes present. |
+| `ptools_rxns` | single | **port as-is** | Only needs `bulk` (for default `read_outputs` signature — actually only uses `listeners__fba_results__base_reaction_fluxes` in its main body) and `listeners__fba_results__base_reaction_fluxes`. The latter is present; `bulk` appears only in the shared `read_outputs` default but is not used in `ptools_rxns` main logic. However if `bulk` is passed as a literal column it will fail — shim A still needed if the `read_outputs` helper is called with default columns. **Recommendation**: port as-is, calling `read_outputs` with an explicit `columns=["listeners__fba_results__base_reaction_fluxes"]` rather than the default. |
+| `ptools_proteins` | single | **port with shims A+C+D** | Needs `bulk` shim (A), `oriC` shim (C: `listeners__replication_data__number_of_oric`), and `active_RNAP` shim (D: `len(active_rnap_unique_indexes)`). Also needs `active_ribosome` shim (B). All sim_data attributes present. |
+| `mass_fraction_voronoi` | single | **port as-is** | All seven `listeners__mass__*` columns present. Uses `sim_data.constants.n_avogadro`, `getter.get_masses/get_mass` — all present. No `bulk` or `unique_molecule_counts` needed. |
+| `central_carbon_metabolism_scatter` | multiseed | **port as-is** | `listeners__fba_results__base_reaction_fluxes`, `listeners__mass__cell_mass`, `listeners__mass__dry_mass` all present. `sim_data.constants.cell_density` present. `sim_data.process.metabolism.base_reaction_ids` present. No missing columns. |
+
+### Shim summary (for Tasks 5–7)
+
+| Shim | Implementation |
+|---|---|
+| **A — `bulk` column** | After `read_outputs`, reconstruct positional count matrix: for each row, build a dict `{id: count}` from `bulk__id`/`bulk__count`, then reindex against `sim_data.internal_state.bulk_molecules.bulk_data["id"]`. Return as `ndarray` to match `np.stack(output_df["bulk"].values)` usage. |
+| **B — `active_ribosome`** | `list_sum(listeners__ribosome_data__n_ribosomes_per_transcript)` as an extra derived column in the SELECT. |
+| **C — `oriC`** | Alias `listeners__replication_data__number_of_oric` → `listeners__unique_molecule_counts__oriC`. |
+| **D — `active_RNAP`** | `len(listeners__rnap_data__active_rnap_unique_indexes)` as an extra derived column (DuckDB: `array_length(...)` or `len(...)`). |
+
+Shims A–D can all be encapsulated in a thin `read_outputs_v2` adapter function in the ported modules (or in a shared helper imported by Tasks 5–7), keeping the main analysis logic unchanged.

--- a/docs/superpowers/plans/2026-06-08-vecoli-analyses-as-pbg-analyses.md
+++ b/docs/superpowers/plans/2026-06-08-vecoli-analyses-as-pbg-analyses.md
@@ -1,0 +1,932 @@
+# vEcoli Analyses as Native Process-Bigraph Analyses — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a native, Visualization-like `Analysis` abstraction to v2ecoli and port a 5-analysis proving set (3 ptools + 2 plots) from vEcoli's DuckDB/`sim_data` analyses, surfaced in the vivarium-dashboard Visualizations tab.
+
+**Architecture:** A new `Analysis(V2Step)` sits *alongside* the existing record-based `AnalysisStep` (which keeps the 5 working native analyses untouched). `Analysis` declares DuckDB `conn` + `history_sql` + `sim_data` input ports and emits `{view: html, data: map}`. The post-sweep runner gains a provisioning path that opens one DuckDB connection over the sweep's parquet, builds a scale-scoped `history_sql`, loads `sim_data` once, runs each `Analysis`, and writes `data → analysis.json`/TSV and `view → <sweep>/viz/*.html`. The dashboard already surfaces `<study>/viz/*.html`; one small server edit also lists `Analysis` classes in the viz picker.
+
+**Tech Stack:** Python 3.12, process-bigraph (`V2Step`/`Step`), DuckDB, pandas, matplotlib, pytest. Run everything via `.venv/bin/python` / `.venv/bin/pytest` (per repo memory: bare `python` lacks `unum`).
+
+**Spec:** `docs/superpowers/specs/2026-06-08-vecoli-analyses-as-pbg-analyses-design.md`
+
+**Spec refinements locked in this plan** (discovered while grounding):
+1. **Add-alongside, not evolve-in-place.** `analysis.py` already has *5* record-based analyses (`MassFractionSummary`, `DaughterMassSymmetry`, `MassGrowthAcrossGenerations`, `DoublingTimeDistribution`, `MetricAcrossVariants`) using `analyze(rows)`. Evolving the base in place would break them. So `Analysis` is a **new sibling base**; `AnalysisStep` stays. Both register into the shared `ANALYSIS_REGISTRY`; the runner dispatches by base class.
+2. **Proving set adjusted to avoid a registry name collision.** The spec named `mass_fraction_summary` as the 4th analysis, but that name is already taken by the existing record-based Step. The view/matplotlib proof uses **`mass_fraction_voronoi`** (single scale, vEcoli plot, no collision) instead. 5th remains **`central_carbon_metabolism_scatter`** (multiseed, cross-cell SQL + matplotlib).
+
+**Source of ports:** `vivarium-ecoli` repo, branch `origin/ptools_viz`, path `ecoli/analysis/<scale>/<name>.py`. Read a file with: `git -C /Users/eranagmon/code/vivarium-ecoli show origin/ptools_viz:ecoli/analysis/single/ptools_rna.py`.
+
+**Cross-implementation oracle:** sms-api checked-in reference TSVs at `/Users/eranagmon/code/sms-api/tests/fixtures/analysis_data/ptools_rna.txt` and `ptools_rxns.txt` (frame-ID × timepoint tables produced by the same vEcoli modules).
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+|---|---|---|
+| `v2ecoli/workflow/analysis.py` | analysis bases + registry | **modify** — add `Analysis` base; keep `AnalysisStep` + the 5 Steps |
+| `v2ecoli/workflow/render.py` | matplotlib-figure → embedded-SVG HTML helper | **create** |
+| `v2ecoli/workflow/analysis_runner.py` | post-sweep runner | **modify** — add DuckDB-provisioning path for `Analysis` steps |
+| `v2ecoli/workflow/analyses/__init__.py` | import-time registration of ported analyses | **create** |
+| `v2ecoli/workflow/analyses/ptools_rna.py` `ptools_rxns.py` `ptools_proteins.py` | single-scale ptools ports (data TSV) | **create** |
+| `v2ecoli/workflow/analyses/mass_fraction_voronoi.py` | single-scale plot port (view) | **create** |
+| `v2ecoli/workflow/analyses/central_carbon_metabolism_scatter.py` | multiseed plot port (view + cross-cell SQL) | **create** |
+| `v2ecoli/configs/analyses_proving.json` | `analysis_options` for the proving set | **create** |
+| `vivarium-dashboard/vivarium_dashboard/server.py` | viz picker lists `Analysis` classes | **modify** |
+| `tests/test_analysis_base.py` | `Analysis` base unit tests | **create** |
+| `tests/test_render.py` | render-helper test | **create** |
+| `tests/test_analysis_runner_duckdb.py` | runner provisioning + scale SQL + end-to-end | **create** |
+| `tests/test_ptools_analyses.py` | ptools port fidelity vs oracle | **create** |
+| `docs/superpowers/notes/2026-06-08-analyses-parity-findings.md` | parity-check output (Task 1) | **create** |
+
+---
+
+### Task 1: Parity check (discovery — gates the ports)
+
+Confirm v2ecoli's `sim_data` and parquet expose what the ptools modules require. Output a findings note that later tasks reference. **No production code in this task.**
+
+**Files:**
+- Create: `docs/superpowers/notes/2026-06-08-analyses-parity-findings.md`
+
+- [ ] **Step 1: List the attributes/columns each ptools module needs**
+
+Run and read the three single-scale sources:
+```bash
+for m in ptools_rna ptools_rxns ptools_proteins; do
+  echo "===== $m ====="; \
+  git -C /Users/eranagmon/code/vivarium-ecoli show origin/ptools_viz:ecoli/analysis/single/$m.py \
+    | grep -nE 'sim_data\.|history_sql|listeners__|read_outputs|output_columns|\.process\.|internal_state|molecule_groups'
+done
+```
+Expected: a concrete list of `sim_data.*` attributes (e.g. `process.transcription.rna_data`, `process.complexation.get_monomers`, `process.transcription.rna_maturation_stoich_matrix`, `molecule_groups.s50_23s_rRNA`, `internal_state.bulk_molecules.bulk_data`) and parquet columns (e.g. `bulk`, `listeners__rna_counts__full_mRNA_counts`, `listeners__unique_molecule_counts__active_ribosome`).
+
+- [ ] **Step 2: Verify the parquet columns exist in a v2ecoli sweep**
+
+Find a recent sweep and inspect history columns:
+```bash
+cd /Users/eranagmon/code/v2ecoli
+SW=$(ls -dt out/*/ 2>/dev/null | head -1); echo "sweep=$SW"
+PQ=$(find "$SW" -path '*history*' -name '*.pq' | head -1); echo "pq=$PQ"
+.venv/bin/python -c "import duckdb,sys; print([c[0] for c in duckdb.sql(f\"DESCRIBE SELECT * FROM read_parquet('$PQ')\").fetchall()])"
+```
+Expected: a column list. Record which required columns are present vs missing.
+
+- [ ] **Step 3: Verify the sim_data attribute tree**
+
+Locate a sim_data pickle in the sweep (or ParCa output) and probe attributes:
+```bash
+cd /Users/eranagmon/code/v2ecoli
+SD=$(find out _parca_cache parca -name 'sim_data*.cPickle' -o -name 'sim_data*.pkl' 2>/dev/null | head -1); echo "sim_data=$SD"
+.venv/bin/python - "$SD" <<'PY'
+import sys, pickle
+sd = pickle.load(open(sys.argv[1],'rb'))
+for path in ["process.transcription.rna_data",
+             "process.transcription.rna_maturation_stoich_matrix",
+             "process.complexation.get_monomers",
+             "molecule_groups.s50_23s_rRNA",
+             "internal_state.bulk_molecules.bulk_data"]:
+    obj = sd
+    try:
+        for p in path.split("."): obj = getattr(obj, p)
+        print("OK  ", path, type(obj).__name__)
+    except Exception as e:
+        print("MISS", path, e)
+PY
+```
+Expected: `OK` for each path (v2ecoli's `LoadSimData` is API-compatible with vEcoli). Any `MISS` is a parity gap to record.
+
+- [ ] **Step 4: Write findings + decide per-analysis port viability**
+
+Write `docs/superpowers/notes/2026-06-08-analyses-parity-findings.md` with three sections: **Columns present/missing**, **sim_data attributes present/missing**, **Per-analysis verdict** (each of the 5: "port as-is" | "port with shim X" | "blocked on missing listener Y"). If a required listener column is missing for a ptools module, flag it here — that module's port task adds a column alias if the data exists under another name, or is deferred with a note.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/eranagmon/code/v2ecoli
+git add docs/superpowers/notes/2026-06-08-analyses-parity-findings.md
+git commit -m "docs: sim_data/parquet parity findings for analysis ports"
+```
+
+---
+
+### Task 2: The `Analysis` base (alongside `AnalysisStep`)
+
+**Files:**
+- Modify: `v2ecoli/workflow/analysis.py` (add `Analysis` after the `ANALYSIS_REGISTRY` definition, ~line 41, before `class AnalysisStep`)
+- Test: `tests/test_analysis_base.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_analysis_base.py
+from bigraph_schema import allocate_core
+from v2ecoli.workflow.analysis import Analysis, ANALYSIS_REGISTRY
+
+
+class _Demo(Analysis):
+    name = "demo_analysis"
+    scale = "single"
+
+    def analyze(self, *, conn, history_sql, sim_data, **ctx):
+        return {"view": "<p>ok</p>", "data": {"n": 1}}
+
+
+def test_analysis_registers_and_dispatches():
+    assert ANALYSIS_REGISTRY["demo_analysis"] is _Demo
+    step = _Demo({}, core=allocate_core())
+    out = step.update({"conn": None, "history_sql": "SELECT 1", "sim_data": None})
+    assert out == {"view": "<p>ok</p>", "data": {"n": 1}}
+
+
+def test_analysis_defaults_missing_keys():
+    class _Bare(Analysis):
+        name = "bare_analysis"
+        scale = "single"
+
+        def analyze(self, **ctx):
+            return {"data": {"x": 2}}  # no "view"
+
+    step = _Bare({}, core=allocate_core())
+    out = step.update({})
+    assert out == {"view": "", "data": {"x": 2}}
+
+
+def test_analysis_inputs_declare_duckdb_ports():
+    assert set(_Demo({}, core=allocate_core()).inputs()) >= {
+        "conn", "history_sql", "sim_data"}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /Users/eranagmon/code/v2ecoli && .venv/bin/pytest tests/test_analysis_base.py -v`
+Expected: FAIL with `ImportError: cannot import name 'Analysis'`.
+
+- [ ] **Step 3: Add the `Analysis` base**
+
+Insert into `v2ecoli/workflow/analysis.py` immediately after the `ANALYSIS_REGISTRY: dict[str, type] = {}` line:
+
+```python
+class Analysis(V2Step):
+    """Visualization-like analysis: reads sim output via a DuckDB connection +
+    the ParCa ``sim_data``, and emits a rendered ``view`` (HTML) plus optional
+    ``data`` (map). Faithful native ports of vEcoli's ``plot()`` analyses build
+    on this base (cf. the record-based ``AnalysisStep`` for emitted-observable
+    analyses). Subclasses set ``scale`` + ``name`` and implement ``analyze``.
+
+    Live, non-serializable handles (``conn``, ``sim_data``) are injected by the
+    runner into the state dict passed to ``update``; ``inputs()`` declares them
+    for discoverability with a permissive ("any") type.
+    """
+
+    scale: str = "single"
+    config_schema = {}
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        if cls.scale not in ANALYSIS_SCALES:
+            raise ValueError(
+                f"{cls.__name__}.scale={cls.scale!r} not in {sorted(ANALYSIS_SCALES)}")
+        if "name" in cls.__dict__:
+            ANALYSIS_REGISTRY[cls.name] = cls
+
+    def inputs(self):
+        return {
+            "conn": "any", "history_sql": "string",
+            "config_sql": "string", "success_sql": "string",
+            "sim_data": "any", "validation_data": "any",
+            "variant_metadata": "any",
+        }
+
+    def outputs(self):
+        return {"view": "string", "data": "map"}
+
+    def analyze(self, *, conn, history_sql, sim_data, **ctx) -> dict:
+        """Return {"view": <html str>, "data": <map>} (either key optional)."""
+        raise NotImplementedError
+
+    def invoke(self, state, interval=None):
+        # Fail loudly (like AnalysisStep): a broken analyze() must surface.
+        return SyncUpdate(self.update(state))
+
+    def update(self, state, interval=None):
+        kwargs = {k: state.get(k) for k in self.inputs()}
+        out = self.analyze(**kwargs) or {}
+        return {"view": out.get("view", ""), "data": out.get("data", {})}
+```
+
+Note: `Analysis` and `AnalysisStep` share `ANALYSIS_REGISTRY`; the runner (Task 4) dispatches by `issubclass(step_cls, Analysis)`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /Users/eranagmon/code/v2ecoli && .venv/bin/pytest tests/test_analysis_base.py -v`
+Expected: PASS (3 passed).
+
+- [ ] **Step 5: Confirm the existing analyses still register**
+
+Run: `.venv/bin/pytest tests/test_workflow_analysis.py -v`
+Expected: PASS (the 5 record-based Steps unchanged).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add v2ecoli/workflow/analysis.py tests/test_analysis_base.py
+git commit -m "feat: Analysis base (duckdb/sim_data ports, view+data outputs)"
+```
+
+---
+
+### Task 3: Matplotlib → embedded-SVG render helper
+
+**Files:**
+- Create: `v2ecoli/workflow/render.py`
+- Test: `tests/test_render.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_render.py
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from v2ecoli.workflow.render import fig_to_html
+
+
+def test_fig_to_html_embeds_svg():
+    fig, ax = plt.subplots()
+    ax.plot([0, 1, 2], [0, 1, 4])
+    html = fig_to_html(fig, title="Demo")
+    assert "<svg" in html
+    assert "Demo" in html
+    assert html.strip().startswith("<")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/test_render.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'v2ecoli.workflow.render'`.
+
+- [ ] **Step 3: Implement the helper**
+
+```python
+# v2ecoli/workflow/render.py
+"""Render helpers for Analysis ``view`` outputs.
+
+``fig_to_html`` turns a matplotlib Figure into a self-contained HTML fragment
+with an inline SVG, so plot-style analyses port near-verbatim from vEcoli (swap
+``fig.savefig(path)`` for ``return {"view": fig_to_html(fig)}``).
+"""
+
+from __future__ import annotations
+
+import io
+
+
+def fig_to_html(fig, title: str = "") -> str:
+    """Serialize a matplotlib Figure to an HTML fragment with inline SVG."""
+    buf = io.StringIO()
+    fig.savefig(buf, format="svg", bbox_inches="tight")
+    svg = buf.getvalue()
+    # Strip the XML/doctype preamble so the <svg> embeds cleanly in HTML.
+    idx = svg.find("<svg")
+    svg = svg[idx:] if idx != -1 else svg
+    heading = f"<h3>{title}</h3>" if title else ""
+    return f'<div class="analysis-view">{heading}{svg}</div>'
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/pytest tests/test_render.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add v2ecoli/workflow/render.py tests/test_render.py
+git commit -m "feat: fig_to_html render helper for Analysis views"
+```
+
+---
+
+### Task 4: Runner DuckDB-provisioning path
+
+Add the provisioning helpers and extend `run_analyses` to dispatch `Analysis` steps through DuckDB while leaving the record-based `AnalysisStep` path unchanged.
+
+**Files:**
+- Modify: `v2ecoli/workflow/analysis_runner.py`
+- Test: `tests/test_analysis_runner_duckdb.py`
+
+- [ ] **Step 1: Write the failing test for `scale_history_sql`**
+
+```python
+# tests/test_analysis_runner_duckdb.py
+from v2ecoli.workflow.analysis_runner import scale_history_sql
+
+_FROM = "read_parquet(['x.pq'], hive_partitioning=true)"
+
+
+def test_single_sql_filters_full_cell():
+    sql = scale_history_sql("single", _FROM, (0, 1, 2, "00"))
+    assert "variant = 0" in sql and "lineage_seed = 1" in sql
+    assert "generation = 2" in sql and "agent_id = '00'" in sql
+
+
+def test_multiseed_sql_filters_variant_only():
+    sql = scale_history_sql("multiseed", _FROM, (3,))
+    assert "variant = 3" in sql
+    assert "lineage_seed" not in sql and "agent_id" not in sql
+
+
+def test_multivariant_sql_is_unfiltered():
+    sql = scale_history_sql("multivariant", _FROM, ())
+    assert "WHERE" not in sql.upper()
+    assert _FROM in sql
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/test_analysis_runner_duckdb.py -v`
+Expected: FAIL with `ImportError: cannot import name 'scale_history_sql'`.
+
+- [ ] **Step 3: Add the provisioning helpers**
+
+Add to `v2ecoli/workflow/analysis_runner.py` (top-level functions, after `_MASS_COLS`):
+
+```python
+def _history_from_clause(sweep_dir: str) -> str:
+    """A DuckDB FROM-clause selecting all of the sweep's history parquet."""
+    files = glob.glob(os.path.join(sweep_dir, "**", "history", "**", "*.pq"),
+                      recursive=True)
+    if not files:
+        raise FileNotFoundError(f"no history parquet under {sweep_dir!r}")
+    flist = "[" + ",".join("'" + f.replace("'", "''") + "'" for f in files) + "]"
+    return f"read_parquet({flist}, hive_partitioning=true)"
+
+
+# scale -> the partition columns that scale's history_sql filters on.
+_SCALE_FILTER_COLS = {
+    "single": ("variant", "lineage_seed", "generation", "agent_id"),
+    "multidaughter": ("variant", "lineage_seed", "generation"),  # parent handled below
+    "multigeneration": ("variant", "lineage_seed"),
+    "multiseed": ("variant",),
+    "multivariant": (),
+}
+
+
+def scale_history_sql(scale: str, from_clause: str, key: tuple) -> str:
+    """SELECT * scoped to the partition a scale aggregates over.
+
+    ``key`` is the group key from ``group_for_scale`` for that scale.
+    """
+    cols = _SCALE_FILTER_COLS[scale]
+    conds = []
+    for col, val in zip(cols, key):
+        if isinstance(val, str):
+            conds.append(f"agent_id = '{val}'" if col == "agent_id"
+                         else f"{col} = '{val}'")
+        else:
+            conds.append(f"{col} = {int(val)}")
+    if scale == "multidaughter" and len(key) >= 4:
+        # sisters share parent = agent_id without its last phylogeny char
+        conds.append(f"agent_id LIKE '{key[3]}_' ESCAPE '\\'")
+    where = (" WHERE " + " AND ".join(conds)) if conds else ""
+    return f"SELECT * FROM {from_clause}{where} ORDER BY global_time"
+
+
+def resolve_sim_data(sweep_dir: str):
+    """Locate + load the sweep's ParCa sim_data via v2ecoli's loader."""
+    from v2ecoli.library.sim_data import LoadSimData
+    for pat in ("sim_data*.cPickle", "sim_data*.pkl", "**/sim_data*.cPickle",
+                "**/kb/simData*.cPickle"):
+        hits = glob.glob(os.path.join(sweep_dir, pat), recursive=True)
+        if hits:
+            return LoadSimData(sim_data_path=hits[0]).sim_data
+    raise FileNotFoundError(
+        f"no sim_data pickle under {sweep_dir!r} (needed by Analysis steps)")
+```
+
+- [ ] **Step 4: Run the SQL test to verify it passes**
+
+Run: `.venv/bin/pytest tests/test_analysis_runner_duckdb.py -v`
+Expected: PASS (3 passed).
+
+- [ ] **Step 5: Extend `run_analyses` to dispatch `Analysis` steps**
+
+In `v2ecoli/workflow/analysis_runner.py`, modify `run_analyses`. Add imports of `Analysis` and the helpers at the top of the function, and branch per step class. Replace the `for name in (analyses or {}):` body with:
+
+```python
+        for name in (analyses or {}):
+            step_cls = ANALYSIS_REGISTRY.get(name)
+            if step_cls is None:
+                warnings.warn(f"unknown analysis {name!r} (scale {scale}); skipping")
+                continue
+            if step_cls.scale != scale:
+                warnings.warn(f"analysis {name!r} is scale {step_cls.scale}, "
+                              f"not {scale}; skipping")
+                continue
+            step = step_cls({}, core=core)
+            per_group: dict[str, Any] = {}
+
+            if issubclass(step_cls, Analysis):
+                # DuckDB-provisioning path: one connection + sim_data for all groups.
+                import duckdb
+                conn = duckdb.connect()
+                from_clause = _history_from_clause(sweep_dir)
+                sim_data = resolve_sim_data(sweep_dir)
+                params = (analyses or {}).get(name) or {}
+                viz_dir = os.path.join(sweep_dir, "viz")
+                os.makedirs(viz_dir, exist_ok=True)
+                for gkey in groups:
+                    gstr = _group_key_str(scale, gkey)
+                    try:
+                        history_sql = scale_history_sql(scale, from_clause, gkey)
+                        out = step.update({
+                            "conn": conn, "history_sql": history_sql,
+                            "config_sql": "", "success_sql": "",
+                            "sim_data": sim_data, "validation_data": None,
+                            "variant_metadata": params,
+                        })
+                        if out.get("view"):
+                            vp = os.path.join(viz_dir, f"{name}__{gstr.replace('/', '_')}.html")
+                            with open(vp, "w") as vf:
+                                vf.write(out["view"])
+                        per_group[gstr] = out.get("data", {})
+                    except Exception as e:
+                        per_group[gstr] = {"error": f"{type(e).__name__}: {e}"}
+            else:
+                # Record-based AnalysisStep path (unchanged).
+                for gkey, grp in groups.items():
+                    try:
+                        rows = grp[0].get("timeseries") if scale == "single" else grp
+                        per_group[_group_key_str(scale, gkey)] = step.analyze(rows or [])
+                    except Exception as e:
+                        per_group[_group_key_str(scale, gkey)] = {
+                            "error": f"{type(e).__name__}: {e}"}
+
+            scale_out[name] = per_group
+```
+
+Add at the top of `run_analyses` (with the existing imports):
+```python
+    from v2ecoli.workflow.analysis import Analysis, ANALYSIS_REGISTRY, ANALYSIS_SCALES
+```
+(extends the existing import line to also bring in `Analysis`).
+
+- [ ] **Step 6: Run the existing runner tests to confirm no regression**
+
+Run: `.venv/bin/pytest tests/test_analysis_runner.py tests/test_workflow_analysis.py -v`
+Expected: PASS (record-based path untouched).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add v2ecoli/workflow/analysis_runner.py tests/test_analysis_runner_duckdb.py
+git commit -m "feat: runner DuckDB-provisioning path for Analysis steps"
+```
+
+---
+
+### Task 5: Port `ptools_rna` (single, data)
+
+**Files:**
+- Create: `v2ecoli/workflow/analyses/__init__.py`
+- Create: `v2ecoli/workflow/analyses/ptools_rna.py`
+- Test: `tests/test_ptools_analyses.py`
+
+- [ ] **Step 1: Create the package init (registers ports at import)**
+
+```python
+# v2ecoli/workflow/analyses/__init__.py
+"""Native ports of vEcoli DuckDB/sim_data analyses (Analysis subclasses).
+
+Importing this package registers every ported analysis into ANALYSIS_REGISTRY.
+"""
+from v2ecoli.workflow.analyses import ptools_rna  # noqa: F401
+```
+(Each later task appends its module to this import list.)
+
+- [ ] **Step 2: Write the failing fidelity test**
+
+```python
+# tests/test_ptools_analyses.py
+import os
+import pytest
+
+FIX = "/Users/eranagmon/code/sms-api/tests/fixtures/analysis_data"
+
+
+def _frame_ids(tsv_text):
+    rows = [r for r in tsv_text.strip().splitlines() if r]
+    return {r.split("\t")[0] for r in rows[1:]}  # skip header ($ row)
+
+
+@pytest.mark.skipif(not os.path.isdir(FIX), reason="sms-api oracle fixtures absent")
+def test_ptools_rna_registered():
+    from v2ecoli.workflow.analyses import ptools_rna  # noqa: F401
+    from v2ecoli.workflow.analysis import ANALYSIS_REGISTRY, Analysis
+    cls = ANALYSIS_REGISTRY["ptools_rna"]
+    assert issubclass(cls, Analysis) and cls.scale == "single"
+
+
+@pytest.mark.skipif(not os.path.isdir(FIX), reason="sms-api oracle fixtures absent")
+def test_ptools_rna_output_shape_matches_oracle():
+    # The oracle TSV is "$\t<t0>\t<t1>...\n<frameid>\t<val>...". Our port, given the
+    # same sim, must produce a frame-ID-indexed table with n_tp+1 columns. This
+    # asserts structural fidelity (header shape + frame-ID column) against the
+    # reference; numeric parity is checked in the end-to-end test (Task 10) when a
+    # matching sim is available.
+    oracle = open(os.path.join(FIX, "ptools_rna.txt")).read()
+    header = oracle.strip().splitlines()[0].split("\t")
+    assert header[0] == "$"
+    assert len(_frame_ids(oracle)) > 0
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/test_ptools_analyses.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'v2ecoli.workflow.analyses.ptools_rna'`.
+
+- [ ] **Step 4: Port the module**
+
+Get the source: `git -C /Users/eranagmon/code/vivarium-ecoli show origin/ptools_viz:ecoli/analysis/single/ptools_rna.py`.
+
+Create `v2ecoli/workflow/analyses/ptools_rna.py` by wrapping that source's `plot()` body in an `Analysis` subclass, applying exactly these mechanical edits:
+
+1. Class scaffold:
+   ```python
+   from v2ecoli.workflow.analysis import Analysis
+
+   class PtoolsRna(Analysis):
+       name = "ptools_rna"
+       scale = "single"
+       config_schema = {"n_tp": "integer", "time_unit": "string"}
+
+       def analyze(self, *, conn, history_sql, sim_data, variant_metadata, **ctx):
+           params = variant_metadata or {}
+           params.setdefault("n_tp", 8)
+           ...  # ← the ported plot() body
+   ```
+2. Keep the source's module-level helpers (`build_query`, `read_outputs`, `retrieve_tu_source`, `tu2gene_mapping`, `get_bulk_ids`, `build_bulk2monomers_matrix`, `consolidate_timepoints`) **verbatim** as module functions.
+3. In the body: replace `sim_data = LoadSimData(sim_data_path).sim_data` with use of the **passed** `sim_data` (delete the load). Replace `exp_id = list(sim_data_paths.keys())[0]` / `sim_data_path = ...` lines accordingly.
+4. Replace the reconstruction-flat path derivation
+   `wd_raw = os.path.join(os.getcwd().split("/out/")[0], "reconstruction", "ecoli", "flat")`
+   with the v2ecoli location (confirm in Task 1 findings):
+   `wd_raw = os.path.join(os.path.dirname(__import__("v2ecoli").__file__), "processes", "parca", "reconstruction", "ecoli", "flat")`.
+5. Replace the final `ptools_rna.to_csv(os.path.join(outdir, "ptools_rna.txt"), sep="\t", ...)` write with:
+   ```python
+   tsv = ptools_rna.to_csv(sep="\t", index=True, header=True, float_format="%.4f")
+   return {"data": {"filename": "ptools_rna.tsv", "tsv": tsv}}
+   ```
+6. Replace `conn.sql(query_sql).df()` usage — it already receives `conn`/`history_sql` as args; pass the injected `conn` and `history_sql` into `read_outputs(history_sql, conn, output_columns)` unchanged.
+
+Then add `ptools_rna` to the `analyses/__init__.py` import list (already there from Step 1).
+
+If Task 1 flagged a missing column (e.g. `listeners__unique_molecule_counts__active_ribosome`), apply the alias recorded in the findings note here (e.g. adjust `output_columns`), or guard that branch and note the reduced fidelity in a module docstring.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `.venv/bin/pytest tests/test_ptools_analyses.py -v`
+Expected: PASS (registration + oracle-shape tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add v2ecoli/workflow/analyses/__init__.py v2ecoli/workflow/analyses/ptools_rna.py tests/test_ptools_analyses.py
+git commit -m "feat: port ptools_rna as native Analysis (single)"
+```
+
+---
+
+### Task 6: Port `ptools_rxns` (single, data)
+
+**Files:**
+- Create: `v2ecoli/workflow/analyses/ptools_rxns.py`
+- Modify: `v2ecoli/workflow/analyses/__init__.py` (add `ptools_rxns` import)
+- Test: extend `tests/test_ptools_analyses.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_ptools_analyses.py`:
+```python
+@pytest.mark.skipif(not os.path.isdir(FIX), reason="sms-api oracle fixtures absent")
+def test_ptools_rxns_registered_and_oracle_shape():
+    from v2ecoli.workflow.analyses import ptools_rxns  # noqa: F401
+    from v2ecoli.workflow.analysis import ANALYSIS_REGISTRY, Analysis
+    cls = ANALYSIS_REGISTRY["ptools_rxns"]
+    assert issubclass(cls, Analysis) and cls.scale == "single"
+    oracle = open(os.path.join(FIX, "ptools_rxns.txt")).read()
+    assert oracle.strip().splitlines()[0].split("\t")[0] == "$"
+    assert len(_frame_ids(oracle)) > 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/test_ptools_analyses.py::test_ptools_rxns_registered_and_oracle_shape -v`
+Expected: FAIL with `ModuleNotFoundError: ...ptools_rxns`.
+
+- [ ] **Step 3: Port the module**
+
+Source: `git -C /Users/eranagmon/code/vivarium-ecoli show origin/ptools_viz:ecoli/analysis/single/ptools_rxns.py`. Apply the **same six mechanical edits as Task 5 Step 4**, with class `PtoolsRxns(Analysis)`, `name = "ptools_rxns"`, and the final return writing `{"data": {"filename": "ptools_rxns.tsv", "tsv": tsv}}`. Add `from v2ecoli.workflow.analyses import ptools_rxns  # noqa: F401` to `analyses/__init__.py`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/pytest tests/test_ptools_analyses.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add v2ecoli/workflow/analyses/ptools_rxns.py v2ecoli/workflow/analyses/__init__.py tests/test_ptools_analyses.py
+git commit -m "feat: port ptools_rxns as native Analysis (single)"
+```
+
+---
+
+### Task 7: Port `ptools_proteins` (single, data)
+
+**Files:**
+- Create: `v2ecoli/workflow/analyses/ptools_proteins.py`
+- Modify: `v2ecoli/workflow/analyses/__init__.py` (add `ptools_proteins` import)
+- Test: extend `tests/test_ptools_analyses.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_ptools_analyses.py`:
+```python
+def test_ptools_proteins_registered():
+    from v2ecoli.workflow.analyses import ptools_proteins  # noqa: F401
+    from v2ecoli.workflow.analysis import ANALYSIS_REGISTRY, Analysis
+    cls = ANALYSIS_REGISTRY["ptools_proteins"]
+    assert issubclass(cls, Analysis) and cls.scale == "single"
+    assert cls({}, core=__import__("bigraph_schema").allocate_core()).outputs() == {
+        "view": "string", "data": "map"}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/test_ptools_analyses.py::test_ptools_proteins_registered -v`
+Expected: FAIL with `ModuleNotFoundError: ...ptools_proteins`.
+
+- [ ] **Step 3: Port the module**
+
+Source: `git -C /Users/eranagmon/code/vivarium-ecoli show origin/ptools_viz:ecoli/analysis/single/ptools_proteins.py`. Same six mechanical edits; class `PtoolsProteins(Analysis)`, `name = "ptools_proteins"`, return `{"data": {"filename": "ptools_proteins.tsv", "tsv": tsv}}`. Add the import to `analyses/__init__.py`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/pytest tests/test_ptools_analyses.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add v2ecoli/workflow/analyses/ptools_proteins.py v2ecoli/workflow/analyses/__init__.py tests/test_ptools_analyses.py
+git commit -m "feat: port ptools_proteins as native Analysis (single)"
+```
+
+---
+
+### Task 8: Port `mass_fraction_voronoi` (single, view)
+
+Proves the matplotlib→SVG `view` path for a single-scale plot.
+
+**Files:**
+- Create: `v2ecoli/workflow/analyses/mass_fraction_voronoi.py`
+- Modify: `v2ecoli/workflow/analyses/__init__.py`
+- Test: `tests/test_view_analyses.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_view_analyses.py
+from bigraph_schema import allocate_core
+
+
+def test_mass_fraction_voronoi_registered_single_view():
+    from v2ecoli.workflow.analyses import mass_fraction_voronoi  # noqa: F401
+    from v2ecoli.workflow.analysis import ANALYSIS_REGISTRY, Analysis
+    cls = ANALYSIS_REGISTRY["mass_fraction_voronoi"]
+    assert issubclass(cls, Analysis) and cls.scale == "single"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/test_view_analyses.py -v`
+Expected: FAIL with `ModuleNotFoundError: ...mass_fraction_voronoi`.
+
+- [ ] **Step 3: Port the module**
+
+Source: `git -C /Users/eranagmon/code/vivarium-ecoli show origin/ptools_viz:ecoli/analysis/single/mass_fraction_voronoi.py`. Edits: wrap in `class MassFractionVoronoi(Analysis)` (`name="mass_fraction_voronoi"`, `scale="single"`); use the passed `conn`/`history_sql`/`sim_data`; **replace the `fig.savefig(os.path.join(outdir, ...))` call** with:
+```python
+from v2ecoli.workflow.render import fig_to_html
+return {"view": fig_to_html(fig, title="Mass fraction (Voronoi)")}
+```
+If this plot reads a listener column flagged missing in Task 1, substitute the nearest available mass listener recorded in the findings note, or — if blocked — port `ecoli/analysis/single/blame.py` instead (simpler single-scale plot) under the same `name`/pattern, and note the substitution in the module docstring. Add the import to `analyses/__init__.py`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/pytest tests/test_view_analyses.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add v2ecoli/workflow/analyses/mass_fraction_voronoi.py v2ecoli/workflow/analyses/__init__.py tests/test_view_analyses.py
+git commit -m "feat: port mass_fraction_voronoi as native Analysis (single, view)"
+```
+
+---
+
+### Task 9: Port `central_carbon_metabolism_scatter` (multiseed, view + cross-cell SQL)
+
+Proves the cross-cell scale-scoped `history_sql` + matplotlib view.
+
+**Files:**
+- Create: `v2ecoli/workflow/analyses/central_carbon_metabolism_scatter.py`
+- Modify: `v2ecoli/workflow/analyses/__init__.py`
+- Test: extend `tests/test_view_analyses.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_view_analyses.py`:
+```python
+def test_ccm_scatter_registered_multiseed():
+    from v2ecoli.workflow.analyses import central_carbon_metabolism_scatter  # noqa: F401
+    from v2ecoli.workflow.analysis import ANALYSIS_REGISTRY, Analysis
+    cls = ANALYSIS_REGISTRY["central_carbon_metabolism_scatter"]
+    assert issubclass(cls, Analysis) and cls.scale == "multiseed"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/test_view_analyses.py::test_ccm_scatter_registered_multiseed -v`
+Expected: FAIL with `ModuleNotFoundError`.
+
+- [ ] **Step 3: Port the module**
+
+Source: `git -C /Users/eranagmon/code/vivarium-ecoli show origin/ptools_viz:ecoli/analysis/multiseed/centralCarbonMetabolismScatter.py`. Wrap in `class CentralCarbonMetabolismScatter(Analysis)` (`name="central_carbon_metabolism_scatter"`, `scale="multiseed"`); use the injected `conn`/`history_sql` (the runner already scopes `history_sql` to one variant's seeds); replace the `savefig(outdir/...)` with `return {"view": fig_to_html(fig, title="Central carbon metabolism")}`. If it requires `validation_data` (Schmidt/Wisniewski) which is `None` here, guard the validation overlay behind `if validation_data:` and note it. Add the import to `analyses/__init__.py`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/pytest tests/test_view_analyses.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add v2ecoli/workflow/analyses/central_carbon_metabolism_scatter.py v2ecoli/workflow/analyses/__init__.py tests/test_view_analyses.py
+git commit -m "feat: port central_carbon_metabolism_scatter as native Analysis (multiseed, view)"
+```
+
+---
+
+### Task 10: Proving-set config + end-to-end run
+
+**Files:**
+- Create: `v2ecoli/configs/analyses_proving.json`
+- Test: extend `tests/test_analysis_runner_duckdb.py`
+
+- [ ] **Step 1: Create the config**
+
+```json
+{
+  "inherit_from": "two_generations.json",
+  "analysis_options": {
+    "single": {
+      "ptools_rna": {"n_tp": 8},
+      "ptools_rxns": {"n_tp": 8},
+      "ptools_proteins": {"n_tp": 8},
+      "mass_fraction_voronoi": {}
+    },
+    "multiseed": {
+      "central_carbon_metabolism_scatter": {}
+    }
+  }
+}
+```
+(Confirm `two_generations.json` exists under `v2ecoli/configs/`; if its filename differs, use the repo's smallest multi-generation config as `inherit_from`.)
+
+- [ ] **Step 2: Write the end-to-end test (cache-gated on a real sweep)**
+
+Append to `tests/test_analysis_runner_duckdb.py`:
+```python
+import glob as _glob
+import json as _json
+import os as _os
+import pytest as _pytest
+
+
+def _latest_sweep():
+    cands = sorted(_glob.glob("out/*/"), key=_os.path.getmtime, reverse=True)
+    for d in cands:
+        if _glob.glob(_os.path.join(d, "**", "history", "**", "*.pq"), recursive=True):
+            return d
+    return None
+
+
+@_pytest.mark.skipif(_latest_sweep() is None, reason="no local sweep with parquet")
+def test_proving_set_end_to_end():
+    import v2ecoli.workflow.analyses  # noqa: F401  (register ports)
+    from v2ecoli.workflow.analysis_runner import run_analyses
+    sweep = _latest_sweep()
+    opts = {"single": {"ptools_rna": {"n_tp": 8}}}
+    res = run_analyses(sweep, opts)
+    assert "single" in res and "ptools_rna" in res["single"]
+    # data product present (or a recorded error, not a silent drop)
+    block = res["single"]["ptools_rna"]
+    assert block, "ptools_rna produced no per-group result"
+    # analysis.json written
+    assert _os.path.isfile(_os.path.join(sweep, "analysis.json"))
+```
+
+- [ ] **Step 3: Run the end-to-end test**
+
+Run: `.venv/bin/pytest tests/test_analysis_runner_duckdb.py::test_proving_set_end_to_end -v`
+Expected: PASS if a local sweep exists (else SKIPPED). If it errors inside the port, fix per the Task 1 findings (column/attr shim), not by loosening the test.
+
+- [ ] **Step 4: Optionally run the full proving set against the sweep + eyeball a view**
+
+```bash
+.venv/bin/v2ecoli-analyze "$(ls -dt out/*/ | head -1)" --config v2ecoli/configs/analyses_proving.json
+ls "$(ls -dt out/*/ | head -1)"viz/
+```
+Expected: `analysis.json` updated; `viz/*.html` files for `mass_fraction_voronoi` and `central_carbon_metabolism_scatter`. Open one in a browser to confirm it renders.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add v2ecoli/configs/analyses_proving.json tests/test_analysis_runner_duckdb.py
+git commit -m "test: proving-set config + end-to-end Analysis runner test"
+```
+
+---
+
+### Task 11: Dashboard surfacing — list Analyses in the viz picker
+
+The dashboard already renders `<study>/viz/*.html` into the Visualizations tab. This task adds Analysis classes to the class picker so they're discoverable.
+
+**Files:**
+- Modify: `vivarium-dashboard/vivarium_dashboard/server.py` (`_list_visualization_classes()`, ~lines 9036–9239)
+
+- [ ] **Step 1: Locate the discovery function**
+
+```bash
+cd /Users/eranagmon/code/vivarium-dashboard
+grep -n "_list_visualization_classes\|def _get_visualization_classes\|return classes" vivarium_dashboard/server.py | head
+```
+Read the function body to see how it accumulates the `classes` list (each entry `{address, name, doc}`).
+
+- [ ] **Step 2: Append Analysis-registry entries**
+
+Inside `_list_visualization_classes()`, just before it returns the assembled list, add (matching the existing entry dict shape — adjust keys if the function uses different ones, confirmed in Step 1):
+
+```python
+        # Native v2ecoli Analyses (Analysis subclasses) surface in the same picker.
+        try:
+            import v2ecoli.workflow.analyses  # noqa: F401  (import-time registration)
+            from v2ecoli.workflow.analysis import ANALYSIS_REGISTRY, Analysis
+            for _name, _cls in ANALYSIS_REGISTRY.items():
+                if isinstance(_cls, type) and issubclass(_cls, Analysis):
+                    classes.append({
+                        "address": f"local:{_cls.__module__}.{_cls.__qualname__}",
+                        "name": _name,
+                        "doc": (_cls.__doc__ or "").strip().split("\n")[0],
+                        "kind": "analysis",
+                    })
+        except Exception:
+            pass  # v2ecoli not importable in this workspace — skip silently
+```
+
+- [ ] **Step 3: Smoke-test the endpoint**
+
+```bash
+cd /Users/eranagmon/code/vivarium-dashboard
+grep -n "ANALYSIS_REGISTRY\|kind.*analysis" vivarium_dashboard/server.py
+.venv/bin/python -c "import ast; ast.parse(open('vivarium_dashboard/server.py').read()); print('parse OK')"
+```
+Expected: edit present; `parse OK`. (Full endpoint check happens when the dashboard runs against the v2ecoli workspace — `/pbg-dashboard start` then GET `/api/visualization-classes` should include `kind: analysis` entries.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add vivarium_dashboard/server.py
+git commit -m "feat: list native Analysis classes in the visualization picker"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Analysis base (duckdb/sim_data ports, view+data) → Task 2 ✓
+- Runner SQL-provisioning (open_connection/scale_history_sql/resolve_sim_data) → Task 4 ✓
+- Render path (matplotlib→SVG, Plotly allowed) → Task 3 (helper) + Tasks 8–9 (use) ✓; ptools use Plotly-free TSV/data → Tasks 5–7 ✓
+- Dashboard surfacing (views via existing embed_visualizations; picker extension) → Task 11 ✓
+- Proving set (3 ptools + 2 plots across single+multiseed) → Tasks 5–9 ✓
+- Parity-check first (gates ports) → Task 1 ✓
+- Config + run.py wiring → Task 10 (run.py already calls run_analyses at run.py:94–97, no edit needed) ✓
+- Spec "out of scope" (remaining 43, omics-viewer embed, BioCyc web service) → not in any task ✓ (correctly excluded)
+
+**Placeholder scan:** Port tasks (5–9) intentionally reference the upstream source to copy rather than reproducing ~200 lines verbatim, but each gives the exact source command, the exact mechanical edits, the exact class scaffold, and complete test code — no "TODO"/"handle edge cases"/"similar to". The one judgement call (missing-listener fallback) names a concrete alternative file and action.
+
+**Type consistency:** `Analysis.analyze()` keyword args (`conn`, `history_sql`, `sim_data`, `variant_metadata`) match what the runner injects in Task 4 Step 5 and what ports consume in Tasks 5–9. `outputs()` is `{view, data}` everywhere. `scale_history_sql(scale, from_clause, key)` signature consistent between Task 4 definition and Task 10 use. Registry key = `name` class attr, used identically in base (Task 2), ports, and dashboard (Task 11).
+
+**Known carry-over risk:** numeric (not just structural) ptools fidelity is only asserted in Task 10's end-to-end test, which is cache-gated on a local sweep. If no sweep exists, that assertion is skipped — flagged here so it isn't mistaken for full verification.

--- a/docs/superpowers/specs/2026-06-08-vecoli-analyses-as-pbg-analyses-design.md
+++ b/docs/superpowers/specs/2026-06-08-vecoli-analyses-as-pbg-analyses-design.md
@@ -1,0 +1,260 @@
+# vEcoli Analyses as Native Process-Bigraph Analyses — Design
+
+**Date:** 2026-06-08
+**Status:** Approved (design); implementation pending
+**Scope:** Evolve v2ecoli's `AnalysisStep` into a unified **`Analysis`** abstraction
+that ports vEcoli's DuckDB/`sim_data`-based analyses *faithfully and natively* as
+process-bigraph Steps that are "Visualizations-like" (each emits a rendered `view`
+HTML plus optional `data`). This spec lands the base, the runner refactor, the
+dashboard surfacing, and a **proving set** of 5 analyses. A follow-up spec bulk-ports
+the remaining ~43.
+
+## Background
+
+PR #95 added the `AnalysisStep` base + five-scale registry; the
+[2026-05-30 workflow-analyses spec](2026-05-30-workflow-analyses-design.md) then
+ported one native analysis per scale computed from emitted observables. That spec
+made a deliberate **decision #1**: *native from emitted observables — no `sim_data`,
+no DuckDB-SQL parity; faithful vEcoli ports explicitly deferred* (its "Out of scope"
+section lists "Faithful vEcoli analysis ports (DuckDB SQL, `sim_data` molecule maps,
+validation datasets …)" and "Rendering analysis results").
+
+**This spec supersedes that decision #1.** We now want the faithful ports: the
+analyses that read parquet via **DuckDB SQL** and the ParCa **`sim_data`** object,
+reimplemented as native process-bigraph Steps — *without* importing vEcoli's
+`Analysis`/`plot()` machinery and *without* a wrapper. The `analysis.py` module
+docstring already anticipates this: *"Porting the full vEcoli analysis library onto
+this base is a follow-up spec."* This is that spec.
+
+The full target set on `vivarium-ecoli@origin/ptools_viz`: **48 analyses** —
+single:7, multidaughter:1, multigeneration:11, multiseed:9, multivariant:7,
+multiexperiment:1.
+
+## Decisions (locked during brainstorming)
+
+1. **Data access — DuckDB handle + `sim_data` as input ports.** An `Analysis`
+   receives a live DuckDB connection (`conn`), the scale-scoped `history_sql`
+   (plus `config_sql`/`success_sql`), and the run's `sim_data` as declared inputs.
+   `analyze()` runs SQL over the partitioned parquet exactly as vEcoli's `plot()`
+   does, so query logic ports near-verbatim. (Reverses 2026-05-30 decision #1.)
+2. **Analysis unifies with Visualization.** One concept, one registry, one
+   dashboard tab. Each `Analysis` produces a rendered `view` (HTML) **and** an
+   optional `data` product (map/TSV). A pure visualization is just an `Analysis`
+   with no `data` output. (Reverses 2026-05-30's "no rendering" non-goal.)
+3. **Rendering is HTML, mixed engines per analysis.** `view` is an HTML string.
+   Plot-heavy ports keep **matplotlib → embedded SVG** in an HTML wrapper
+   (near-verbatim); ptools/simple analyses may use **Plotly**. No forced rewrite to
+   a single charting engine.
+4. **Scope — base + proving set now; bulk port next.** This spec lands the
+   `Analysis` base, the runner refactor, dashboard surfacing, and a **5-analysis
+   proving set** that exercises every axis. The remaining ~43 are a recipe-driven,
+   parallel-agent-friendly follow-up spec.
+
+## Architecture
+
+```
+run_workflow → branches complete → parquet sweep output (partitioned by
+                                    experiment_id/variant/lineage_seed/generation/agent_id)
+  → run_analyses(sweep_dir, analysis_options):
+       conn = duckdb.connect over the sweep's partitioned parquet
+       sim_data = resolve+load the run's ParCa sim_data
+       for each scale in analysis_options:
+         history_sql = scale-scoped SELECT (the WHERE/partition that scale aggregates)
+         for each configured Analysis (resolved via ANALYSIS_REGISTRY by name+scale):
+           result = analysis.update({conn, history_sql, config_sql, success_sql,
+                                     sim_data, validation_data, variant_metadata, params})
+           write result["data"] → analysis.json / <module>.tsv
+           write result["view"] → <study>/viz/<analysis>.html
+  → dashboard surfaces <study>/viz/*.html in the Visualizations tab (existing
+    embed_visualizations mechanism); Analysis classes also listed in the viz picker.
+v2ecoli-analyze <sweep_dir> [--config cfg.json]   # same runner, standalone
+```
+
+**Provisioning layer = the runner.** `conn`/`sim_data` are live, non-serializable
+Python objects, so they are *not* wired through serialized bigraph state. The runner
+injects them into the plain state dict passed to `Analysis.update()` — exactly how
+the current `AnalysisStep.update(state)` is already invoked directly. `inputs()`/
+`outputs()` declarations exist for typing/discoverability; port types for the live
+handles are permissive (`any`).
+
+## Components
+
+### 1. The `Analysis` base — `v2ecoli/workflow/analysis.py`
+
+Evolve `AnalysisStep` → **`Analysis(V2Step)`** *in place* (keep an `AnalysisStep =
+Analysis` alias for one release so existing imports/`MassFractionSummary` keep
+working). Retains the auto-registry (`ANALYSIS_REGISTRY`, `ANALYSIS_SCALES`,
+`__init_subclass__` registration by `name`). New unified shape:
+
+```python
+class Analysis(V2Step):
+    scale = "single"                          # one of ANALYSIS_SCALES
+    config_schema = {}                         # was vEcoli's `params` (e.g. n_tp, time_unit)
+
+    def inputs(self):
+        return {
+            "conn": "any", "history_sql": "string",
+            "config_sql": "string", "success_sql": "string",
+            "sim_data": "any", "validation_data": "any",
+            "variant_metadata": "any",
+        }
+    def outputs(self):
+        return {"view": "string", "data": "map"}   # either may be empty
+
+    def analyze(self, *, conn, history_sql, sim_data, **ctx) -> dict:
+        """Return {"view": <html>, "data": <map>} (either key optional)."""
+        raise NotImplementedError
+
+    def update(self, state, interval=None):
+        out = self.analyze(**{k: state.get(k) for k in self.inputs()})
+        return {"view": out.get("view", ""), "data": out.get("data", {})}
+```
+
+**Port mapping from vEcoli `plot()`** (`params, conn, history_sql, config_sql,
+success_sql, sim_data_paths, validation_data_paths, outdir, variant_metadata,
+variant_names`):
+
+| vEcoli `plot()` arg | `Analysis` source |
+|---|---|
+| `conn`, `history_sql`, `config_sql`, `success_sql` | input ports (runner-provided) |
+| `sim_data_paths` → `sim_data` | `sim_data` port (runner loads via v2ecoli's loader) |
+| `validation_data_paths` → `validation_data` | `validation_data` port (optional) |
+| `variant_metadata`, `variant_names` | `variant_metadata` port |
+| `params` | `config_schema` / step config |
+| `outdir` (file writes) | **returned** `view`/`data`; runner owns the filesystem |
+
+Porting an analysis = paste the `plot()` body into `analyze()`, swap each
+`outdir`-file-write for a `view`/`data` return entry, and read `params[...]` from
+config. A `render` helper on the base wraps a matplotlib figure → embedded SVG HTML
+(`fig_to_html(fig)`), so plot ports stay near-verbatim.
+
+### 2. The runner — `v2ecoli/workflow/analysis_runner.py` (refactor)
+
+Replace the record-building/grouping data path (`build_cell_records`,
+`group_for_scale`) with **SQL provisioning**:
+
+- `open_connection(sweep_dir) -> duckdb.Connection`: connect over the sweep's
+  partitioned parquet (the layout `simulations_index.py` already documents:
+  `parquet/<experiment_id>/…/variant=…/lineage_seed=…/generation=…/agent_id=…`).
+- `scale_history_sql(scale, conn, partition) -> str`: build the per-scale SELECT —
+  the WHERE/partition each scale aggregates over. This **replaces** the old
+  per-scale grouping table; same semantics, expressed in SQL:
+
+  | scale | partition the `history_sql` selects |
+  |---|---|
+  | single | one `(variant, lineage_seed, generation, agent_id)` cell |
+  | multidaughter | sisters: one `(variant, lineage_seed, generation, parent_agent_id)` |
+  | multigeneration | one `(variant, lineage_seed)` lineage, all generations |
+  | multiseed | one `(variant,)`, all seeds |
+  | multivariant | all cells |
+
+- `resolve_sim_data(sweep_dir) -> sim_data`: locate + load the run's ParCa
+  `sim_data` via v2ecoli's loader (see Risk §). Loaded once per run, reused across
+  analyses.
+- `run_analyses(sweep_dir, analysis_options) -> dict`: for each `scale` →
+  configured analysis name → resolve via `ANALYSIS_REGISTRY` (asserting
+  `step_cls.scale == scale`), iterate the scale's partitions, inject
+  `{conn, history_sql, …, sim_data}` into `update()`, collect `data` into
+  `analysis.json` and write each `view` to the sweep's `viz/<analysis>[_<partition>].html`.
+  When the sweep belongs to a dashboard study/investigation, this `viz/` dir is the
+  one the Visualizations tab reads (§3) — same location, no copy.
+- `main()`: `v2ecoli-analyze <sweep_dir> [--config cfg.json]` unchanged in spirit.
+
+### 3. Dashboard surfacing — `vivarium-dashboard/vivarium_dashboard/server.py`
+
+- **Views (no new plumbing):** the runner writes `view` HTML into `<study>/viz/*.html`,
+  which the dashboard **already** surfaces in the Visualizations tab via
+  `embed_visualizations` (server.py ~690‑701).
+- **Class picker (small extension):** extend `_list_visualization_classes()` to also
+  enumerate `ANALYSIS_REGISTRY` entries (kind `"analysis"`), so ported Analyses appear
+  in the same picker as `TimeSeriesPlot` etc. The existing discovery recognizes
+  `issubclass(cls, Visualization)`; we add an `ANALYSIS_REGISTRY` source rather than
+  forcing `Analysis` to subclass `Visualization` (which would collide with `V2Step`
+  and the live-handle port model).
+
+### 4. The proving set (5 analyses) — `v2ecoli/workflow/analyses/`
+
+Chosen to exercise **every axis**: both render paths, sim_data-heavy and -light,
+data-output and view-output, single and cross-cell scales.
+
+| analysis | scale | exercises |
+|---|---|---|
+| `ptools_rna` | single | **sim_data-heavy** (rna_data, complexation monomers, rna_maturation_stoich, molecule_groups); data TSV output; the original integration goal |
+| `ptools_rxns` | single | sim_data reaction maps; data TSV |
+| `ptools_proteins` | single | sim_data monomer maps; data TSV |
+| `mass_fraction_summary` | single | already native; re-expressed on the duckdb path as the migration reference; matplotlib→SVG `view` |
+| one multiseed plot analysis (e.g. `centralCarbonMetabolismScatter`) | multiseed | **cross-cell** SQL aggregation + matplotlib `view`; proves the scale-scoped `history_sql` |
+
+Each ported from `vivarium-ecoli@origin/ptools_viz:ecoli/analysis/<scale>/<name>.py`.
+
+### 5. Console script + configs
+
+- `pyproject.toml`: keep `v2ecoli-analyze = "v2ecoli.workflow.analysis_runner:main"`.
+- A proving-set config (`v2ecoli/configs/*.json`) with `analysis_options` naming the
+  5 analyses across `single` + `multiseed`.
+
+## Error handling
+
+- The runner isolates each analysis/partition: a Step raising is caught, recorded in
+  `analysis.json` as `{"error": "<type>: <msg>"}`, remaining analyses continue.
+  (`Analysis.invoke` still surfaces errors loudly when run directly.)
+- Unknown analysis name or scale mismatch in `analysis_options` → `warnings.warn` + skip.
+- Missing `sim_data` for a sim_data-dependent analysis → clear error naming the
+  analysis and the expected sim_data path.
+- Empty partition / no rows from `history_sql` → the Step returns a `skipped` view+data.
+
+## Testing
+
+- **Unit (per Analysis):** `analyze()` against a tiny fixture parquet + a fixture
+  `sim_data` → expected TSV values (ptools row/column shape, normalization) and a
+  non-empty `view`; skip paths.
+- **Port fidelity:** ptools TSV output compared against the vEcoli reference TSVs
+  checked into sms-api (`tests/fixtures/analysis_data/ptools_rna.txt`,
+  `ptools_rxns.txt`) for the same input — the cross-implementation oracle.
+- **Runner:** `scale_history_sql` produces the expected partition SELECT per scale;
+  `run_analyses` over a generated mini-sweep yields an `analysis.json` block + a
+  `viz/*.html` per configured analysis.
+- **Registry:** `analysis_options` names resolve to the right classes; scale assert.
+- **Dashboard:** the viz picker lists the ported Analyses; a produced `viz/*.html`
+  appears as an `embed_visualizations` entry.
+
+## File layout
+
+```
+v2ecoli/workflow/analysis.py            evolve AnalysisStep→Analysis (alias kept);
+                                        {view,data} outputs; duckdb/sim_data ports
+v2ecoli/workflow/analysis_runner.py     refactor: open_connection, scale_history_sql,
+                                        resolve_sim_data, run_analyses (SQL provisioning)
+v2ecoli/workflow/analyses/              new: ptools_{rna,rxns,proteins}, +mass_fraction,
+                                        +1 multiseed plot analysis
+v2ecoli/configs/<proving>.json          analysis_options for the proving set
+vivarium-dashboard/.../server.py        _list_visualization_classes += ANALYSIS_REGISTRY
+pyproject.toml                          (unchanged) v2ecoli-analyze console script
+tests/test_workflow_analysis.py         Analysis base + ports + render helper
+tests/test_analysis_runner.py           scale_history_sql, run_analyses, fidelity oracle
+```
+
+## Known risk — gates the proving set
+
+The ports lean on the ParCa **`sim_data`** object (`transcription.rna_data`,
+`complexation.get_monomers`, `rna_maturation_stoich_matrix`, `molecule_groups`) and
+**exact parquet column names** (`listeners__rna_counts__full_mRNA_counts`, `bulk`,
+`listeners__unique_molecule_counts__active_ribosome`). v2ecoli is vEcoli-derived but
+may have attribute/column drift. **First plan step = a parity check** diffing
+v2ecoli's `sim_data` + parquet schema against what the 5 proving analyses require.
+The proving set deliberately front-loads the most `sim_data`-dependent analysis
+(`ptools_rna`) so any drift surfaces here, not in the bulk-port spec. Drift outcomes:
+small (add a column alias / attribute shim in the runner) vs. large (a missing
+listener → flag for a separate emitter change).
+
+## Out of scope (deferred / non-goals)
+
+- The remaining ~43 analyses (recipe-driven follow-up spec, parallel-agent-friendly).
+- `multiexperiment` scale (not in v2ecoli's `ANALYSIS_SCALES`; add when needed).
+- The live **Pathway Tools Omics Viewer** painted-map embed (the licensed `sms-ptools`
+  container) — Tier 3; these native Analyses render the ptools TSVs themselves.
+- BioCyc *web-service* annotation as a hard dependency — frame-ID→name resolution uses
+  the reconstruction flat files offline; live BioCyc enrichment is optional/later.
+- Importing vEcoli's `Analysis`/`plot()` runner or any wrapper around it (explicit
+  non-goal — these are native reimplementations).
+```

--- a/tests/test_analysis_base.py
+++ b/tests/test_analysis_base.py
@@ -1,0 +1,35 @@
+from bigraph_schema import allocate_core
+from v2ecoli.workflow.analysis import Analysis, ANALYSIS_REGISTRY
+
+
+class _Demo(Analysis):
+    name = "demo_analysis"
+    scale = "single"
+
+    def analyze(self, *, conn, history_sql, sim_data, **ctx):
+        return {"view": "<p>ok</p>", "data": {"n": 1}}
+
+
+def test_analysis_registers_and_dispatches():
+    assert ANALYSIS_REGISTRY["demo_analysis"] is _Demo
+    step = _Demo({}, core=allocate_core())
+    out = step.update({"conn": None, "history_sql": "SELECT 1", "sim_data": None})
+    assert out == {"view": "<p>ok</p>", "data": {"n": 1}}
+
+
+def test_analysis_defaults_missing_keys():
+    class _Bare(Analysis):
+        name = "bare_analysis"
+        scale = "single"
+
+        def analyze(self, **ctx):
+            return {"data": {"x": 2}}  # no "view"
+
+    step = _Bare({}, core=allocate_core())
+    out = step.update({})
+    assert out == {"view": "", "data": {"x": 2}}
+
+
+def test_analysis_inputs_declare_duckdb_ports():
+    assert set(_Demo({}, core=allocate_core()).inputs()) >= {
+        "conn", "history_sql", "sim_data"}

--- a/tests/test_analysis_runner_duckdb.py
+++ b/tests/test_analysis_runner_duckdb.py
@@ -19,3 +19,56 @@ def test_multivariant_sql_is_unfiltered():
     sql = scale_history_sql("multivariant", _FROM, ())
     assert "WHERE" not in sql.upper()
     assert _FROM in sql
+
+
+import glob as _glob
+import json as _json
+import os as _os
+import pytest as _pytest
+
+
+def _ref_history_dir():
+    d = "out/compare_harness/v2_sim/parquet/two_generations/history"
+    return d if _glob.glob(_os.path.join(d, "**", "*.pq"), recursive=True) else None
+
+
+_PAIRED_SIMDATA = "out/workflow/simData.cPickle"
+
+
+@_pytest.mark.skipif(_ref_history_dir() is None or not _os.path.isfile(_PAIRED_SIMDATA),
+                     reason="reference sweep parquet or paired sim_data absent")
+def test_proving_set_end_to_end(tmp_path):
+    # Build a self-contained sweep dir: history parquet (symlinked) + the PAIRED
+    # sim_data at the sweep root, so resolve_sim_data finds the correct one.
+    import v2ecoli.workflow.analyses  # noqa: F401  (register ports)
+    from v2ecoli.workflow.analysis_runner import run_analyses
+    sweep = tmp_path / "sweep"
+    sweep.mkdir()
+    (sweep / "history").symlink_to(_os.path.abspath(_ref_history_dir()))
+    (sweep / "simData.cPickle").symlink_to(_os.path.abspath(_PAIRED_SIMDATA))
+
+    opts = {
+        "single": {"ptools_rna": {"n_tp": 8}, "ptools_rxns": {"n_tp": 8}},
+        "multiseed": {"central_carbon_metabolism_scatter": {}},
+    }
+    res = run_analyses(str(sweep), opts)
+
+    # data product present (not a recorded error) for a single-scale data analysis
+    rna = res["single"]["ptools_rna"]
+    assert rna, "ptools_rna produced no per-group result"
+    first = next(iter(rna.values()))
+    assert "error" not in first, f"ptools_rna errored: {first}"
+    assert first.get("filename") == "ptools_rna.tsv"
+
+    # reaction analysis did NOT trip the pairing assertion (correct sim_data)
+    rxns = res["single"]["ptools_rxns"]
+    first_rx = next(iter(rxns.values()))
+    assert "error" not in first_rx, f"ptools_rxns errored (pairing?): {first_rx}"
+
+    # multiseed VIEW analysis wrote a viz html
+    assert res["multiseed"]["central_carbon_metabolism_scatter"]
+    viz = _glob.glob(str(sweep / "viz" / "central_carbon_metabolism_scatter*.html"))
+    assert viz, "no viz html written for ccm_scatter"
+
+    # analysis.json written
+    assert _os.path.isfile(str(sweep / "analysis.json"))

--- a/tests/test_analysis_runner_duckdb.py
+++ b/tests/test_analysis_runner_duckdb.py
@@ -1,0 +1,21 @@
+from v2ecoli.workflow.analysis_runner import scale_history_sql
+
+_FROM = "read_parquet(['x.pq'], hive_partitioning=true)"
+
+
+def test_single_sql_filters_full_cell():
+    sql = scale_history_sql("single", _FROM, (0, 1, 2, "00"))
+    assert "variant = 0" in sql and "lineage_seed = 1" in sql
+    assert "generation = 2" in sql and "agent_id = '00'" in sql
+
+
+def test_multiseed_sql_filters_variant_only():
+    sql = scale_history_sql("multiseed", _FROM, (3,))
+    assert "variant = 3" in sql
+    assert "lineage_seed" not in sql and "agent_id" not in sql
+
+
+def test_multivariant_sql_is_unfiltered():
+    sql = scale_history_sql("multivariant", _FROM, ())
+    assert "WHERE" not in sql.upper()
+    assert _FROM in sql

--- a/tests/test_ptools_analyses.py
+++ b/tests/test_ptools_analyses.py
@@ -39,3 +39,12 @@ def test_ptools_rxns_oracle_shape():
     oracle = open(os.path.join(FIX, "ptools_rxns.txt")).read()
     assert oracle.strip().splitlines()[0].split("\t")[0] == "$"
     assert len(_frame_ids(oracle)) > 0
+
+
+def test_ptools_proteins_registered():
+    from v2ecoli.workflow.analyses import ptools_proteins  # noqa: F401
+    from v2ecoli.workflow.analysis import ANALYSIS_REGISTRY, Analysis
+    cls = ANALYSIS_REGISTRY["ptools_proteins"]
+    assert issubclass(cls, Analysis) and cls.scale == "single"
+    from bigraph_schema import allocate_core
+    assert cls({}, core=allocate_core()).outputs() == {"view": "string", "data": "map"}

--- a/tests/test_ptools_analyses.py
+++ b/tests/test_ptools_analyses.py
@@ -11,8 +11,8 @@ def _frame_ids(tsv_text):
     return {r.split("\t")[0] for r in rows[1:]}  # skip header ($ row)
 
 
-@pytest.mark.skipif(not os.path.isdir(FIX), reason="sms-api oracle fixtures absent")
 def test_ptools_rna_registered():
+    # No fixture needed — always runs so CI confirms the port imports + registers.
     from v2ecoli.workflow.analyses import ptools_rna  # noqa: F401
     from v2ecoli.workflow.analysis import ANALYSIS_REGISTRY, Analysis
     cls = ANALYSIS_REGISTRY["ptools_rna"]

--- a/tests/test_ptools_analyses.py
+++ b/tests/test_ptools_analyses.py
@@ -25,3 +25,17 @@ def test_ptools_rna_output_shape_matches_oracle():
     header = oracle.strip().splitlines()[0].split("\t")
     assert header[0] == "$"
     assert len(_frame_ids(oracle)) > 0
+
+
+def test_ptools_rxns_registered():
+    from v2ecoli.workflow.analyses import ptools_rxns  # noqa: F401
+    from v2ecoli.workflow.analysis import ANALYSIS_REGISTRY, Analysis
+    cls = ANALYSIS_REGISTRY["ptools_rxns"]
+    assert issubclass(cls, Analysis) and cls.scale == "single"
+
+
+@pytest.mark.skipif(not os.path.isdir(FIX), reason="sms-api oracle fixtures absent")
+def test_ptools_rxns_oracle_shape():
+    oracle = open(os.path.join(FIX, "ptools_rxns.txt")).read()
+    assert oracle.strip().splitlines()[0].split("\t")[0] == "$"
+    assert len(_frame_ids(oracle)) > 0

--- a/tests/test_ptools_analyses.py
+++ b/tests/test_ptools_analyses.py
@@ -1,0 +1,27 @@
+"""Fidelity tests for the ptools_rna native Analysis port."""
+
+import os
+import pytest
+
+FIX = "/Users/eranagmon/code/sms-api/tests/fixtures/analysis_data"
+
+
+def _frame_ids(tsv_text):
+    rows = [r for r in tsv_text.strip().splitlines() if r]
+    return {r.split("\t")[0] for r in rows[1:]}  # skip header ($ row)
+
+
+@pytest.mark.skipif(not os.path.isdir(FIX), reason="sms-api oracle fixtures absent")
+def test_ptools_rna_registered():
+    from v2ecoli.workflow.analyses import ptools_rna  # noqa: F401
+    from v2ecoli.workflow.analysis import ANALYSIS_REGISTRY, Analysis
+    cls = ANALYSIS_REGISTRY["ptools_rna"]
+    assert issubclass(cls, Analysis) and cls.scale == "single"
+
+
+@pytest.mark.skipif(not os.path.isdir(FIX), reason="sms-api oracle fixtures absent")
+def test_ptools_rna_output_shape_matches_oracle():
+    oracle = open(os.path.join(FIX, "ptools_rna.txt")).read()
+    header = oracle.strip().splitlines()[0].split("\t")
+    assert header[0] == "$"
+    assert len(_frame_ids(oracle)) > 0

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,0 +1,13 @@
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from v2ecoli.workflow.render import fig_to_html
+
+
+def test_fig_to_html_embeds_svg():
+    fig, ax = plt.subplots()
+    ax.plot([0, 1, 2], [0, 1, 4])
+    html = fig_to_html(fig, title="Demo")
+    assert "<svg" in html
+    assert "Demo" in html
+    assert html.strip().startswith("<")

--- a/tests/test_view_analyses.py
+++ b/tests/test_view_analyses.py
@@ -8,3 +8,10 @@ def test_mass_fraction_voronoi_registered_single_view():
     from v2ecoli.workflow.analysis import ANALYSIS_REGISTRY, Analysis
     cls = ANALYSIS_REGISTRY["mass_fraction_voronoi"]
     assert issubclass(cls, Analysis) and cls.scale == "single"
+
+
+def test_ccm_scatter_registered_multiseed():
+    from v2ecoli.workflow.analyses import central_carbon_metabolism_scatter  # noqa: F401
+    from v2ecoli.workflow.analysis import ANALYSIS_REGISTRY, Analysis
+    cls = ANALYSIS_REGISTRY["central_carbon_metabolism_scatter"]
+    assert issubclass(cls, Analysis) and cls.scale == "multiseed"

--- a/tests/test_view_analyses.py
+++ b/tests/test_view_analyses.py
@@ -1,0 +1,10 @@
+"""Tests for Analysis subclasses that return a rendered HTML view."""
+
+from bigraph_schema import allocate_core  # noqa: F401
+
+
+def test_mass_fraction_voronoi_registered_single_view():
+    from v2ecoli.workflow.analyses import mass_fraction_voronoi  # noqa: F401
+    from v2ecoli.workflow.analysis import ANALYSIS_REGISTRY, Analysis
+    cls = ANALYSIS_REGISTRY["mass_fraction_voronoi"]
+    assert issubclass(cls, Analysis) and cls.scale == "single"

--- a/tests/test_workflow_analysis.py
+++ b/tests/test_workflow_analysis.py
@@ -80,9 +80,12 @@ def test_unimplemented_analyze_propagates():
 def test_analysis_registry_maps_names_to_steps():
     from v2ecoli.workflow.analysis import ANALYSIS_REGISTRY, MassFractionSummary
     assert ANALYSIS_REGISTRY["mass_fraction_summary"] is MassFractionSummary
-    from v2ecoli.workflow.analysis import AnalysisStep
+    # The registry holds both analysis bases: the record-based AnalysisStep and
+    # the duckdb/view-based Analysis (added for native vEcoli ports). Both are
+    # V2Step analysis bases keyed by their ``name``.
+    from v2ecoli.workflow.analysis import Analysis, AnalysisStep
     for name, cls in ANALYSIS_REGISTRY.items():
-        assert issubclass(cls, AnalysisStep)
+        assert issubclass(cls, (AnalysisStep, Analysis))
         assert cls.name == name
 
 

--- a/v2ecoli/configs/analyses_proving.json
+++ b/v2ecoli/configs/analyses_proving.json
@@ -1,0 +1,14 @@
+{
+  "inherit_from": "two_generations.json",
+  "analysis_options": {
+    "single": {
+      "ptools_rna": {"n_tp": 8},
+      "ptools_rxns": {"n_tp": 8},
+      "ptools_proteins": {"n_tp": 8},
+      "mass_fraction_voronoi": {}
+    },
+    "multiseed": {
+      "central_carbon_metabolism_scatter": {}
+    }
+  }
+}

--- a/v2ecoli/processes/parca/reconstruction/ecoli/dataclasses/process/complexation.py
+++ b/v2ecoli/processes/parca/reconstruction/ecoli/dataclasses/process/complexation.py
@@ -151,11 +151,17 @@ class Complexation(object):
         Builds a stoichiometric matrix based on each given complexation
         reaction. One reaction corresponds to one column in the stoichiometric
         matrix.
+
+        The result is cached on the instance because ``get_monomers`` calls
+        this method once per molecule, making repeated reconstruction very
+        expensive for large bulk_molecules lists (~16 k entries in E. coli).
         """
-        shape = (self._stoich_matrix_I.max() + 1, self._stoich_matrix_J.max() + 1)
-        out = np.zeros(shape, np.float64)
-        out[self._stoich_matrix_I, self._stoich_matrix_J] = self._stoich_matrix_V
-        return out
+        if not hasattr(self, "_stoich_matrix_built"):
+            shape = (self._stoich_matrix_I.max() + 1, self._stoich_matrix_J.max() + 1)
+            out = np.zeros(shape, np.float64)
+            out[self._stoich_matrix_I, self._stoich_matrix_J] = self._stoich_matrix_V
+            self._stoich_matrix_built = out
+        return self._stoich_matrix_built
 
     def mass_matrix(self):
         """

--- a/v2ecoli/workflow/analyses/__init__.py
+++ b/v2ecoli/workflow/analyses/__init__.py
@@ -6,3 +6,4 @@ Importing this package registers every ported analysis into ANALYSIS_REGISTRY.
 from v2ecoli.workflow.analyses import ptools_rna  # noqa: F401
 from v2ecoli.workflow.analyses import ptools_rxns  # noqa: F401
 from v2ecoli.workflow.analyses import ptools_proteins  # noqa: F401
+from v2ecoli.workflow.analyses import mass_fraction_voronoi  # noqa: F401

--- a/v2ecoli/workflow/analyses/__init__.py
+++ b/v2ecoli/workflow/analyses/__init__.py
@@ -7,3 +7,4 @@ from v2ecoli.workflow.analyses import ptools_rna  # noqa: F401
 from v2ecoli.workflow.analyses import ptools_rxns  # noqa: F401
 from v2ecoli.workflow.analyses import ptools_proteins  # noqa: F401
 from v2ecoli.workflow.analyses import mass_fraction_voronoi  # noqa: F401
+from v2ecoli.workflow.analyses import central_carbon_metabolism_scatter  # noqa: F401

--- a/v2ecoli/workflow/analyses/__init__.py
+++ b/v2ecoli/workflow/analyses/__init__.py
@@ -5,3 +5,4 @@ Importing this package registers every ported analysis into ANALYSIS_REGISTRY.
 
 from v2ecoli.workflow.analyses import ptools_rna  # noqa: F401
 from v2ecoli.workflow.analyses import ptools_rxns  # noqa: F401
+from v2ecoli.workflow.analyses import ptools_proteins  # noqa: F401

--- a/v2ecoli/workflow/analyses/__init__.py
+++ b/v2ecoli/workflow/analyses/__init__.py
@@ -1,0 +1,6 @@
+"""Native ports of vEcoli DuckDB/sim_data analyses (Analysis subclasses).
+
+Importing this package registers every ported analysis into ANALYSIS_REGISTRY.
+"""
+
+from v2ecoli.workflow.analyses import ptools_rna  # noqa: F401

--- a/v2ecoli/workflow/analyses/__init__.py
+++ b/v2ecoli/workflow/analyses/__init__.py
@@ -4,3 +4,4 @@ Importing this package registers every ported analysis into ANALYSIS_REGISTRY.
 """
 
 from v2ecoli.workflow.analyses import ptools_rna  # noqa: F401
+from v2ecoli.workflow.analyses import ptools_rxns  # noqa: F401

--- a/v2ecoli/workflow/analyses/_shims.py
+++ b/v2ecoli/workflow/analyses/_shims.py
@@ -1,0 +1,75 @@
+"""Shared data shims for native vEcoli analysis ports.
+
+v2ecoli's parquet schema differs from vEcoli in two ways that matter for
+the ptools analyses:
+
+    Shim A – bulk count matrix
+        vEcoli stores a single ``bulk`` list column (counts in sim_data order).
+        v2ecoli stores ``bulk__id`` + ``bulk__count`` (both per-row lists,
+        ordering may differ from sim_data).  ``bulk_count_matrix`` re-indexes
+        the counts to sim_data column order so all downstream index arithmetic
+        is identical to the vEcoli original.
+
+    Shim B – active ribosome scalar
+        vEcoli emits ``listeners__unique_molecule_counts__active_ribosome``
+        (a scalar per row).  v2ecoli has no such column; the equivalent is the
+        sum of ``listeners__ribosome_data__n_ribosomes_per_transcript``
+        (a list per row).  Use the SQL snippet ``ACTIVE_RIBOSOME_SQL`` in
+        SELECT lists and read the resulting ``active_ribosome`` column.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+# ---------------------------------------------------------------------------
+# Shim B — active-ribosome SQL snippet
+# ---------------------------------------------------------------------------
+
+ACTIVE_RIBOSOME_SQL = (
+    "list_sum(listeners__ribosome_data__n_ribosomes_per_transcript)"
+    " AS active_ribosome"
+)
+"""Drop this into a SELECT column list to synthesise the active-ribosome
+scalar from v2ecoli's per-transcript ribosome count list."""
+
+
+# ---------------------------------------------------------------------------
+# Shim A — bulk count matrix
+# ---------------------------------------------------------------------------
+
+def bulk_count_matrix(df: pd.DataFrame, sim_data) -> np.ndarray:
+    """Return an (n_tp, n_bulk) count matrix in *sim_data* column order.
+
+    vEcoli provides a single ``bulk`` list column already ordered to match
+    ``sim_data.internal_state.bulk_molecules.bulk_data["id"]``.  v2ecoli's
+    parquet stores ``bulk__id`` + ``bulk__count`` (per row, but with a stable
+    ordering that may differ from sim_data).
+
+    This function:
+      1. Reads the parquet ordering from the first row of ``bulk__id``
+         (verified constant across rows / files).
+      2. Stacks ``bulk__count`` rows into an (n_tp, n_pq) matrix.
+      3. Reorders columns to match sim_data order.
+
+    Parameters
+    ----------
+    df:
+        DataFrame returned by ``read_outputs`` containing ``bulk__id`` and
+        ``bulk__count`` columns.
+    sim_data:
+        Loaded sim_data object (provides the canonical bulk ordering).
+
+    Returns
+    -------
+    np.ndarray of shape (n_tp, n_bulk) with counts in sim_data order.
+    """
+    sim_ids: list[str] = list(
+        sim_data.internal_state.bulk_molecules.bulk_data["id"]
+    )
+    pq_ids: list[str] = list(df["bulk__id"].iloc[0])
+    counts = np.stack(df["bulk__count"].values)          # (n_tp, n_pq)
+    pos = {bid: i for i, bid in enumerate(pq_ids)}
+    col_idx = [pos[b] for b in sim_ids]
+    return counts[:, col_idx]

--- a/v2ecoli/workflow/analyses/_shims.py
+++ b/v2ecoli/workflow/analyses/_shims.py
@@ -1,6 +1,6 @@
 """Shared data shims for native vEcoli analysis ports.
 
-v2ecoli's parquet schema differs from vEcoli in two ways that matter for
+v2ecoli's parquet schema differs from vEcoli in four ways that matter for
 the ptools analyses:
 
     Shim A – bulk count matrix
@@ -16,6 +16,18 @@ the ptools analyses:
         sum of ``listeners__ribosome_data__n_ribosomes_per_transcript``
         (a list per row).  Use the SQL snippet ``ACTIVE_RIBOSOME_SQL`` in
         SELECT lists and read the resulting ``active_ribosome`` column.
+
+    Shim C – oriC count scalar
+        vEcoli emits ``listeners__unique_molecule_counts__oriC`` (scalar).
+        v2ecoli uses ``listeners__replication_data__number_of_oric`` (also
+        scalar).  Use ``ORIC_SQL`` in SELECT lists and read ``oriC``.
+
+    Shim D – active RNAP scalar
+        vEcoli emits ``listeners__unique_molecule_counts__active_RNAP``
+        (scalar).  v2ecoli has no such column; the equivalent is the LENGTH of
+        ``listeners__rnap_data__active_rnap_unique_indexes`` (an INTEGER[]
+        per row).  Use ``ACTIVE_RNAP_SQL`` in SELECT lists and read
+        ``active_RNAP``.
 """
 
 from __future__ import annotations
@@ -33,6 +45,29 @@ ACTIVE_RIBOSOME_SQL = (
 )
 """Drop this into a SELECT column list to synthesise the active-ribosome
 scalar from v2ecoli's per-transcript ribosome count list."""
+
+# ---------------------------------------------------------------------------
+# Shim C — oriC count SQL snippet
+# ---------------------------------------------------------------------------
+
+ORIC_SQL = "listeners__replication_data__number_of_oric AS oriC"
+"""Drop this into a SELECT column list to read the oriC count (scalar).
+
+vEcoli used ``listeners__unique_molecule_counts__oriC``; v2ecoli exposes the
+same value via ``listeners__replication_data__number_of_oric``."""
+
+# ---------------------------------------------------------------------------
+# Shim D — active-RNAP scalar SQL snippet
+# ---------------------------------------------------------------------------
+
+ACTIVE_RNAP_SQL = (
+    "len(listeners__rnap_data__active_rnap_unique_indexes) AS active_RNAP"
+)
+"""Drop this into a SELECT column list to synthesise the active-RNAP scalar.
+
+vEcoli used ``listeners__unique_molecule_counts__active_RNAP``; v2ecoli has
+no such scalar column — the equivalent is the length of
+``listeners__rnap_data__active_rnap_unique_indexes`` (an INTEGER[] per row)."""
 
 
 # ---------------------------------------------------------------------------

--- a/v2ecoli/workflow/analyses/central_carbon_metabolism_scatter.py
+++ b/v2ecoli/workflow/analyses/central_carbon_metabolism_scatter.py
@@ -1,0 +1,258 @@
+"""Native port of vEcoli ``ecoli/analysis/multiseed/centralCarbonMetabolismScatter.py``.
+
+Scatter plot of simulated central-carbon-metabolism reaction fluxes vs. Toya
+2010 experimental measurements.  Registered in ANALYSIS_REGISTRY as
+``"central_carbon_metabolism_scatter"`` (scale: ``"multiseed"``).
+
+Key design decisions vs. the vEcoli original
+--------------------------------------------
+* ``base_reaction_ids`` comes from ``sim_data.process.metabolism.base_reaction_ids``
+  (not from ``field_metadata(conn, config_sql, ...)``) — v2ecoli analyses do not
+  receive a ``config_sql`` argument.
+* 1:1 alignment is asserted loudly: if ``len(base_reaction_ids) != flux_width`` we
+  raise a clear ``ValueError`` rather than silently truncating (a mismatch means
+  the caller passed the wrong sim_data).  Use ``out/workflow/simData.cPickle``
+  (2820 base_reaction_ids) for the parquet emitted by the compare_harness sweep.
+* t=0 rows where FBA has not yet run (empty flux array) are dropped before the
+  alignment check, matching ``ptools_rxns`` behaviour.
+* ``validation_data=None`` guard: the Toya 2010 comparison requires
+  ``validation_data.reactionFlux.toya2010fluxes``.  When ``validation_data`` is
+  ``None``, the analysis falls back to a bar chart of the top-30 base reactions
+  by absolute mean simulated flux so that the view is still informative.
+"""
+
+from __future__ import annotations
+
+import matplotlib
+matplotlib.use("Agg")  # headless — must precede pyplot import
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from typing import Any
+from duckdb import DuckDBPyConnection
+from scipy.stats import pearsonr
+
+from wholecell.utils import units
+from v2ecoli.workflow.analysis import Analysis, ANALYSIS_REGISTRY
+from v2ecoli.workflow.render import fig_to_html
+
+# cell_density is a unum quantity [g/L]; asNumber requires a unum unit
+# (VOLUME_UNITS/MASS_UNITS from v2ecoli.processes.metabolism are pint units and
+# are incompatible with unum's asNumber — use wholecell unum units directly).
+_DENSITY_UNITS = units.g / units.L
+
+
+# ---------------------------------------------------------------------------
+# Column list
+# ---------------------------------------------------------------------------
+
+_DATA_COLUMNS = [
+    "agent_id",
+    "generation",
+    "lineage_seed",
+    "listeners__fba_results__base_reaction_fluxes",
+    "listeners__mass__cell_mass",
+    "listeners__mass__dry_mass",
+]
+
+
+def _read_ccm_data(history_sql: str, conn: DuckDBPyConnection) -> pd.DataFrame:
+    """Query required columns from parquet, ordered by global_time."""
+    col_list = ", ".join(_DATA_COLUMNS)
+    query = f"""
+        SELECT {col_list}, global_time AS time
+        FROM ({history_sql})
+        ORDER BY time
+    """
+    return conn.sql(query).df()
+
+
+# ---------------------------------------------------------------------------
+# Analysis subclass
+# ---------------------------------------------------------------------------
+
+class CentralCarbonMetabolismScatter(Analysis):
+    """Central carbon metabolism flux scatter: model vs. Toya 2010 (multiseed).
+
+    Faithfully ported from vEcoli
+    ``ecoli/analysis/multiseed/centralCarbonMetabolismScatter.py``.
+    Returns ``{"view": <html with inline SVG>}``.
+
+    When ``validation_data`` is ``None``, falls back to a bar chart of the
+    top-30 base reactions by absolute mean simulated flux.
+    """
+
+    name = "central_carbon_metabolism_scatter"
+    scale = "multiseed"
+
+    def analyze(
+        self,
+        *,
+        conn: DuckDBPyConnection,
+        history_sql: str,
+        sim_data,
+        validation_data=None,
+        variant_metadata: dict[str, Any] | None = None,
+        **ctx,
+    ) -> dict:
+        # --- 1. base_reaction_ids from sim_data ------------------------------
+        base_reaction_ids = sim_data.process.metabolism.base_reaction_ids
+        base_reaction_id_to_index = {
+            rxn_id: i for i, rxn_id in enumerate(base_reaction_ids)
+        }
+
+        # --- 2. Query parquet ------------------------------------------------
+        result = _read_ccm_data(history_sql, conn)
+
+        # --- 3. Drop t=0 rows where FBA hasn't run (empty flux arrays) -------
+        flux_col = "listeners__fba_results__base_reaction_fluxes"
+        result = result[result[flux_col].apply(len) > 0].reset_index(drop=True)
+
+        if result.empty:
+            raise ValueError("No non-empty FBA flux rows found in history_sql")
+
+        # --- 4. 1:1 alignment assertion (see module docstring) ---------------
+        sample_flux = result[flux_col].iloc[0]
+        flux_width = len(sample_flux)
+        n_ids = len(base_reaction_ids)
+        if n_ids != flux_width:
+            raise ValueError(
+                f"base_reaction_ids ({n_ids}) != flux width ({flux_width}); "
+                "sim_data does not pair with this parquet — use "
+                "out/workflow/simData.cPickle, not out/kb/simData.cPickle"
+            )
+
+        # --- 5. Convert fluxes: raw (mmol/gDW/s) → mmol/gDW/h ---------------
+        # coefficient = dryMass/cellMass * density  [g/L]
+        # flux_converted = flux / coefficient * 3600  [mmol/g/h]
+        cellDensity = sim_data.constants.cell_density
+        cell_mass = result["listeners__mass__cell_mass"].values
+        dry_mass = result["listeners__mass__dry_mass"].values
+        coefficient = dry_mass / cell_mass * cellDensity.asNumber(_DENSITY_UNITS)
+
+        fluxes_full = np.stack(result[flux_col].values)           # (N, n_rxns)
+        # broadcast coefficient (N,) across reactions axis
+        fluxes_converted = fluxes_full / coefficient[:, np.newaxis] * 3600
+
+        # --- 6. Per-agent mean fluxes ----------------------------------------
+        lineage_seeds = result["lineage_seed"].values
+        generations = result["generation"].values
+        agent_ids = result["agent_id"].values
+
+        # Unique (seed, generation, agent_id) triples
+        unique_agents = list(
+            {(int(s), int(g), a)
+             for s, g, a in zip(lineage_seeds, generations, agent_ids)}
+        )
+
+        # --- 7. Branch: with vs. without validation_data ---------------------
+        if validation_data is not None:
+            # Full Toya 2010 comparison scatter (faithful port)
+            toyaReactions = validation_data.reactionFlux.toya2010fluxes["reactionID"]
+            toyaFluxes = validation_data.reactionFlux.toya2010fluxes["reactionFlux"]
+            toyaStdev = validation_data.reactionFlux.toya2010fluxes["reactionFluxStdev"]
+            toyaFluxesDict = dict(zip(toyaReactions, toyaFluxes))
+            toyaStdevDict = dict(zip(toyaReactions, toyaStdev))
+            mmol_per_g_per_h = units.mmol / units.g / units.h
+
+            modelFluxes: dict[str, list[float]] = {rxn: [] for rxn in toyaReactions}
+
+            for seed, gen, agent in unique_agents:
+                mask = (
+                    (lineage_seeds == seed)
+                    & (generations == gen)
+                    & (agent_ids == agent)
+                )
+                agent_fluxes = fluxes_converted[mask]  # (n_timepoints_agent, n_rxns)
+                for toyaReaction in toyaReactions:
+                    if toyaReaction in base_reaction_id_to_index:
+                        rxn_idx = base_reaction_id_to_index[toyaReaction]
+                        flux_tc = agent_fluxes[:, rxn_idx]
+                        modelFluxes[toyaReaction].append(float(np.mean(flux_tc)))
+
+            toyaVsReactionAve = []
+            for rxn, toyaFlux in toyaFluxesDict.items():
+                if rxn in modelFluxes and len(modelFluxes[rxn]) > 0:
+                    toyaVsReactionAve.append((
+                        np.mean(modelFluxes[rxn]),
+                        toyaFlux.asNumber(mmol_per_g_per_h),
+                        np.std(modelFluxes[rxn]),
+                        toyaStdevDict[rxn].asNumber(mmol_per_g_per_h),
+                    ))
+
+            if not toyaVsReactionAve:
+                raise ValueError(
+                    "No Toya 2010 reactions found in base_reaction_ids; "
+                    "cannot render CCM scatter with validation_data"
+                )
+
+            toyaVsReactionAve = np.array(toyaVsReactionAve)
+            rWithAll = pearsonr(toyaVsReactionAve[:, 0], toyaVsReactionAve[:, 1])
+
+            fig, ax = plt.subplots(figsize=(8, 8))
+            ax.set_title(
+                "Central Carbon Metabolism Flux, Pearson R = %.4f, p = %s\n"
+                % (rWithAll[0], rWithAll[1])
+            )
+            ax.set_xlabel("Toya 2010 Reaction Flux [mmol/g/hr]")
+            ax.set_ylabel("Mean WCM Reaction Flux [mmol/g/hr]")
+            ax.errorbar(
+                toyaVsReactionAve[:, 1],
+                toyaVsReactionAve[:, 0],
+                xerr=toyaVsReactionAve[:, 3],
+                yerr=toyaVsReactionAve[:, 2],
+                fmt=".",
+                ecolor="k",
+                alpha=0.5,
+                linewidth=0.5,
+            )
+            ylim = ax.get_ylim()
+            ax.plot([ylim[0], ylim[1]], [ylim[0], ylim[1]], color="k")
+            ax.plot(toyaVsReactionAve[:, 1], toyaVsReactionAve[:, 1], color="black")
+            ax.plot(
+                toyaVsReactionAve[:, 1],
+                toyaVsReactionAve[:, 0],
+                "ob",
+                markeredgewidth=0.1,
+                alpha=0.9,
+            )
+            ax.set_xlim([-20, 30])
+            ax.set_ylim([-20, 70])
+            xlim = ax.get_xlim()
+            ylim = ax.get_ylim()
+            ax.set_yticks(list(range(int(ylim[0]), int(ylim[1]) + 1, 10)))
+            ax.set_xticks(list(range(int(xlim[0]), int(xlim[1]) + 1, 10)))
+
+        else:
+            # validation_data is None — render simulated flux distribution.
+            # Compute mean flux across all timepoints and agents for every
+            # base reaction, then show the top 30 by absolute mean flux.
+            # NOTE: the full Toya 2010 comparison (scatter vs. experimental
+            # fluxes) requires validation_data.reactionFlux.toya2010fluxes
+            # and is unavailable here.
+            mean_fluxes = np.mean(fluxes_converted, axis=0)  # (n_rxns,)
+
+            top_n = min(30, len(base_reaction_ids))
+            top_idx = np.argsort(np.abs(mean_fluxes))[-top_n:][::-1]
+            top_ids = [base_reaction_ids[i] for i in top_idx]
+            top_fluxes = mean_fluxes[top_idx]
+
+            colors = ["#2196F3" if f >= 0 else "#F44336" for f in top_fluxes]
+            fig, ax = plt.subplots(figsize=(12, 6))
+            ax.set_title(
+                "Central Carbon Metabolism — Simulated Flux Distribution\n"
+                f"(validation_data not provided; n_seeds={len(set(lineage_seeds))}, "
+                f"top {top_n} of {len(base_reaction_ids)} reactions by |mean flux|)"
+            )
+            ax.barh(range(top_n), top_fluxes, color=colors)
+            ax.set_yticks(range(top_n))
+            ax.set_yticklabels(top_ids, fontsize=7)
+            ax.set_xlabel("Mean Reaction Flux [mmol/gDW/hr]")
+            ax.axvline(0, color="k", linewidth=0.5)
+            ax.invert_yaxis()
+            fig.tight_layout()
+
+        html = fig_to_html(fig, title="Central carbon metabolism")
+        plt.close(fig)
+        return {"view": html}

--- a/v2ecoli/workflow/analyses/mass_fraction_voronoi.py
+++ b/v2ecoli/workflow/analyses/mass_fraction_voronoi.py
@@ -1,0 +1,242 @@
+"""Native port of vEcoli ``ecoli/analysis/single/mass_fraction_voronoi.py``.
+
+Produces a Voronoi-tiled biomass-fraction figure (initial vs. final cell mass
+components) and returns it as an inline-SVG HTML view.  Registered in
+ANALYSIS_REGISTRY as ``"mass_fraction_voronoi"`` (scale: ``"single"``).
+
+No shims required: all seven ``listeners__mass__*`` columns are present in the
+v2ecoli parquet schema.  The bulk lookup (lipids/polyamines/LPS/murein/
+glycogen) uses Shim A (bulk_count_matrix) exactly as the ptools analyses do.
+"""
+
+from __future__ import annotations
+
+import matplotlib
+matplotlib.use("Agg")  # headless — must precede pyplot import
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from typing import Any
+from duckdb import DuckDBPyConnection
+
+from wholecell.utils import units
+from wholecell.utils.voronoi_plot_main import VoronoiMaster
+import wholecell.utils.voronoi_plot_main as _vpm
+
+from v2ecoli.workflow.analysis import Analysis, ANALYSIS_REGISTRY
+from v2ecoli.workflow.analyses._shims import bulk_count_matrix
+from v2ecoli.workflow.render import fig_to_html
+
+# ---------------------------------------------------------------------------
+# matplotlib 3.10 compat + wholecell VoronoiMaster bug fixes
+#
+# Bug 1: Polygon(xy, closed) → Polygon(xy, closed=closed)
+#   matplotlib 3.10 made `closed` keyword-only.  voronoi_plot_main does
+#   `from matplotlib.patches import Polygon` at module level, so we patch the
+#   name in *that* module's namespace rather than in matplotlib itself.
+#
+# Bug 2: _add_labels recurses on [label, site] leaf pairs
+#   The method checks `isinstance(element, list)` and recurses, but
+#   [label_string, coordinate_array] is also a list — causing it to iterate
+#   over the string label and fail with IndexError.  We detect a leaf pair by
+#   checking: len==2, first element is str, second is not str.
+# ---------------------------------------------------------------------------
+_OrigPoly = _vpm.Polygon
+
+class _Poly310(_OrigPoly):  # type: ignore[misc]
+    def __init__(self, xy, closed=True, **kwargs):
+        super().__init__(xy, closed=closed, **kwargs)
+
+_vpm.Polygon = _Poly310
+
+
+def _fixed_add_labels(self, label_site_list, font_size, ax):
+    """Replacement for VoronoiMaster._add_labels that handles leaf pairs."""
+    for element in label_site_list:
+        # Leaf: [label_string, (x, y)]
+        if (
+            isinstance(element, (list, tuple))
+            and len(element) == 2
+            and isinstance(element[0], str)
+            and not isinstance(element[1], str)
+        ):
+            ax.text(
+                element[1][0],
+                element[1][1],
+                element[0],
+                fontsize=font_size,
+                horizontalalignment="center",
+                verticalalignment="center",
+            )
+        elif isinstance(element, (list, tuple)):
+            _fixed_add_labels(self, element, font_size, ax)
+
+_vpm.VoronoiMaster._add_labels = _fixed_add_labels
+
+
+def _fixed_compute_error(self, polygon_value_list, total_value, total_area):
+    """Replacement that skips broken leaf-pair traversal.
+
+    The installed wholecell version has the same isinstance(list) confusion
+    as _add_labels: it recurses on [polygon, value] leaf pairs instead of
+    handling them directly.  Since _compute_error is only used for the
+    verbose area-error print (verbose=False by default), returning 0 is safe.
+    """
+    return 0.0
+
+_vpm.VoronoiMaster._compute_error = _fixed_compute_error
+
+
+# ---------------------------------------------------------------------------
+# Query helper
+# ---------------------------------------------------------------------------
+
+_MASS_COLUMNS = [
+    "listeners__mass__rna_mass",
+    "listeners__mass__protein_mass",
+    "listeners__mass__tRna_mass",
+    "listeners__mass__rRna_mass",
+    "listeners__mass__mRna_mass",
+    "listeners__mass__dna_mass",
+    "listeners__mass__smallMolecule_mass",
+    "bulk__id",
+    "bulk__count",
+]
+
+
+def _read_voronoi_data(
+    history_sql: str,
+    conn: DuckDBPyConnection,
+) -> pd.DataFrame:
+    """Query mass listener columns + bulk from parquet, ordered by time."""
+    col_list = ", ".join(_MASS_COLUMNS)
+    query = f"""
+        SELECT {col_list}, global_time AS time
+        FROM ({history_sql})
+        ORDER BY time
+    """
+    return conn.sql(query).df()
+
+
+# ---------------------------------------------------------------------------
+# Analysis subclass
+# ---------------------------------------------------------------------------
+
+class MassFractionVoronoi(Analysis):
+    """Voronoi biomass-fraction plot: initial vs. final cell (single scale).
+
+    Faithfully ported from vEcoli ``ecoli/analysis/single/mass_fraction_voronoi.py``.
+    Returns ``{"view": <html with inline SVG>}``.
+    """
+
+    name = "mass_fraction_voronoi"
+    scale = "single"
+
+    def analyze(
+        self,
+        *,
+        conn: DuckDBPyConnection,
+        history_sql: str,
+        sim_data,
+        variant_metadata: dict[str, Any] | None = None,
+        **ctx,
+    ) -> dict:
+        # --- 1. Query data ---------------------------------------------------
+        df = _read_voronoi_data(history_sql, conn)
+
+        # --- 2. Bulk molecule count matrix (Shim A) --------------------------
+        bulk_molecule_counts = bulk_count_matrix(df, sim_data)
+
+        # Build index from sim_data order
+        bulk_molecule_ids: list[str] = list(
+            sim_data.internal_state.bulk_molecules.bulk_data["id"]
+        )
+        bulk_molecule_idx = {name: idx for idx, name in enumerate(bulk_molecule_ids)}
+
+        nAvogadro = sim_data.constants.n_avogadro
+
+        # --- 3. Helper functions (verbatim from vEcoli) ----------------------
+        def find_mass_molecule_group(group_id):
+            temp_ids = getattr(sim_data.molecule_groups, str(group_id))
+            temp_indexes = np.array([bulk_molecule_idx[t] for t in temp_ids])
+            temp_counts = bulk_molecule_counts[:, temp_indexes]
+            temp_mw = sim_data.getter.get_masses(temp_ids)
+            return (units.dot(temp_counts, temp_mw) / nAvogadro).asNumber(units.fg)
+
+        def find_mass_single_molecule(molecule_id):
+            temp_id = getattr(sim_data.molecule_ids, str(molecule_id))
+            temp_index = bulk_molecule_idx[temp_id]
+            temp_counts = bulk_molecule_counts[:, temp_index]
+            temp_mw = sim_data.getter.get_mass(temp_id)
+            return (units.multiply(temp_counts, temp_mw) / nAvogadro).asNumber(units.fg)
+
+        # --- 4. Derived mass arrays ------------------------------------------
+        lipid = find_mass_molecule_group("lipids")
+        polyamines = find_mass_molecule_group("polyamines")
+        lps = find_mass_single_molecule("LPS")
+        murein = find_mass_single_molecule("murein")
+        glycogen = find_mass_single_molecule("glycogen")
+
+        protein = df["listeners__mass__protein_mass"].values
+        rna = df["listeners__mass__rna_mass"].values
+        tRna = df["listeners__mass__tRna_mass"].values
+        rRna = df["listeners__mass__rRna_mass"].values
+        mRna = df["listeners__mass__mRna_mass"].values
+        miscRna = rna - (tRna + rRna + mRna)
+        dna = df["listeners__mass__dna_mass"].values
+        smallMolecules = df["listeners__mass__smallMolecule_mass"].values
+        metabolites = smallMolecules - (lipid + lps + murein + polyamines + glycogen)
+
+        # --- 5. Build voronoi data dicts (verbatim) --------------------------
+        dic_initial = {
+            "nucleic_acid": {
+                "DNA": dna[0],
+                "mRNA": mRna[0],
+                "miscRNA": miscRna[0],
+                "rRNA": rRna[0],
+                "tRNA": tRna[0],
+            },
+            "metabolites": {
+                "LPS": lps[0],
+                "glycogen": glycogen[0],
+                "lipid": lipid[0],
+                "metabolites": metabolites[0],
+                "peptidoglycan": murein[0],
+                "polyamines": polyamines[0],
+            },
+            "protein": protein[0],
+        }
+        dic_final = {
+            "nucleic_acid": {
+                "DNA": dna[-1],
+                "mRNA": mRna[-1],
+                "miscRNA": miscRna[-1],
+                "rRNA": rRna[-1],
+                "tRNA": tRna[-1],
+            },
+            "metabolites": {
+                "LPS": lps[-1],
+                "glycogen": glycogen[-1],
+                "lipid": lipid[-1],
+                "metabolites": metabolites[-1],
+                "peptidoglycan": murein[-1],
+                "polyamines": polyamines[-1],
+            },
+            "protein": protein[-1],
+        }
+
+        # --- 6. Render Voronoi plot ------------------------------------------
+        vm = VoronoiMaster()
+        vm.plot(
+            [[dic_initial, dic_final]],
+            title=[["Initial biomass components", "Final biomass components"]],
+            ax_shape=(1, 2),
+            chained=True,
+        )
+
+        fig = plt.gcf()
+        html = fig_to_html(fig, title="Mass fraction (Voronoi)")
+        plt.close(fig)
+
+        return {"view": html}

--- a/v2ecoli/workflow/analyses/ptools_proteins.py
+++ b/v2ecoli/workflow/analyses/ptools_proteins.py
@@ -1,0 +1,187 @@
+"""Native port of vEcoli ``ecoli/analysis/single/ptools_proteins.py``.
+
+Produces a protein-monomer × timepoint proteomics TSV (PathwayTools-compatible
+format).  Registered in ANALYSIS_REGISTRY as ``"ptools_proteins"``
+(scale: ``"single"``).
+
+Four v2ecoli parquet shims are applied (see _shims.py):
+  - bulk__id + bulk__count  → bulk_count_matrix()            (Shim A)
+  - list_sum(n_ribosomes_per_transcript) → active_ribosome   (Shim B)
+  - listeners__replication_data__number_of_oric AS oriC      (Shim C)
+  - len(active_rnap_unique_indexes) AS active_RNAP           (Shim D)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pandas as pd
+from duckdb import DuckDBPyConnection
+
+from v2ecoli.workflow.analysis import Analysis, ANALYSIS_REGISTRY
+from v2ecoli.workflow.analyses._shims import (
+    bulk_count_matrix,
+    ACTIVE_RIBOSOME_SQL,
+    ORIC_SQL,
+    ACTIVE_RNAP_SQL,
+)
+# Re-use pure-computation helpers already defined in ptools_rna to avoid
+# duplication (same algorithm, identical to the vEcoli originals).
+from v2ecoli.workflow.analyses.ptools_rna import (
+    get_bulk_ids,
+    build_bulk2monomers_matrix,
+    consolidate_timepoints,
+)
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers
+# ---------------------------------------------------------------------------
+
+def build_query(columns, history_sql):
+    """Generate SQL query for user-specified parquet columns."""
+    query_sql = f"""
+        SELECT {",".join(columns)}, global_time AS time
+        FROM ({history_sql})
+        ORDER BY time
+    """
+    return query_sql
+
+
+def read_outputs(
+    history_sql: str,
+    conn: DuckDBPyConnection,
+    columns=None,
+):
+    """Retrieve specific columns from parquet outputs and return a DataFrame."""
+    if columns is None:
+        columns = [
+            "bulk__id",
+            "bulk__count",
+            ORIC_SQL,
+            ACTIVE_RNAP_SQL,
+            ACTIVE_RIBOSOME_SQL,
+        ]
+    query_sql = build_query(columns, history_sql)
+    outputs_df = conn.sql(query_sql).df()
+    outputs_df = outputs_df.groupby("time", as_index=False).sum()
+    return outputs_df
+
+
+# ---------------------------------------------------------------------------
+# Analysis subclass
+# ---------------------------------------------------------------------------
+
+class PtoolsProteins(Analysis):
+    """Protein-monomer × timepoint proteomics table (PathwayTools-compatible TSV)."""
+
+    name = "ptools_proteins"
+    scale = "single"
+    config_schema = {"n_tp": "integer", "time_unit": "string"}
+
+    def analyze(
+        self,
+        *,
+        conn: DuckDBPyConnection,
+        history_sql: str,
+        sim_data,
+        variant_metadata: dict[str, Any] | None = None,
+        **ctx,
+    ) -> dict:
+        params = dict(variant_metadata or {})
+        params.setdefault("n_tp", 8)
+        params.setdefault("time_unit", "minutes")
+
+        if params["time_unit"] not in ("minutes", "seconds"):
+            params["time_unit"] = "minutes"
+
+        bulk_ids = get_bulk_ids(sim_data)
+
+        output_columns = [
+            "bulk__id",
+            "bulk__count",
+            ORIC_SQL,            # Shim C: oriC count (number_of_oric scalar)
+            ACTIVE_RNAP_SQL,     # Shim D: active RNAP (len of unique_indexes list)
+            ACTIVE_RIBOSOME_SQL, # Shim B: active ribosome (sum of per-transcript list)
+        ]
+
+        output_df = read_outputs(history_sql, conn, output_columns)
+
+        # Shim A: reorder bulk__count columns to sim_data order
+        bulk_mtx = bulk_count_matrix(output_df, sim_data)
+
+        translation_module = sim_data.process.translation.monomer_data.fullArray()
+
+        replisome_monomer_subunits = sim_data.molecule_groups.replisome_monomer_subunits
+        replisome_trimer_subunits = sim_data.molecule_groups.replisome_trimer_subunits
+        riboproteins = [
+            sim_data.molecule_ids.s30_full_complex,
+            sim_data.molecule_ids.s50_full_complex,
+        ]
+        rnap_id = sim_data.molecule_ids.full_RNAP
+
+        # Distribute replisome-bound proteins back into bulk counts.
+        # Each oriC fork has 2 copies of monomer subunits and 6 of trimer subunits
+        # (matching vEcoli's unique-molecule → bulk decomplexation logic).
+        for bulk_id in replisome_monomer_subunits:
+            unique_complex = output_df["oriC"].values  # Shim C
+            add_bulk = unique_complex * 2
+            bulk_idx = bulk_ids.index(bulk_id)
+            bulk_mtx[:, bulk_idx] = bulk_mtx[:, bulk_idx] + add_bulk
+
+        for bulk_id in replisome_trimer_subunits:
+            unique_complex = output_df["oriC"].values  # Shim C
+            add_bulk = unique_complex * 6
+            bulk_idx = bulk_ids.index(bulk_id)
+            bulk_mtx[:, bulk_idx] = bulk_mtx[:, bulk_idx] + add_bulk
+
+        for bulk_id in riboproteins:
+            unique_complex = output_df["active_ribosome"].values  # Shim B
+            add_bulk = unique_complex
+            bulk_idx = bulk_ids.index(bulk_id)
+            bulk_mtx[:, bulk_idx] = bulk_mtx[:, bulk_idx] + add_bulk
+
+        rnap_counts = output_df["active_RNAP"].values  # Shim D
+        rnap_idx = bulk_ids.index(rnap_id)
+        bulk_mtx[:, rnap_idx] = bulk_mtx[:, rnap_idx] + rnap_counts
+
+        bulk2monomers, all_monomers = build_bulk2monomers_matrix(sim_data)
+
+        protein_monomers = translation_module["id"]
+
+        protein_monomer_idxs = np.array(
+            [all_monomers.index(protein) for protein in protein_monomers]
+        )
+
+        bulk2protein_monomers = bulk2monomers[:, protein_monomer_idxs]
+
+        protein_labels = [protein[:-3] for protein in protein_monomers]
+
+        proteomics = np.matmul(bulk_mtx, bulk2protein_monomers)
+
+        n_tp = int(params["n_tp"])
+
+        proteomics_bulksum, tp_idx = consolidate_timepoints(
+            proteomics, n_tp, normalized=True
+        )
+
+        tp_checkpoints = output_df["time"].values[tp_idx]
+
+        if params["time_unit"] == "minutes":
+            tp_checkpoints = tp_checkpoints / 60
+            tp_checkpoints = [round(x) for x in tp_checkpoints]
+
+        tp_columns = [str(i) + params["time_unit"][0] for i in tp_checkpoints]
+
+        ptools_proteins_df = pd.DataFrame(
+            data=proteomics_bulksum.transpose(),
+            index=protein_labels,
+            columns=tp_columns,
+        )
+        ptools_proteins_df.index.name = "$"
+
+        tsv = ptools_proteins_df.to_csv(
+            sep="\t", index=True, header=True, float_format="%.4f"
+        )
+        return {"data": {"filename": "ptools_proteins.tsv", "tsv": tsv}}

--- a/v2ecoli/workflow/analyses/ptools_rna.py
+++ b/v2ecoli/workflow/analyses/ptools_rna.py
@@ -1,0 +1,396 @@
+"""Native port of vEcoli ``ecoli/analysis/single/ptools_rna.py``.
+
+Produces a gene × timepoint RNA-count TSV (PathwayTools-compatible format).
+Registered in ANALYSIS_REGISTRY as ``"ptools_rna"`` (scale: ``"single"``).
+
+Two v2ecoli parquet shims are applied (see _shims.py):
+  - bulk__id + bulk__count  → bulk_count_matrix()  (Shim A)
+  - list_sum(n_ribosomes_per_transcript) → active_ribosome  (Shim B)
+"""
+
+from __future__ import annotations
+
+import importlib.resources as _ir
+import os
+from typing import Any
+
+import numpy as np
+import pandas as pd
+from duckdb import DuckDBPyConnection
+
+from v2ecoli.workflow.analysis import Analysis, ANALYSIS_REGISTRY
+from v2ecoli.workflow.analyses._shims import bulk_count_matrix, ACTIVE_RIBOSOME_SQL
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers (verbatim from vEcoli, except wd_raw derivation)
+# ---------------------------------------------------------------------------
+
+def _flat_dir() -> str:
+    """Return the path to the ``reconstruction/ecoli/flat`` directory."""
+    import reconstruction.ecoli.flat as _flat_pkg  # installed via vEcoli-sources
+    # ir.files() returns a MultiplexedPath; navigate to a file first to get a
+    # concrete PosixPath, then take its parent.
+    return str((_ir.files(_flat_pkg) / "transcription_units.tsv").parent)
+
+
+def build_query(columns, history_sql):
+    """Generate SQL query for user-specified parquet columns."""
+    query_sql = f"""
+        SELECT {",".join(columns)}, global_time AS time
+        FROM ({history_sql})
+        ORDER BY time
+    """
+    return query_sql
+
+
+def read_outputs(
+    history_sql: str,
+    conn: DuckDBPyConnection,
+    columns=None,
+):
+    """Retrieve specific columns from parquet outputs and return a DataFrame."""
+    if columns is None:
+        columns = [
+            "bulk__id",
+            "bulk__count",
+            "listeners__rna_counts__full_mRNA_counts",
+        ]
+    query_sql = build_query(columns, history_sql)
+    outputs_df = conn.sql(query_sql).df()
+    # For list/array columns, groupby sum works via element-wise numpy addition.
+    # With a single-cell (single scale) query there is typically one row per
+    # timestep, so this is effectively identity but preserves vEcoli semantics.
+    outputs_df = outputs_df.groupby("time", as_index=False).sum()
+    return outputs_df
+
+
+def retrieve_tu_source(wd_raw):
+    """Read and combine transcription units raw data."""
+    tu_source_1 = pd.read_csv(
+        os.path.join(wd_raw, "transcription_units.tsv"),
+        sep="\t",
+        header=5,
+        index_col=0,
+    )
+    tu_source_2 = pd.read_csv(
+        os.path.join(wd_raw, "transcription_units_added.tsv"),
+        sep="\t",
+        header=0,
+        index_col=0,
+    )
+    tu_source_2 = tu_source_2.drop("_comments", axis=1)
+    tu_source = pd.concat([tu_source_1, tu_source_2], axis=0)
+    return tu_source
+
+
+def tu2gene_mapping(tu_ids, tu_source):
+    """Create a mapping between transcription units and individual genes."""
+    tu_ids_source = [id_[:-3] for id_ in tu_ids]
+
+    tu_id2genes = []
+    for i, tu_id_src in enumerate(tu_ids_source):
+        try:
+            tu_id_genes = tu_source["genes"][tu_id_src]
+        except KeyError:
+            tu_id_genes = f"[{tu_id_src.replace('_RNA', '')}]"
+
+        tu_id_genes = tu_id_genes[1:-1].replace('"', "").split(", ")
+        tu_id2genes.append(tu_id_genes)
+
+    tu_id2genes = dict(zip(tu_ids, tu_id2genes))
+    genes_tu_all = np.unique(
+        [gene for genes in list(tu_id2genes.values()) for gene in genes]
+    ).tolist()
+
+    return tu_id2genes, genes_tu_all
+
+
+def get_bulk_ids(sim_data):
+    """Return list of bulk molecule IDs in sim_data order."""
+    return sim_data.internal_state.bulk_molecules.bulk_data["id"].tolist()
+
+
+def build_bulk2monomers_matrix(sim_data):
+    """Decomplexe bulk species into monomers."""
+    bulk_ids = sim_data.internal_state.bulk_molecules.bulk_data["id"].tolist()
+    get_monomers = sim_data.process.complexation.get_monomers
+    all_monomers = [list(get_monomers(bulk_id)["subunitIds"]) for bulk_id in bulk_ids]
+    all_monomers = [item for sublist in all_monomers for item in sublist]
+    all_monomers = list(np.unique(all_monomers))
+
+    bulk2monomers = np.zeros((len(bulk_ids), len(all_monomers)))
+    for idx, bulk_id in enumerate(bulk_ids):
+        monomer_mapping = get_monomers(bulk_id)
+        subunits = monomer_mapping["subunitIds"]
+        stoich_coeffs = monomer_mapping["subunitStoich"]
+        for j in range(len(subunits)):
+            subunit = subunits[j]
+            monomer_idx = all_monomers.index(subunit)
+            bulk2monomers[idx, monomer_idx] = stoich_coeffs[j]
+
+    return bulk2monomers, all_monomers
+
+
+def consolidate_timepoints(state_mtx, n_tp, normalized=False):
+    """Generate consolidated relative time points."""
+    checkpoints = np.linspace(0, np.shape(state_mtx)[0] - 1, n_tp, dtype=int)
+
+    if normalized:
+        denom = [
+            len(state_mtx[checkpoints[i]: checkpoints[i + 1]])
+            for i in range(len(checkpoints) - 1)
+        ]
+        block_sums = [
+            state_mtx[checkpoints[i]: checkpoints[i + 1]].sum(axis=0) / denom[i]
+            for i in range(len(checkpoints) - 1)
+        ]
+    else:
+        block_sums = [
+            state_mtx[checkpoints[i]: checkpoints[i + 1]].sum(axis=0)
+            for i in range(len(checkpoints) - 1)
+        ]
+
+    block_sums = np.stack(block_sums, axis=0)
+    block_sums_final = np.insert(block_sums, 0, state_mtx[0], axis=0)
+
+    return block_sums_final, checkpoints
+
+
+# ---------------------------------------------------------------------------
+# Analysis subclass
+# ---------------------------------------------------------------------------
+
+class PtoolsRna(Analysis):
+    """Gene × timepoint RNA-count table (PathwayTools-compatible TSV)."""
+
+    name = "ptools_rna"
+    scale = "single"
+    config_schema = {"n_tp": "integer", "time_unit": "string"}
+
+    def analyze(
+        self,
+        *,
+        conn: DuckDBPyConnection,
+        history_sql: str,
+        sim_data,
+        variant_metadata: dict[str, Any] | None = None,
+        **ctx,
+    ) -> dict:
+        params = dict(variant_metadata or {})
+        params.setdefault("n_tp", 8)
+        params.setdefault("time_unit", "minutes")
+
+        if params["time_unit"] not in ("minutes", "seconds"):
+            params["time_unit"] = "minutes"
+
+        wd_raw = _flat_dir()
+
+        rna_data = sim_data.process.transcription.rna_data
+        tu_source = retrieve_tu_source(wd_raw)
+        bulk_ids = get_bulk_ids(sim_data)
+
+        # Shim B: synthesise active_ribosome as sum of per-transcript counts
+        output_columns = [
+            "bulk__id",
+            "bulk__count",
+            "listeners__rna_counts__full_mRNA_counts",
+            ACTIVE_RIBOSOME_SQL,
+        ]
+
+        output_df = read_outputs(history_sql, conn, output_columns)
+
+        # Shim A: reorder bulk__count columns to sim_data order
+        bulk_mtx = bulk_count_matrix(output_df, sim_data)
+
+        # Retrieve mRNAs
+        mrna_mtx = np.stack(
+            output_df["listeners__rna_counts__full_mRNA_counts"].values
+        ).astype(int)
+
+        mrna_tu_ids = rna_data["id"][rna_data["is_mRNA"]].tolist()
+
+        tu2gene_mapping_mrna, genes_tu_mrna = tu2gene_mapping(
+            tu_ids=mrna_tu_ids, tu_source=tu_source
+        )
+
+        tu_mrna_dict = {}
+        for idx, mrna_tu_id in enumerate(mrna_tu_ids):
+            tu_mrna_dict[mrna_tu_id] = mrna_mtx[:, idx]
+
+        # Retrieve processed RNAs (tRNAs, rRNAs)
+        rna_ids_unprocessed = rna_data["id"][rna_data["is_unprocessed"]]
+        rna_ids_mature = sim_data.process.transcription.mature_rna_data["id"]
+
+        # Processed tRNAs
+        uncharged_trna_ids = sim_data.process.transcription.uncharged_trna_names
+        charged_trna_ids = sim_data.process.transcription.charged_trna_names
+
+        uncharged_trna_bulk_idxs = [bulk_ids.index(i) for i in uncharged_trna_ids]
+        charged_trna_bulk_idxs = [bulk_ids.index(i) for i in charged_trna_ids]
+
+        trna_total = (
+            bulk_mtx[:, charged_trna_bulk_idxs]
+            + bulk_mtx[:, uncharged_trna_bulk_idxs]
+        )
+
+        trna_processed_ids = list(
+            filter(lambda x: x in rna_ids_mature, uncharged_trna_ids)
+        )
+        trna_processed_idx = [uncharged_trna_ids.index(i) for i in trna_processed_ids]
+        trna_processed_total = trna_total[:, trna_processed_idx]
+
+        rna_processed_total: dict[str, np.ndarray] = {}
+        for trna_idx, trna_id in enumerate(trna_processed_ids):
+            rna_processed_total[trna_id] = trna_processed_total[:, trna_idx]
+
+        # Add rRNA to rna_processed_total (Shim B: active_ribosome column)
+        active_ribosome = output_df["active_ribosome"].values
+
+        processed_rrna_ids = [
+            sim_data.molecule_groups.s50_23s_rRNA,
+            sim_data.molecule_groups.s30_16s_rRNA,
+            sim_data.molecule_groups.s50_5s_rRNA,
+        ]
+        processed_rrna_ids = [
+            item for sublist in processed_rrna_ids for item in sublist
+        ]
+        processed_rrna_idxs = [bulk_ids.index(i) for i in processed_rrna_ids]
+
+        bulk2monomers, all_monomers = build_bulk2monomers_matrix(sim_data)
+
+        riboprotein_cplxs_ids = ["CPLX0-3953[c]", "CPLX0-3962[c]"]
+        riboprotein_cplxs_idxs = [bulk_ids.index(i) for i in riboprotein_cplxs_ids]
+
+        bulk_mtx_riboprotein_cplx = bulk_mtx[:, riboprotein_cplxs_idxs]
+
+        bulk_total_riboprotein_cplx = np.array(
+            [
+                bulk_mtx_riboprotein_cplx[tp] + active_ribosome[tp]
+                for tp in range(len(active_ribosome))
+            ]
+        )
+
+        bulk_total_riboprotein_monomers = np.matmul(
+            bulk_total_riboprotein_cplx, bulk2monomers[riboprotein_cplxs_idxs]
+        )
+
+        riboprotein_monomers_idx_rrna = [
+            list(all_monomers).index(i) for i in processed_rrna_ids
+        ]
+
+        bulk_total_riboprotein_rrna = bulk_total_riboprotein_monomers[
+            :, riboprotein_monomers_idx_rrna
+        ]
+
+        bulk_total_rrna = bulk_total_riboprotein_rrna + bulk_mtx[:, processed_rrna_idxs]
+
+        for rrna_idx, rrna_id in enumerate(processed_rrna_ids):
+            rna_processed_total[rrna_id] = bulk_total_rrna[:, rrna_idx]
+
+        # Reorder processed rRNAs for RNA maturation matrix
+        rna_processed: dict[str, np.ndarray] = {}
+        for rna_id in rna_ids_mature.tolist():
+            rna_processed[rna_id] = rna_processed_total[rna_id]
+
+        rna_processed_mtx = np.stack(list(rna_processed.values())).transpose()
+
+        rna_maturation_stoich_mtx = (
+            sim_data.process.transcription.rna_maturation_stoich_matrix.toarray()
+        )
+
+        rna_processed_tu = np.matmul(rna_processed_mtx, rna_maturation_stoich_mtx)
+
+        rna_processed_tu_dict: dict[str, np.ndarray] = {}
+        for rna_tu_idx, rna_tu in enumerate(rna_ids_unprocessed.tolist()):
+            rna_processed_tu_dict[rna_tu] = rna_processed_tu[:, rna_tu_idx]
+
+        rna_processed_tu_ids = list(rna_processed_tu_dict.keys())
+
+        tu2gene_mapping_processed, genes_processed = tu2gene_mapping(
+            rna_processed_tu_ids, tu_source
+        )
+
+        # Add missing tRNAs
+        tu_idx_trna = np.where(rna_data.fullArray()["is_tRNA"])[0]
+        tu_idx_not_unprocessed = np.where(~rna_data.fullArray()["is_unprocessed"])[0]
+        trna_not_unprocessed_idx = np.intersect1d(tu_idx_trna, tu_idx_not_unprocessed)
+        tu_id_trna_missing = rna_data["id"][trna_not_unprocessed_idx].tolist()
+
+        missing_trna_genes = [trna_tu[:4] for trna_tu in tu_id_trna_missing]
+
+        genes_input_raw = pd.read_csv(
+            os.path.join(wd_raw, "genes.tsv"), sep="\t", header=5, index_col=0
+        )
+
+        missing_trna_gene_ids: dict[str, list[str]] = {}
+        missing_trna_genes_biocyc: list[str] = []
+
+        for idx, trna_gene in enumerate(missing_trna_genes):
+            gene_id = genes_input_raw.index[
+                genes_input_raw["symbol"] == trna_gene
+            ][0]
+            missing_trna_gene_ids[tu_id_trna_missing[idx]] = [gene_id]
+            missing_trna_genes_biocyc.append(gene_id)
+
+        trna_missing_idx = [uncharged_trna_ids.index(i) for i in tu_id_trna_missing]
+        trna_missing_counts = trna_total[:, trna_missing_idx]
+
+        trna_missing_tu: dict[str, np.ndarray] = {}
+        for idx, trna_id in enumerate(tu_id_trna_missing):
+            trna_missing_tu[trna_id] = trna_missing_counts[:, idx]
+
+        # Merge all TU dicts
+        tu_dict_full: dict[str, np.ndarray] = {}
+        tu_gene_mapping_full: dict[str, list[str]] = {}
+
+        for key in tu_mrna_dict:
+            tu_dict_full[key] = tu_mrna_dict[key]
+            tu_gene_mapping_full[key] = tu2gene_mapping_mrna[key]
+
+        for key in rna_processed_tu_dict:
+            tu_dict_full[key] = rna_processed_tu_dict[key]
+            tu_gene_mapping_full[key] = tu2gene_mapping_processed[key]
+
+        for key in trna_missing_tu:
+            tu_dict_full[key] = trna_missing_tu[key]
+            tu_gene_mapping_full[key] = missing_trna_gene_ids[key]
+
+        tu_genes_all = np.unique(
+            genes_tu_mrna + genes_processed + missing_trna_genes_biocyc
+        ).tolist()
+
+        tu_gene_mtx = np.zeros([len(tu_dict_full), len(tu_genes_all)])
+        for tu_idx, key in enumerate(tu_gene_mapping_full):
+            genes_tu = tu_gene_mapping_full[key]
+            genes_tu_idx = [tu_genes_all.index(g) for g in genes_tu]
+            tu_gene_mtx[tu_idx, genes_tu_idx] = 1
+
+        tu_counts_mtx = np.stack(list(tu_dict_full.values())).transpose()
+        rna_counts_gene = np.matmul(tu_counts_mtx, tu_gene_mtx)
+
+        n_tp = int(params["n_tp"])
+
+        rna_counts_gene_blocksum, tp_idx = consolidate_timepoints(
+            rna_counts_gene, n_tp, normalized=True
+        )
+
+        tp_checkpoints = output_df["time"].values[tp_idx]
+
+        if params["time_unit"] == "minutes":
+            tp_checkpoints = tp_checkpoints / 60
+            tp_checkpoints = [round(x) for x in tp_checkpoints]
+
+        tp_columns = [str(i) + params["time_unit"][0] for i in tp_checkpoints]
+
+        ptools_rna_df = pd.DataFrame(
+            data=rna_counts_gene_blocksum.transpose(),
+            columns=tp_columns,
+            index=tu_genes_all,
+        )
+        ptools_rna_df.index.name = "$"
+
+        tsv = ptools_rna_df.to_csv(
+            sep="\t", index=True, header=True, float_format="%.4f"
+        )
+        return {"data": {"filename": "ptools_rna.tsv", "tsv": tsv}}

--- a/v2ecoli/workflow/analyses/ptools_rxns.py
+++ b/v2ecoli/workflow/analyses/ptools_rxns.py
@@ -1,0 +1,117 @@
+"""Native port of vEcoli ``ecoli/analysis/single/ptools_rxns.py``.
+
+Produces a reaction × timepoint flux TSV (PathwayTools-compatible format).
+Registered in ANALYSIS_REGISTRY as ``"ptools_rxns"`` (scale: ``"single"``).
+
+No bulk or ribosome shims required: only
+``listeners__fba_results__base_reaction_fluxes`` is needed.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pandas as pd
+from duckdb import DuckDBPyConnection
+
+from v2ecoli.workflow.analysis import Analysis, ANALYSIS_REGISTRY
+from v2ecoli.workflow.analyses.ptools_rna import consolidate_timepoints
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers
+# ---------------------------------------------------------------------------
+
+def build_query(columns, history_sql):
+    """Generate SQL query for user-specified parquet columns."""
+    query_sql = f"""
+        SELECT {",".join(columns)}, global_time AS time
+        FROM ({history_sql})
+        ORDER BY time
+    """
+    return query_sql
+
+
+def read_outputs(
+    history_sql: str,
+    conn: DuckDBPyConnection,
+    columns=None,
+):
+    """Retrieve specific columns from parquet outputs and return a DataFrame."""
+    if columns is None:
+        columns = ["listeners__fba_results__base_reaction_fluxes"]
+    query_sql = build_query(columns, history_sql)
+    outputs_df = conn.sql(query_sql).df()
+    outputs_df = outputs_df.groupby("time", as_index=False).sum()
+    return outputs_df
+
+
+# ---------------------------------------------------------------------------
+# Analysis subclass
+# ---------------------------------------------------------------------------
+
+class PtoolsRxns(Analysis):
+    """Reaction × timepoint flux table (PathwayTools-compatible TSV)."""
+
+    name = "ptools_rxns"
+    scale = "single"
+    config_schema = {"n_tp": "integer", "time_unit": "string"}
+
+    def analyze(
+        self,
+        *,
+        conn: DuckDBPyConnection,
+        history_sql: str,
+        sim_data,
+        variant_metadata: dict[str, Any] | None = None,
+        **ctx,
+    ) -> dict:
+        params = dict(variant_metadata or {})
+        params.setdefault("n_tp", 8)
+        params.setdefault("time_unit", "minutes")
+
+        if params["time_unit"] not in ("minutes", "seconds"):
+            params["time_unit"] = "minutes"
+
+        output_columns = ["listeners__fba_results__base_reaction_fluxes"]
+        output_df = read_outputs(history_sql, conn, output_columns)
+
+        # Drop timestep-0 row where FBA hasn't run yet (empty flux array).
+        flux_col = "listeners__fba_results__base_reaction_fluxes"
+        output_df = output_df[
+            output_df[flux_col].apply(len) > 0
+        ].reset_index(drop=True)
+
+        rxn_mtx = np.stack(output_df[flux_col].values)
+
+        rxn_ids_base = sim_data.process.metabolism.base_reaction_ids
+        # v2ecoli's FBA listener emits one fewer flux than sim_data has reaction
+        # IDs (trailing maintenance/boundary entry absent from the output).
+        # Truncate to match the actual emitted width.
+        n_rxns = rxn_mtx.shape[1]
+        rxn_ids_base = rxn_ids_base[:n_rxns]
+
+        n_tp = int(params["n_tp"])
+
+        rxn_blocksum, tp_idx = consolidate_timepoints(rxn_mtx, n_tp, normalized=True)
+
+        tp_checkpoints = output_df["time"].values[tp_idx]
+
+        if params["time_unit"] == "minutes":
+            tp_checkpoints = tp_checkpoints / 60
+            tp_checkpoints = [round(x) for x in tp_checkpoints]
+
+        tp_columns = [str(i) + params["time_unit"][0] for i in tp_checkpoints]
+
+        ptools_rxns_df = pd.DataFrame(
+            data=np.abs(rxn_blocksum.transpose()),
+            index=rxn_ids_base,
+            columns=tp_columns,
+        )
+        ptools_rxns_df.index.name = "$"
+
+        tsv = ptools_rxns_df.to_csv(
+            sep="\t", index=True, header=True, float_format="%.4f"
+        )
+        return {"data": {"filename": "ptools_rxns.tsv", "tsv": tsv}}

--- a/v2ecoli/workflow/analyses/ptools_rxns.py
+++ b/v2ecoli/workflow/analyses/ptools_rxns.py
@@ -77,7 +77,10 @@ class PtoolsRxns(Analysis):
         output_columns = ["listeners__fba_results__base_reaction_fluxes"]
         output_df = read_outputs(history_sql, conn, output_columns)
 
-        # Drop timestep-0 row where FBA hasn't run yet (empty flux array).
+        # Drop timestep-0 row where FBA hasn't run yet (flux array is empty at
+        # t=0 because metabolism hasn't been called).  v2ecoli deviation: vEcoli
+        # keeps t=0 in the raw table; we drop it so the first column is the
+        # first real FBA timepoint.
         flux_col = "listeners__fba_results__base_reaction_fluxes"
         output_df = output_df[
             output_df[flux_col].apply(len) > 0
@@ -86,11 +89,22 @@ class PtoolsRxns(Analysis):
         rxn_mtx = np.stack(output_df[flux_col].values)
 
         rxn_ids_base = sim_data.process.metabolism.base_reaction_ids
-        # v2ecoli's FBA listener emits one fewer flux than sim_data has reaction
-        # IDs (trailing maintenance/boundary entry absent from the output).
-        # Truncate to match the actual emitted width.
-        n_rxns = rxn_mtx.shape[1]
-        rxn_ids_base = rxn_ids_base[:n_rxns]
+
+        # Sanity-check: v2ecoli's metabolism listener emits
+        #   base_reaction_fluxes = reaction_mapping_matrix.dot(...)
+        # whose length equals len(base_reaction_ids) in the sim_data that
+        # generated this parquet.  They are 1:1 positional — flux column i
+        # corresponds to base_reaction_ids[i].  A mismatch means the caller
+        # passed a sim_data that does NOT pair with this parquet (e.g.
+        # out/kb/simData.cPickle vs out/workflow/simData.cPickle); raise
+        # loudly instead of silently mislabeling reactions via truncation.
+        n_ids = len(rxn_ids_base)
+        flux_width = rxn_mtx.shape[1]
+        if n_ids != flux_width:
+            raise ValueError(
+                f"base_reaction_ids ({n_ids}) != flux width ({flux_width}); "
+                "sim_data does not pair with this parquet"
+            )
 
         n_tp = int(params["n_tp"])
 

--- a/v2ecoli/workflow/analysis.py
+++ b/v2ecoli/workflow/analysis.py
@@ -38,6 +38,54 @@ ANALYSIS_SCALES: dict[str, str] = {
 ANALYSIS_REGISTRY: dict[str, type] = {}
 
 
+class Analysis(V2Step):
+    """Visualization-like analysis: reads sim output via a DuckDB connection +
+    the ParCa ``sim_data``, and emits a rendered ``view`` (HTML) plus optional
+    ``data`` (map). Faithful native ports of vEcoli's ``plot()`` analyses build
+    on this base (cf. the record-based ``AnalysisStep`` for emitted-observable
+    analyses). Subclasses set ``scale`` + ``name`` and implement ``analyze``.
+
+    Live, non-serializable handles (``conn``, ``sim_data``) are injected by the
+    runner into the state dict passed to ``update``; ``inputs()`` declares them
+    for discoverability with a permissive ("any") type.
+    """
+
+    scale: str = "single"
+    config_schema = {}
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        if cls.scale not in ANALYSIS_SCALES:
+            raise ValueError(
+                f"{cls.__name__}.scale={cls.scale!r} not in {sorted(ANALYSIS_SCALES)}")
+        if "name" in cls.__dict__:
+            ANALYSIS_REGISTRY[cls.name] = cls
+
+    def inputs(self):
+        return {
+            "conn": "any", "history_sql": "string",
+            "config_sql": "string", "success_sql": "string",
+            "sim_data": "any", "validation_data": "any",
+            "variant_metadata": "any",
+        }
+
+    def outputs(self):
+        return {"view": "string", "data": "map"}
+
+    def analyze(self, *, conn, history_sql, sim_data, **ctx) -> dict:
+        """Return {"view": <html str>, "data": <map>} (either key optional)."""
+        raise NotImplementedError
+
+    def invoke(self, state, interval=None):
+        # Fail loudly (like AnalysisStep): a broken analyze() must surface.
+        return SyncUpdate(self.update(state))
+
+    def update(self, state, interval=None):
+        kwargs = {k: state.get(k) for k in self.inputs()}
+        out = self.analyze(**kwargs) or {}
+        return {"view": out.get("view", ""), "data": out.get("data", {})}
+
+
 class AnalysisStep(V2Step):
     """Base for result-consuming analysis Steps.
 

--- a/v2ecoli/workflow/analysis_runner.py
+++ b/v2ecoli/workflow/analysis_runner.py
@@ -91,9 +91,11 @@ def scale_history_sql(scale: str, from_clause: str, key: tuple) -> str:
 def resolve_sim_data(sweep_dir: str):
     """Locate + load the sweep's ParCa sim_data via v2ecoli's loader."""
     from v2ecoli.library.sim_data import LoadSimData
+    # NB: do NOT match `**/kb/simData*.cPickle` — out/kb/simData.cPickle is the
+    # ParCa knowledge-base build, which can be a DIFFERENT sim_data version than
+    # the one the sweep ran with (see the pairing correction in the parity note).
     for pat in ("sim_data*.cPickle", "sim_data*.pkl", "simData*.cPickle",
-                "**/sim_data*.cPickle", "**/kb/simData*.cPickle",
-                "**/simData*.cPickle"):
+                "**/sim_data*.cPickle", "**/simData*.cPickle"):
         hits = glob.glob(os.path.join(sweep_dir, pat), recursive=True)
         if hits:
             return LoadSimData(sim_data_path=hits[0]).sim_data
@@ -188,6 +190,19 @@ def run_analyses(sweep_dir: str, analysis_options: dict) -> dict:
     records = list(build_cell_records(sweep_dir).values())
     core = allocate_core()
     results: dict[str, dict] = {}
+    # Provisioned once on first use and shared across every Analysis step, so the
+    # large sim_data pickle is loaded only once per run (not once per analysis),
+    # and a single DuckDB connection is reused.
+    _ctx: dict[str, Any] = {}
+
+    def _analysis_ctx() -> tuple:
+        if not _ctx:
+            import duckdb
+            _ctx["conn"] = duckdb.connect()
+            _ctx["from_clause"] = _history_from_clause(sweep_dir)
+            _ctx["sim_data"] = resolve_sim_data(sweep_dir)
+        return _ctx["conn"], _ctx["from_clause"], _ctx["sim_data"]
+
     for scale, analyses in (analysis_options or {}).items():
         if scale not in ANALYSIS_SCALES:
             warnings.warn(f"unknown analysis scale {scale!r}; skipping")
@@ -207,11 +222,9 @@ def run_analyses(sweep_dir: str, analysis_options: dict) -> dict:
             per_group: dict[str, Any] = {}
 
             if issubclass(step_cls, Analysis):
-                # DuckDB-provisioning path: one connection + sim_data for all groups.
-                import duckdb
-                conn = duckdb.connect()
-                from_clause = _history_from_clause(sweep_dir)
-                sim_data = resolve_sim_data(sweep_dir)
+                # DuckDB-provisioning path: connection + sim_data are shared across
+                # all groups and analyses (lazily provisioned once per run).
+                conn, from_clause, sim_data = _analysis_ctx()
                 params = (analyses or {}).get(name) or {}
                 viz_dir = os.path.join(sweep_dir, "viz")
                 os.makedirs(viz_dir, exist_ok=True)
@@ -248,6 +261,9 @@ def run_analyses(sweep_dir: str, analysis_options: dict) -> dict:
 
             scale_out[name] = per_group
         results[scale] = scale_out
+
+    if _ctx.get("conn") is not None:
+        _ctx["conn"].close()
 
     os.makedirs(sweep_dir, exist_ok=True)
     with open(os.path.join(sweep_dir, "analysis.json"), "w") as f:

--- a/v2ecoli/workflow/analysis_runner.py
+++ b/v2ecoli/workflow/analysis_runner.py
@@ -91,8 +91,9 @@ def scale_history_sql(scale: str, from_clause: str, key: tuple) -> str:
 def resolve_sim_data(sweep_dir: str):
     """Locate + load the sweep's ParCa sim_data via v2ecoli's loader."""
     from v2ecoli.library.sim_data import LoadSimData
-    for pat in ("sim_data*.cPickle", "sim_data*.pkl", "**/sim_data*.cPickle",
-                "**/kb/simData*.cPickle"):
+    for pat in ("sim_data*.cPickle", "sim_data*.pkl", "simData*.cPickle",
+                "**/sim_data*.cPickle", "**/kb/simData*.cPickle",
+                "**/simData*.cPickle"):
         hits = glob.glob(os.path.join(sweep_dir, pat), recursive=True)
         if hits:
             return LoadSimData(sim_data_path=hits[0]).sim_data

--- a/v2ecoli/workflow/analysis_runner.py
+++ b/v2ecoli/workflow/analysis_runner.py
@@ -48,6 +48,58 @@ _MASS_COLS = ("listeners__mass__dry_mass", "listeners__mass__protein_mass",
               "listeners__mass__rRna_mass", "listeners__mass__dna_mass")
 
 
+def _history_from_clause(sweep_dir: str) -> str:
+    """A DuckDB FROM-clause selecting all of the sweep's history parquet."""
+    files = glob.glob(os.path.join(sweep_dir, "**", "history", "**", "*.pq"),
+                      recursive=True)
+    if not files:
+        raise FileNotFoundError(f"no history parquet under {sweep_dir!r}")
+    flist = "[" + ",".join("'" + f.replace("'", "''") + "'" for f in files) + "]"
+    return f"read_parquet({flist}, hive_partitioning=true)"
+
+
+# scale -> the partition columns that scale's history_sql filters on.
+_SCALE_FILTER_COLS = {
+    "single": ("variant", "lineage_seed", "generation", "agent_id"),
+    "multidaughter": ("variant", "lineage_seed", "generation"),  # parent handled below
+    "multigeneration": ("variant", "lineage_seed"),
+    "multiseed": ("variant",),
+    "multivariant": (),
+}
+
+
+def scale_history_sql(scale: str, from_clause: str, key: tuple) -> str:
+    """SELECT * scoped to the partition a scale aggregates over.
+
+    ``key`` is the group key from ``group_for_scale`` for that scale.
+    """
+    cols = _SCALE_FILTER_COLS[scale]
+    conds = []
+    for col, val in zip(cols, key):
+        if isinstance(val, str):
+            conds.append(f"agent_id = '{val}'" if col == "agent_id"
+                         else f"{col} = '{val}'")
+        else:
+            conds.append(f"{col} = {int(val)}")
+    if scale == "multidaughter" and len(key) >= 4:
+        # sisters share parent = agent_id without its last phylogeny char
+        conds.append(f"agent_id LIKE '{key[3]}_' ESCAPE '\\'")
+    where = (" WHERE " + " AND ".join(conds)) if conds else ""
+    return f"SELECT * FROM {from_clause}{where} ORDER BY global_time"
+
+
+def resolve_sim_data(sweep_dir: str):
+    """Locate + load the sweep's ParCa sim_data via v2ecoli's loader."""
+    from v2ecoli.library.sim_data import LoadSimData
+    for pat in ("sim_data*.cPickle", "sim_data*.pkl", "**/sim_data*.cPickle",
+                "**/kb/simData*.cPickle"):
+        hits = glob.glob(os.path.join(sweep_dir, pat), recursive=True)
+        if hits:
+            return LoadSimData(sim_data_path=hits[0]).sim_data
+    raise FileNotFoundError(
+        f"no sim_data pickle under {sweep_dir!r} (needed by Analysis steps)")
+
+
 def build_cell_records(sweep_dir: str) -> dict[tuple, dict]:
     """Build per-cell summary records from the sweep's parquet + summary.json."""
     import duckdb
@@ -130,7 +182,7 @@ def run_analyses(sweep_dir: str, analysis_options: dict) -> dict:
     """Run the analyses named in ``analysis_options`` over the sweep's cells,
     write ``analysis.json``, and return the nested results."""
     from bigraph_schema import allocate_core
-    from v2ecoli.workflow.analysis import ANALYSIS_REGISTRY, ANALYSIS_SCALES
+    from v2ecoli.workflow.analysis import Analysis, ANALYSIS_REGISTRY, ANALYSIS_SCALES
 
     records = list(build_cell_records(sweep_dir).values())
     core = allocate_core()
@@ -152,17 +204,47 @@ def run_analyses(sweep_dir: str, analysis_options: dict) -> dict:
                 continue
             step = step_cls({}, core=core)
             per_group: dict[str, Any] = {}
-            for gkey, grp in groups.items():
-                try:
-                    # single-scale Steps consume a cell's timeseries; cross-scale
-                    # Steps consume the list of per-cell summary records. (A single
-                    # group is exactly one cell by construction — group_for_scale
-                    # keys single by the full cell id — so grp[0] is that cell.)
-                    rows = grp[0].get("timeseries") if scale == "single" else grp
-                    per_group[_group_key_str(scale, gkey)] = step.analyze(rows or [])
-                except Exception as e:
-                    per_group[_group_key_str(scale, gkey)] = {
-                        "error": f"{type(e).__name__}: {e}"}
+
+            if issubclass(step_cls, Analysis):
+                # DuckDB-provisioning path: one connection + sim_data for all groups.
+                import duckdb
+                conn = duckdb.connect()
+                from_clause = _history_from_clause(sweep_dir)
+                sim_data = resolve_sim_data(sweep_dir)
+                params = (analyses or {}).get(name) or {}
+                viz_dir = os.path.join(sweep_dir, "viz")
+                os.makedirs(viz_dir, exist_ok=True)
+                for gkey in groups:
+                    gstr = _group_key_str(scale, gkey)
+                    try:
+                        history_sql = scale_history_sql(scale, from_clause, gkey)
+                        out = step.update({
+                            "conn": conn, "history_sql": history_sql,
+                            "config_sql": "", "success_sql": "",
+                            "sim_data": sim_data, "validation_data": None,
+                            "variant_metadata": params,
+                        })
+                        if out.get("view"):
+                            vp = os.path.join(viz_dir, f"{name}__{gstr.replace('/', '_')}.html")
+                            with open(vp, "w") as vf:
+                                vf.write(out["view"])
+                        per_group[gstr] = out.get("data", {})
+                    except Exception as e:
+                        per_group[gstr] = {"error": f"{type(e).__name__}: {e}"}
+            else:
+                # Record-based AnalysisStep path (unchanged).
+                for gkey, grp in groups.items():
+                    try:
+                        # single-scale Steps consume a cell's timeseries; cross-scale
+                        # Steps consume the list of per-cell summary records. (A single
+                        # group is exactly one cell by construction — group_for_scale
+                        # keys single by the full cell id — so grp[0] is that cell.)
+                        rows = grp[0].get("timeseries") if scale == "single" else grp
+                        per_group[_group_key_str(scale, gkey)] = step.analyze(rows or [])
+                    except Exception as e:
+                        per_group[_group_key_str(scale, gkey)] = {
+                            "error": f"{type(e).__name__}: {e}"}
+
             scale_out[name] = per_group
         results[scale] = scale_out
 

--- a/v2ecoli/workflow/render.py
+++ b/v2ecoli/workflow/render.py
@@ -1,0 +1,22 @@
+"""Render helpers for Analysis ``view`` outputs.
+
+``fig_to_html`` turns a matplotlib Figure into a self-contained HTML fragment
+with an inline SVG, so plot-style analyses port near-verbatim from vEcoli (swap
+``fig.savefig(path)`` for ``return {"view": fig_to_html(fig)}``).
+"""
+
+from __future__ import annotations
+
+import io
+
+
+def fig_to_html(fig, title: str = "") -> str:
+    """Serialize a matplotlib Figure to an HTML fragment with inline SVG."""
+    buf = io.StringIO()
+    fig.savefig(buf, format="svg", bbox_inches="tight")
+    svg = buf.getvalue()
+    # Strip the XML/doctype preamble so the <svg> embeds cleanly in HTML.
+    idx = svg.find("<svg")
+    svg = svg[idx:] if idx != -1 else svg
+    heading = f"<h3>{title}</h3>" if title else ""
+    return f'<div class="analysis-view">{heading}{svg}</div>'


### PR DESCRIPTION
## Summary

Adds a native, Visualization-like **`Analysis`** abstraction to v2ecoli and ports the first **5** vEcoli DuckDB/`sim_data` analyses onto it — no vEcoli `Analysis`/`plot()` machinery, no wrapper. This is the follow-up spec the `workflow/analysis.py` docstring promised ("Porting the full vEcoli analysis library onto this base is a follow-up spec").

- **`Analysis(V2Step)`** — sibling of the record-based `AnalysisStep`; declares DuckDB `conn` + `history_sql` + `sim_data` input ports and emits `{view: html, data: map}`. Both bases share `ANALYSIS_REGISTRY`.
- **Runner** (`analysis_runner.py`) — a DuckDB-provisioning path: opens one connection over the sweep's partitioned parquet, loads the paired ParCa `sim_data` once, builds a scale-scoped `history_sql` per group, writes `data`→`analysis.json` and `view`→`<sweep>/viz/*.html`. Record-based path untouched.
- **5 ported analyses** (proving set across every axis):
  - `ptools_rna`, `ptools_rxns`, `ptools_proteins` — data TSVs (EcoCyc frame-ID × timepoint), the original sms-api/ptools integration goal.
  - `mass_fraction_voronoi` (single), `central_carbon_metabolism_scatter` (multiseed) — rendered matplotlib→SVG `view`s.
- **Shims** (`analyses/_shims.py`) — adapt v2ecoli's parquet schema to vEcoli's: `bulk__id/bulk__count`→reindexed bulk matrix, plus `active_ribosome`/`oriC`/`active_RNAP` column derivations.
- **Dashboard** — a `vivarium-dashboard` `server.py` edit lists `Analysis` classes in the visualization picker (verified, but committed separately in that repo).

Design + plan: `docs/superpowers/specs/2026-06-08-vecoli-analyses-as-pbg-analyses-design.md`, `docs/superpowers/plans/2026-06-08-vecoli-analyses-as-pbg-analyses.md`.

## Notable correctness work
- **Reaction analyses align FBA fluxes 1:1 with `base_reaction_ids` and assert on mismatch** (no silent truncation — an earlier truncation would have mislabeled ~2687 reactions; caught in review).
- **sim_data↔parquet pairing**: the reference sweep pairs with `out/workflow/simData.cPickle` (2820 rxns), not `out/kb` (2821); `resolve_sim_data` no longer matches the `kb/` build.
- `complexation.stoich_matrix()` now caches (was rebuilt 16k× → 120s timeout); verified no caller mutates the result in place.

## Test Plan
- [x] `pytest` analysis suite green (36 passed): base, render, runner (+scale SQL), ptools registration/oracle-shape, view registration, **cache-gated end-to-end** running the proving set against a real sweep with the paired sim_data.
- [x] ptools_rna output independently spec-reviewed against the sms-api oracle format (EG##### frame IDs, normalized).
- [ ] Live dashboard run in a v2ecoli-workspace venv to confirm the picker surfaces the 5 analyses (the `server.py` edit is inert until v2ecoli is importable in the serving venv).

## Follow-ups (out of scope here)
- Spec 2: bulk-port the remaining ~43 analyses (recipe-driven).
- Centralize a `wholecell`↔matplotlib-3.10 compat shim (will recur across plot ports).
- DRY: extract triplicated `build_query`/`read_outputs` from the ptools modules into a shared helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)