### PR TITLE
feat(emitters): Parquet + XArray emitters import & register by default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,28 +35,29 @@ dependencies = [
     "numba",
     "unum",
     "requests",
+    # Emitters are now BASE/default deps (no longer optional extras): v2ecoli
+    # always imports & registers BOTH the Parquet and XArray emitters so they
+    # appear in the vivarium-dashboard emitters list. Parquet remains the
+    # default (workspace.yaml runtime.default_emitter = parquet); XArray is
+    # merely available. [parquet] pulls in duckdb/polars/pyarrow/fsspec/tqdm;
+    # [xarray] pulls in xarray/zarr/zarrs. The implementations live in
+    # pbg-emitters; v2ecoli.library.{parquet,xarray}_emitter are shims. PEP 508
+    # direct-URL since pbg-emitters is not yet on PyPI — works with both pip
+    # (CI) and uv; pip/uv union the two extras of the same package. Mirrored in
+    # [tool.uv.sources] for uv-native resolution.
+    "pbg-emitters[parquet] @ git+https://github.com/vivarium-collective/pbg-emitters.git@main",
+    "pbg-emitters[xarray] @ git+https://github.com/vivarium-collective/pbg-emitters.git@main",
 ]
 
 [project.optional-dependencies]
 # Test-only deps. `uv sync --extra dev` pulls these in.
 dev = ["pytest-timeout>=2.3", "pytest-xdist>=3.6"]
