### PR TITLE
types: resolve bigraph-schema Quantity collision + Overwrite/Quote cross-wrap

### DIFF
--- a/v2ecoli/types/__init__.py
+++ b/v2ecoli/types/__init__.py
@@ -66,7 +66,18 @@ from bigraph_schema.schema import (
     Float as _Float, Node as _Node, Array as _Array, Map as _Map,
     Integer as _Integer, List as _List, Tuple as _Tuple, String as _String,
     Overwrite as _Overwrite, Boolean as _Boolean, Quote as _Quote,
+    Quantity as _BSQuantity,
 )
+
+# bigraph-schema 6fa6c63 added its own Quantity at key 'quantity'; v2ecoli's
+# Quantity has a custom _serialize_state, so prefer v2ecoli's on collision.
+@_resolve.dispatch
+def _resolve_bs_quantity_v2(current: _BSQuantity, update: Quantity, path=None):
+    return update
+
+@_resolve.dispatch
+def _resolve_v2_quantity_bs(current: Quantity, update: _BSQuantity, path=None):
+    return current
 
 # vEcoli-style type relaxation dispatches (from bigraph_types.py)
 @_resolve.dispatch
@@ -128,6 +139,17 @@ def _resolve_map_string(current: _Map, update: _String, path=None):
 @_resolve.dispatch
 def _resolve_quote_quote(current: _Quote, update: _Quote, path=None):
     return current
+
+# Cross-wrap resolve: agents store is Overwrite[Map[...]]; daughter docs
+# inserted via _add carry Quote[Node] process slots. Keep the structural
+# agents schema (current) and let the descent handle the Quote subfields.
+@_resolve.dispatch
+def _resolve_overwrite_quote(current: _Overwrite, update: _Quote, path=None):
+    return current
+
+@_resolve.dispatch
+def _resolve_quote_overwrite(current: _Quote, update: _Overwrite, path=None):
+    return update
 
 @_resolve.dispatch
 def _resolve_list_integer(current: _List, update: _Integer, path=None):
@@ -320,9 +342,8 @@ def _resolve_map_listener(current: _Map, update: ListenerStore, path=None):
 def _resolve_listener_map(current: ListenerStore, update: _Map, path=None):
     return update
 
-
 ECOLI_TYPES = {
-    'quantity': Quantity,
+    'quantity': _BSQuantity,
     'csr_matrix': CSRMatrix,
     'units_array': UnitsArray,
     'method': Method,

--- a/v2ecoli/types/__init__.py
+++ b/v2ecoli/types/__init__.py
@@ -70,7 +70,9 @@ from bigraph_schema.schema import (
 )
 
 # bigraph-schema 6fa6c63 added its own Quantity at key 'quantity'; v2ecoli's
-# Quantity has a custom _serialize_state, so prefer v2ecoli's on collision.
+# Quantity (custom _serialize_state + parameterized units) stays registered at
+# the key, and these dispatches prefer it when a bigraph-schema Quantity meets
+# it during resolve.
 @_resolve.dispatch
 def _resolve_bs_quantity_v2(current: _BSQuantity, update: Quantity, path=None):
     return update
@@ -343,7 +345,7 @@ def _resolve_listener_map(current: ListenerStore, update: _Map, path=None):
     return update
 
 ECOLI_TYPES = {
-    'quantity': _BSQuantity,
+    'quantity': Quantity,
     'csr_matrix': CSRMatrix,
     'units_array': UnitsArray,
     'method': Method,


### PR DESCRIPTION
Extracted from the `plasmids` branch as standalone infrastructure so the whole repo benefits, independent of the plasmid science.

## What
Adds `@_resolve.dispatch` handlers in `v2ecoli/types/__init__.py` for two collisions that are **live on `main` today**:

1. **`Quantity` key collision.** bigraph-schema (now pinned at 1.4.1 on main) ships its own `Quantity` at key `quantity`, colliding with v2ecoli's custom `Quantity` (which has a custom `_serialize_state`). The new dispatches prefer v2ecoli's on collision in both directions.
2. **`Overwrite`<->`Quote` cross-wrap.** The post-division `agents` store is `Overwrite[Map[...]]` while daughter docs inserted via `_add` carry `Quote[Node]` process slots. The cross-wrap resolves keep the structural agents schema and let descent handle the `Quote` subfields — needed by anyone running division / multigen.

## Why now
On `main` the collision is unhandled: bigraph-schema 1.4.1 exports `Quantity` (verified), so without this, `_resolve` can pick the wrong `Quantity` schema during state merges.

## Scope / risk
- Single file, **+23/-2**, purely additive dispatch handlers.
- Verified `import v2ecoli.types` registers cleanly against main's deps.
- (The plasmid branch also dropped a dead `pbg-physicell` catalog entry, but `main` already removed it — nothing to port.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)