### PR TITLE
docs(AGENTS): note ParCa --mode full is required for sim data

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,6 +136,11 @@ biological name.
 - **ParCa** (Parameter Calculator) builds `sim_data` from raw EcoCyc-derived
   knowledge bases. It's expensive (minutes to hours). Never run ParCa in CI —
   CI uses a frozen gzipped cache at `tests/fixtures/cache/`.
+  - **Always build ParCa with `--mode full` for any simulation.** `--mode fast`
+    (debug) reduces the set of TF conditions and mis-calibrates regulation — it
+    over-expresses dnaA ~2× and breaks replication initiation. Fast mode is for
+    pipeline debugging only, never for sim data. `scripts/build_cache.py` guards
+    against using a fast-built cache.
 - **Architectures**:
   - `baseline` — partitioned, 55 processes, upstream-parity (the reference).
   - `colony` — many baseline cells in a shared environment (multi-agent).


### PR DESCRIPTION
Documents the ParCa fast-mode gotcha in AGENTS.md so agents don't build sim data with `--mode fast`:

`--mode fast` (debug) reduces the TF-condition set and mis-calibrates regulation — it over-expresses dnaA ~2× and breaks replication initiation. It's for pipeline debugging only. `scripts/build_cache.py` already guards against using a fast-built cache; this records the *why*.

5-line docs-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)