-parquet = [
-    # Pulls in duckdb / polars / pyarrow / fsspec / tqdm transitively
-    # via pbg-emitters[parquet]. The ParquetEmitter implementation now
-    # lives in pbg-emitters; v2ecoli.library.parquet_emitter is a shim.
-    # PEP 508 direct-URL since pbg-emitters is not yet on PyPI — works
-    # with both pip (CI) and uv. Mirrored in [tool.uv.sources] for
-    # uv-native resolution.
-    "pbg-emitters[parquet] @ git+https://github.com/vivarium-collective/pbg-emitters.git@main",
-]
-xarray = [
-    # Pulls in xarray / zarr / zarrs transitively via pbg-emitters[xarray].
-    # The XArrayEmitter implementation now lives in pbg-emitters;
-    # v2ecoli.library.xarray_emitter is a shim. PEP 508 direct-URL since
-    # pbg-emitters is not yet on PyPI — works with both pip (CI) and uv.
-    # Mirrored in [tool.uv.sources] for uv-native resolution.
-    "pbg-emitters[xarray] @ git+https://github.com/vivarium-collective/pbg-emitters.git@main",
-]
+# The Parquet and XArray emitter deps moved into base [project.dependencies]
+# above (they are now default/always-installed). These groups are kept as
+# empty back-compat aliases so `pip install v2ecoli[parquet]` /
+# `v2ecoli[xarray]` still resolve.
+parquet = []
+xarray = []
 emitters = ["v2ecoli[parquet,xarray]"]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -2594,7 +2594,7 @@ dependencies = [
 [[package]]
 name = "pbg-emitters"
 version = "0.1.0"
-source = { git = "https://github.com/vivarium-collective/pbg-emitters.git?branch=main#ad269f4b6cb6e26a7e5016b38f50708a92452d5f" }
+source = { git = "https://github.com/vivarium-collective/pbg-emitters.git?branch=main#772403751e74ec6e3309b662c4d4bb682f68794e" }
 dependencies = [
     { name = "bigraph-schema" },
     { name = "numpy" },
@@ -2608,6 +2608,13 @@ parquet = [
     { name = "polars" },
     { name = "pyarrow" },
     { name = "tqdm" },
+]
+xarray = [
+    { name = "pint" },
+    { name = "unum" },
+    { name = "xarray" },
+    { name = "zarr" },
+    { name = "zarrs" },
 ]
 
 [[package]]
@@ -4030,6 +4037,7 @@ dependencies = [
     { name = "numpy" },
     { name = "pandas" },
     { name = "pbg-copasi" },
+    { name = "pbg-emitters", extra = ["parquet", "xarray"] },
     { name = "pbg-superpowers" },
     { name = "plum-dispatch" },
     { name = "process-bigraph" },
@@ -4049,15 +4057,6 @@ dev = [
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
 ]
-emitters = [
-    { name = "pbg-emitters", extra = ["parquet"] },
-]
-parquet = [
-    { name = "pbg-emitters", extra = ["parquet"] },
-]
-xarray = [
-    { name = "pbg-emitters" },
-]
 
 [package.metadata]
 requires-dist = [
@@ -4070,8 +4069,8 @@ requires-dist = [
     { name = "numpy" },
     { name = "pandas" },
     { name = "pbg-copasi", git = "https://github.com/vivarium-collective/pbg-copasi.git?branch=main" },
-    { name = "pbg-emitters", extras = ["parquet"], marker = "extra == 'parquet'", git = "https://github.com/vivarium-collective/pbg-emitters.git?branch=main" },
-    { name = "pbg-emitters", extras = ["xarray"], marker = "extra == 'xarray'", git = "https://github.com/vivarium-collective/pbg-emitters.git?branch=main" },
+    { name = "pbg-emitters", extras = ["parquet"], git = "https://github.com/vivarium-collective/pbg-emitters.git?branch=main" },
+    { name = "pbg-emitters", extras = ["xarray"], git = "https://github.com/vivarium-collective/pbg-emitters.git?branch=main" },
     { name = "pbg-superpowers", git = "https://github.com/vivarium-collective/pbg-superpowers.git?branch=main" },
     { name = "plum-dispatch", specifier = ">=2.5" },
     { name = "process-bigraph", git = "https://github.com/vivarium-collective/process-bigraph.git?branch=main" },
@@ -4292,6 +4291,20 @@ wheels = [
 ]
 
 [[package]]
+name = "xarray"
+version = "2026.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pandas" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4b/a6/6fe936a798a3a38a79c7422d1a31afd2e9a14690fcb0ccff96bc01f04bf2/xarray-2026.4.0.tar.gz", hash = "sha256:c4ac9a01a945d90d5b1628e2af045099a9d4943536d4f2ee3ae963c3b222d15b", size = 3132311, upload-time = "2026-04-13T19:45:36.688Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/83/6d810a8a9ebc9c307989b418840c20e46907c74d707beb67ab566773e6fc/xarray-2026.4.0-py3-none-any.whl", hash = "sha256:d43751d9fb4a90f9249c30431684f00c41bc874f1edccd862631a40cbc0edf08", size = 1414326, upload-time = "2026-04-13T19:45:34.659Z" },
+]
+
+[[package]]
 name = "xmltodict"
 version = "1.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -4347,6 +4360,28 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/31/5a/b8a0cf39a14c770c30bd1f2d120c54000c8cd9e84e8e79f38d9a7ce58071/zarr-3.1.6.tar.gz", hash = "sha256:d95e72cbea4b90e9a70679468b8266400331756232576ae2b43400ac5108d0eb", size = 386531, upload-time = "2026-03-23T17:25:18.748Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/de/7c/ba8ca8cbe9dbef8e83a95fc208fed8e6686c98b4719aaa0aa7f3d31fe390/zarr-3.1.6-py3-none-any.whl", hash = "sha256:b5a82c5079d1c3d4ee8f06746fa3b9a98a7d804300fa3f4be154362a33e1207e", size = 295655, upload-time = "2026-03-23T17:25:17.189Z" },
+]
+
+[[package]]
+name = "zarrs"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "zarr" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f9/b3/9e088d4ab5c971e5d2b52cd4d58e3acce35acb3e131990fdc28b69366233/zarrs-0.2.3.tar.gz", hash = "sha256:61640dbbffb9a0b0ebd73f970ce97b52ef56df2828c2809058016d76da59ee60", size = 64827, upload-time = "2026-03-27T08:47:44.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/c0/e10e618293351247e948527c0d2b4c3d8fa9f7478e9f8e945755fc47ecdc/zarrs-0.2.3-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:b9470b17629961badf4261fb0d26ad5fcbe316b63c1b00fb0489a51c3f8ef157", size = 6276814, upload-time = "2026-03-27T08:47:24.992Z" },
+    { url = "https://files.pythonhosted.org/packages/80/ad/8a8525a72190db2c8d6807c69695ef0ea959fd50a4ac887af80803ff5487/zarrs-0.2.3-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:e6998bf1a61cd7c4afd3c263130317c1001599b37ff6f27082cc900a0ad48baa", size = 5776732, upload-time = "2026-03-27T08:47:26.685Z" },
+    { url = "https://files.pythonhosted.org/packages/56/63/27f9f7784006a900ffaa3d62d5c4d0dde98821683cd298cad79f66aa25c5/zarrs-0.2.3-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:19b194f80139b838bb4bf18ed6ef93ecb1904717a04695fbc50cdc0c6074f282", size = 6139081, upload-time = "2026-03-27T08:47:28.465Z" },
+    { url = "https://files.pythonhosted.org/packages/59/a9/28b91493c7db9f3db191a1bc396cd2e212559536f2bc7325e5d5cdbb8b53/zarrs-0.2.3-cp311-abi3-manylinux_2_28_armv7l.whl", hash = "sha256:59a29dfdea088bb25c1e9b5107cbb8de15c8d571d51484ff128cd526c40521b9", size = 5966557, upload-time = "2026-03-27T08:47:30.064Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/c1/0aba516796af22be08e82e37ded59f46cc7ffabf6932957455fccb9c6109/zarrs-0.2.3-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:1d387b75a19c31795cb2a81ef973c905c2c04ca3b1a4cca4bc84c81050974827", size = 6736692, upload-time = "2026-03-27T08:47:31.988Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/fa/471e2511b0c77419ac2228ce72770e94e994ab99c6b9275cb3de1dcead2d/zarrs-0.2.3-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:ab4074056f01f3292c89cd769e8c0db92c0df076e3d36665eec7fc557a62a2ed", size = 6467125, upload-time = "2026-03-27T08:47:34.107Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/6a/7a4230676bd66c0181b4e9000bec30deee1b1695557e5d245514f0454103/zarrs-0.2.3-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9db202e95c3b5c9116afdfebf9912e1faa5ab60e6a1982e0406953cdb47bec38", size = 12507436, upload-time = "2026-03-27T08:47:36.138Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/85/7ad323d428540ca7add343ade347841d181e4e3d73a69f39e34e447f0acc/zarrs-0.2.3-cp311-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:991556a7589e93bc5445da2b97e0c89d7d871e539b9ef28dae857b8573c65f5c", size = 12209703, upload-time = "2026-03-27T08:47:38.619Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/90/ca544236092ab4803d1c3c88ac7b143885e280a63954d454d60885784af8/zarrs-0.2.3-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:437dd4fcf74607480361f401f15b47416aa69f0ff4379c4ea330c453b7e05098", size = 13044036, upload-time = "2026-03-27T08:47:40.589Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/c1/be4e37d80a95347334c287cbb42d94c6181d447f1624c0c5354f593e1fda/zarrs-0.2.3-cp311-abi3-win_amd64.whl", hash = "sha256:72eb1f5c4ca8382cb9e38dd98a48a0e484170d703152110f32a39520c7fa570d", size = 5854312, upload-time = "2026-03-27T08:47:42.856Z" },
 ]
 
 [[package]]

--- a/v2ecoli/composites/_helpers.py
+++ b/v2ecoli/composites/_helpers.py
@@ -313,6 +313,26 @@ def _build_declared_emitter(decl: dict, listeners_schema: dict, core):
         cfg = {"emit": emit_schema, **preset, **cfg_in}
         return ParquetEmitter(cfg, core), topo
 
+    if address == "XArrayEmitter":
+        from pbg_emitters import XArrayEmitter
+        # Mirror the ParquetEmitter wiring (global_time + bulk + listeners).
+        # The xarray_vecoli preset's ``transducer`` / ``view`` are
+        # per-composite (not preset-able), so a generator declaring an
+        # XArrayEmitter default supplies them via ``decl['config']``; those
+        # flow through ``cfg_in`` here.
+        emit_schema = {
+            "global_time": "float",
+            "bulk": "array[integer]",
+            "listeners": listeners_schema,
+        }
+        topo = {
+            "global_time": ("global_time",),
+            "bulk": ("bulk",),
+            "listeners": ("listeners",),
+        }
+        cfg = {"emit": emit_schema, **cfg_in}
+        return XArrayEmitter(cfg, core), topo
+
     if address == "SQLiteEmitter":
         emit_schema = {"global_time": "float", "listeners": listeners_schema}
         topo = {"global_time": ("global_time",), "listeners": ("listeners",)}
@@ -327,7 +347,8 @@ def _build_declared_emitter(decl: dict, listeners_schema: dict, core):
 
     raise ValueError(
         f"declared default emitter address {decl.get('address')!r} is not "
-        "recognised (expected one of ParquetEmitter, SQLiteEmitter, RAMEmitter)"
+        "recognised (expected one of ParquetEmitter, XArrayEmitter, "
+        "SQLiteEmitter, RAMEmitter)"
     )
 
 

--- a/v2ecoli/core.py
+++ b/v2ecoli/core.py
@@ -40,6 +40,27 @@ def build_core():
     """Create and configure a bigraph-schema core with ecoli types."""
     core = allocate_core()
     core.register_types(ECOLI_TYPES)
+    # Register emitters as links so they're discoverable (dashboard scans
+    # core.link_registry for Emitter subclasses). Parquet stays the default
+    # (workspace.yaml runtime.default_emitter = parquet). Be defensive: these
+    # carry heavy optional deps — register what imports successfully and never
+    # let an emitter import break build_core.
+    try:
+        from process_bigraph.emitter import SQLiteEmitter, RAMEmitter
+        core.register_link("SQLiteEmitter", SQLiteEmitter)
+        core.register_link("RAMEmitter", RAMEmitter)
+    except Exception:
+        pass
+    try:
+        from pbg_emitters import ParquetEmitter
+        core.register_link("ParquetEmitter", ParquetEmitter)
+    except Exception:
+        pass
+    try:
+        from pbg_emitters import XArrayEmitter
+        core.register_link("XArrayEmitter", XArrayEmitter)
+    except Exception:
+        pass
     return core
 
 


### PR DESCRIPTION
Moves `pbg-emitters[parquet]` and `pbg-emitters[xarray]` out of optional extras into base `[project].dependencies` so both emitters are always importable (the old `parquet`/`xarray` extra groups stay as empty back-compat aliases). Registers `ParquetEmitter`/`XArrayEmitter`/`SQLiteEmitter`/`RAMEmitter` into the core `link_registry` in `build_core()` so they appear in the vivarium-dashboard emitters list (the dashboard scans `link_registry` for `Emitter` subclasses); registration is defensive so a heavy emitter import can never break `build_core`. Adds an `XArrayEmitter` case to `_build_declared_emitter` (the address->instance mapper).

Parquet stays the default (workspace.yaml `runtime.default_emitter` and the composite default `local:ParquetEmitter` are unchanged). Heavier base install (xarray/zarr/zarrs + duckdb/polars/pyarrow/...) is intended. `uv.lock` regenerated; pbg-emitters pin bumped to main HEAD which carries the `xarray` extra.

Verification: build_core registers all four; ParquetEmitter & XArrayEmitter are Emitter subclasses; `pytest -k 'emitter and not slow'` -> 58 passed, 5 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)