### PR TITLE
fix(tests): isolate emitter experiment_id per test (kill parquet partition race)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,8 +24,22 @@ Path overrides:
 """
 import json
 import os
+import uuid
 
 import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate_emitter_experiment_id(monkeypatch):
+    """Give every test a unique emitter experiment_id so parallel baseline
+    runs (pytest -n auto) don't collide on the shared
+    out/.../experiment_id=default/history partition (the division-time
+    recursive partition delete otherwise races across xdist workers)."""
+    worker = os.environ.get("PYTEST_XDIST_WORKER", "main")
+    monkeypatch.setenv(
+        "V2ECOLI_EMITTER_EXPERIMENT_ID",
+        f"test-{worker}-{uuid.uuid4().hex[:8]}",
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/v2ecoli/composites/_helpers.py
+++ b/v2ecoli/composites/_helpers.py
@@ -299,7 +299,11 @@ def _build_declared_emitter(decl: dict, listeners_schema: dict, core):
             out_dir = (str(ws_root / ".pbg" / "parquet-runs")
                        if ws_root is not None else "out/parquet")
         preset = parquet_vecoli(out_dir=out_dir,
-                                experiment_id=cfg_in.pop("experiment_id", "default"))
+                                experiment_id=cfg_in.pop(
+                                    "experiment_id",
+                                    os.environ.get(
+                                        "V2ECOLI_EMITTER_EXPERIMENT_ID",
+                                        "default")))
         emit_schema = {
             "global_time": "float",
             "bulk": "array[integer]",
@@ -622,7 +626,8 @@ def parquet_emitter(*, out_dir: str | None = None,
         out_dir = str(ws_root / ".pbg" / "parquet-runs")
 
     if experiment_id is None:
-        experiment_id = "default-" + uuid.uuid4().hex[:8]
+        experiment_id = (os.environ.get("V2ECOLI_EMITTER_EXPERIMENT_ID")
+                         or ("default-" + uuid.uuid4().hex[:8]))
 
     # Build the emitter config dict via the vEcoli-shaped preset so the
     # hive layout + dtype overrides match upstream conventions exactly.


### PR DESCRIPTION
Behavior tests sharing `experiment_id=default` raced on the parquet partition under `pytest -n auto`: on cell division the emitter recursively deletes/recreates the partition dir, so two tests on different xdist workers writing to the same `<out>/experiment_id=default/history` root wiped a peer's daughter partition mid-write -> intermittent `FileNotFoundError` (e.g. `test_growth_parity`, surfaced by #147).

Fix (two small changes):
- `v2ecoli/composites/_helpers.py`: the declared-ParquetEmitter materialisation (~L302) and the `parquet_emitter()` helper's None-fallback (~L625) now resolve the default `experiment_id` via `os.environ.get("V2ECOLI_EMITTER_EXPERIMENT_ID", ...)`. Env unset => unchanged production behavior ("default" / "default-<uuid>"). Call sites passing an explicit `experiment_id` still win.
- `tests/conftest.py`: an autouse, function-scoped fixture sets `V2ECOLI_EMITTER_EXPERIMENT_ID` to a unique `test-<worker>-<uuid>` per test, so parallel baseline runs never share a partition.

No test reads back a hardcoded `experiment_id=default` path, so per-test unique ids are safe. SQLite/xarray emitters carry no experiment_id partition default, and `parquet_run.py`'s `experiment_id` is a required param — so no other fallback needed changing.

Verified: mechanism check (env override -> emitter `experiment_id`/`partitioning_path`; env-unset -> "default"; explicit config still wins) and fast tests `-k 'emitter or conftest or preset'` => 55 passed, 6 skipped, no collection breakage. Full slow behavior suite left to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)