### PR TITLE
Self-describing emitters: LabeledArray type carries listener element names (Readout-coord #1)

### DIFF
--- a/docs/superpowers/plans/2026-06-10-self-describing-emitters-subproject-1.md
+++ b/docs/superpowers/plans/2026-06-10-self-describing-emitters-subproject-1.md
@@ -1,0 +1,83 @@
+# Self-Describing Emitters (Readout-Coordination Sub-project #1) — Plan
+
+> REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use `- [ ]`.
+
+**Goal:** Make v2ecoli runs **self-describing** — persist listener-vector element NAMES with the data so the evaluator can resolve readouts/aggregates (e.g. "sum across DnaA forms", `monomer_counts`) from a stored run alone, no `sim_data`. Mirror vEcoli's mechanism: annotate listener `outputs()` port schemas with element names, harvest them via an `output_metadata()` walker, and feed them into the emitter config (xarray `id` coord = names; parquet `output_metadata__<field>`; sqlite catalog).
+
+**Architecture / key facts (grounded):**
+- The emitters ALREADY persist a provided catalog — pbg-emitters xarray fills an `id_<var>` coordinate (currently with integer `0..N-1`, see `pbg_emitters/xarray_emitter/storage.py` `VAR_COO_PREFIX="id_"`), parquet writes `output_metadata__<field>` from `config["metadata"]` (`pbg_emitters/parquet_emitter.py` `METADATA_PREFIX`, `_write_configuration`), sqlite has a `simulations.metadata` slot. So the WRITE plumbing exists; **the missing piece is the source of names**, which must come from v2ecoli (the emitter only sees values; emit types are erased to `node`).
+- vEcoli pattern to mirror: `vEcoli/ecoli/library/schema.py:596` `listener_schema` (a `(default, names)` tuple → `_properties.metadata`); `vEcoli/ecoli/experiments/ecoli_master_sim.py:1011` `output_metadata()` (iterate processes, `get_schema`, pull `_properties.metadata` leaves, `inverse_topology` re-root, deep-merge); `:852` `metadata["output_metadata"] = output_metadata()`.
+- v2ecoli today: listeners declared bare (`v2ecoli/composites/_helpers.py` `'monomer_counts': 'array[integer]'`; `v2ecoli/processes/polypeptide_initiation.py` `ribosome_init_event_per_monomer`); element names live in process configs (`v2ecoli/library/sim_data.py` `monomer_ids` ~:1073/:1780). A vivarium-style listener_schema helper is vendored in `v2ecoli/library/schema.py` (supports the metadata convention) but unused with the metadata form. `v2ecoli/library/xarray_run.py` `extract_output_metadata_from_state` currently emits `range(N)` integer coords — to be replaced/augmented with real names.
+
+**Tech Stack:** Python 3.11+ (run via `.venv/bin/python` — bare python lacks `unum`); process-bigraph; pbg-emitters; pytest. Spec: `pbg-superpowers/docs/specs/2026-06-09-readout-coordination-design.md` (sub-project #1).
+
+**Repo:** v2ecoli (branch `feat/self-describing-emitters`, off `main`). Light verification in pbg-emitters (separate, optional).
+
+**Scope guardrails:**
+- Backward-compatible: the `(default, names)`/`_properties.metadata` annotation must NOT change runtime behavior of existing listeners (the vendored helper supports it; process-bigraph treats `_properties` as an annotation). Run the relevant v2ecoli tests/a tiny sim to confirm nothing breaks.
+- Start with the listeners the dnaa evaluator needs: `monomer_counts`, `rnap_data.*` (init-rate), `replication_data.*` (oriC). Don't annotate everything.
+- Golden proves names reach the emitter CONFIG (no full ParCa rebuild). A tiny sim only if cheap using the existing cache.
+
+---
+
+## File map (verify exact paths against live code first)
+- `v2ecoli/library/schema.py` — confirm/extend the vendored `listener_schema` helper for the `(default, names)` convention.
+- `v2ecoli/processes/*.py` and/or `v2ecoli/composites/_helpers.py` — annotate the target listener `outputs()` with names from their config.
+- `v2ecoli/library/output_metadata.py` (new) — the `output_metadata()` walker.
+- `v2ecoli/library/xarray_run.py` / the emitter-config build path — wire `output_metadata()` into `config["metadata"]["output_metadata"]` (replace the `range(N)` coord source).
+- Tests under `v2ecoli/.../tests/`.
+
+---
+
+## Task 1: `output_metadata()` walker
+
+**Files:** Create `v2ecoli/library/output_metadata.py`; Test alongside.
+
+- [ ] **Step 1: Failing test** — build the baseline composite (use `v2ecoli.core.build_core()` + the baseline generator; reuse how the dashboard/tests build it), call `output_metadata(composite)`, assert it returns `{}` initially (no annotations yet) — establishing the walker contract. (After Task 2 it returns names.)
+- [ ] **Step 2: Run → fail** (`.venv/bin/python -m pytest <test> -v`).
+- [ ] **Step 3: Implement** `output_metadata(composite_or_core) -> dict[str, list]` mirroring vEcoli `ecoli_master_sim.py:1011`: iterate process/step instances in the composite, get each one's output port schema (`get_schema`/`outputs()`), pull leaves carrying `_properties.metadata`, re-root the port-relative path to the absolute store path (use the composite topology / an inverse-topology helper), deep-merge into one dict. Read vEcoli's `extract_metadata` (`ecoli_master_sim.py:1055`) + `inverse_topology` for the exact shape.
+- [ ] **Step 4: Run → pass.** **Step 5: Commit** — `feat(output_metadata): walker harvesting _properties.metadata from listener schemas`
+
+## Task 2: Annotate the dnaa-relevant listener outputs with names
+
+**Files:** `v2ecoli/library/schema.py` (helper, if needed) + the target listener process `outputs()`.
+
+- [ ] **Step 1: Failing test** — for the annotated listener (start with `monomer_counts`), assert its `outputs()`/`get_schema` carries `_properties.metadata` = the element names (from the process config, e.g. `monomer_ids`), AND `output_metadata(composite)` (Task 1) now returns `{<store_path>: [names...]}` for it.
+- [ ] **Step 2: Run → fail.**
+- [ ] **Step 3: Implement** — use the vendored `listener_schema((default, names))` convention (confirm it produces `_properties: {metadata: names}` and is realized without error by process-bigraph). Annotate `monomer_counts` (names = `monomer_ids` from config), then `rnap_data` init vectors and `replication_data` as needed. Names come from the producing process's config (already available at construction). DO NOT change the listener's runtime values — only add the metadata annotation.
+- [ ] **Step 4: Run → pass; AND run a representative existing listener/sim test to confirm no behavior change.** **Step 5: Commit** — `feat(listeners): annotate monomer_counts/rnap/replication outputs with element names`
+
+## Task 3: Wire `output_metadata()` into the emitter config at run build
+
+**Files:** the v2ecoli run-build path (`xarray_run.py` and/or the composite-generator emitter config / wherever `config["metadata"]`/emitter is assembled per run).
+
+- [ ] **Step 1: Failing test** — building a run's emitter config (the path the dashboard/CLI uses) now includes `config["metadata"]["output_metadata"]` = the walker's output; for xarray, the `id_<var>` coord source is the names (not `range(N)`).
+- [ ] **Step 2: Run → fail.**
+- [ ] **Step 3: Implement** — at emitter-config assembly, call `output_metadata(composite)` and set `config["metadata"]["output_metadata"]` (parquet/sqlite) and the xarray `output_metadata` coord input (so `id_<var>` carries names). Reconcile/replace `extract_output_metadata_from_state`'s `range(N)` default with the names where available; keep `range(N)` fallback for un-annotated vectors (never break — un-named vectors still get an integer coord).
+- [ ] **Step 4: Run → pass.** **Step 5: Commit** — `feat(run): feed output_metadata names into emitter config (xarray id coord / parquet output_metadata)`
+
+## Task 4: Golden — a run is self-describing (config-level; tiny-sim optional)
+
+**Files:** Test.
+
+- [ ] **Step 1: Config-level golden** — build the baseline composite + emitter config for the default emitter, assert the names for `monomer_counts` (and the others) are present in the config (parquet `output_metadata`) / the xarray coord inputs. This proves names reach the store without a full ParCa rebuild.
+- [ ] **Step 2: (Optional, if cheap on the existing cache)** run a minimal sim (1 gen, few steps, existing `out/cache`/`out/kb`) to a tmp out dir; open the resulting store with `pbg_emitters.RunReader` and assert the names are recoverable from the store alone (e.g. parquet `output_metadata__monomer_counts` via `field_metadata`, or xarray `id_monomer_counts` coord = names). NEVER write to the user's `out/` — use a tmp dir.
+- [ ] **Step 3: Full suite** `.venv/bin/python -m pytest -q` (the relevant subset) — confirm green; no existing sim/listener test regressed.
+- [ ] **Step 4: Commit** — `test(self-describing): golden — listener names reach the run store`
+
+## Task 5 (light, separate): pbg-emitters consumption check
+- [ ] Confirm pbg-emitters consumes the catalog across backends (xarray `id` coord already; parquet `output_metadata__` already; **sqlite** — add catalog persistence to `simulations.metadata` + a RunReader read path IF missing). This may be deferred into sub-project #2 (RunReader catalog) — note status. (Do NOT block #1 on sqlite if the default emitter is parquet/xarray.)
+
+---
+
+## Self-Review
+- Spec coverage (sub-project #1 = self-describing stores): names persisted via xarray id-coord + parquet output_metadata (+ sqlite noted) → Tasks 2-4; the walker mirroring vEcoli → Task 1; backward-compat + don't-break-sims → Task 2/3 guardrails. #2 (RunReader read/resolve) and #6 (evaluator via readouts) are separate.
+- No placeholders: design + vEcoli refs are concrete; the implementer grounds exact v2ecoli code/paths before each task (paths above are to-verify).
+- Risk: if process-bigraph does NOT realize `_properties.metadata` cleanly (breaks the listener), STOP and report (BLOCKED) — do not force it; the fallback is the run-wiring lookup (the alternative the user did not pick) as a contingency.
+
+## Notes for the executor
+- Branch `feat/self-describing-emitters` (off main) is set; do not switch to the user's `feat/baseline-configure-knobs`.
+- `.venv/bin/python -m pytest` (bare python lacks `unum`).
+- Ground exact paths/signatures in LIVE v2ecoli + vEcoli (`/Users/eranagmon/code/vEcoli`) before each task — the file:line refs here are from a prior survey and must be verified.
+- Use the existing ParCa cache (`out/kb/simData.cPickle`, `out/cache`); NEVER rebuild ParCa, never write to the user's `out/`.
+- pbg-emitters RunReader is importable in v2ecoli's `.venv`? Verify; if not, `uv pip install -e /Users/eranagmon/code/pbg-emitters[parquet]` into v2ecoli's venv for the optional sim-golden.

--- a/tests/test_output_metadata.py
+++ b/tests/test_output_metadata.py
@@ -1,0 +1,310 @@
+"""Tests for v2ecoli.library.output_metadata (self-describing emitters).
+
+TDD for sub-project #1 (readout-coordination): make v2ecoli runs self-describing
+by annotating listener outputs() with element names and harvesting them via a
+walker that mirrors vEcoli's EcoliSim.output_metadata() pattern.
+"""
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Task 1: output_metadata() walker baseline (before any annotations)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.fast
+def test_extract_metadata_no_annotation():
+    """Schema without _properties.metadata → extract_metadata returns None."""
+    from v2ecoli.library.output_metadata import extract_metadata
+
+    schema = {
+        "monomer_counts": {"_type": "array[integer]", "_default": []}
+    }
+    result = extract_metadata(schema)
+    assert result is None, (
+        "Un-annotated schema should return None, got: %r" % result
+    )
+
+
+@pytest.mark.fast
+def test_extract_metadata_with_annotation():
+    """Nested schema with _properties.metadata → extract_metadata returns the names."""
+    from v2ecoli.library.output_metadata import extract_metadata
+
+    names = ["MONOMER_A", "MONOMER_B"]
+    schema = {
+        "listeners": {
+            "monomer_counts": {
+                "_type": "array[integer]",
+                "_default": [],
+                "_properties": {"metadata": names},
+            }
+        }
+    }
+    result = extract_metadata(schema)
+    assert result == {"listeners": {"monomer_counts": names}}, (
+        "Expected listener-nested metadata dict, got: %r" % result
+    )
+
+
+@pytest.mark.fast
+def test_extract_metadata_top_level_properties():
+    """Schema where _properties.metadata is at the leaf → returns metadata directly."""
+    from v2ecoli.library.output_metadata import extract_metadata
+
+    names = ["X", "Y"]
+    schema = {
+        "_type": "array[integer]",
+        "_default": [],
+        "_properties": {"metadata": names},
+    }
+    result = extract_metadata(schema)
+    assert result == names
+
+
+@pytest.mark.fast
+def test_output_metadata_empty_state_returns_empty():
+    """output_metadata({}) returns {} without crashing."""
+    from v2ecoli.library.output_metadata import output_metadata
+
+    assert output_metadata({}) == {}
+
+
+@pytest.mark.fast
+def test_output_metadata_no_instances_returns_empty():
+    """State with data but no step instances → returns {}."""
+    from v2ecoli.library.output_metadata import output_metadata
+
+    state = {
+        "listeners": {"monomer_counts": []},
+        "global_time": 0.0,
+        "bulk": [],
+    }
+    assert output_metadata(state) == {}
+
+
+@pytest.mark.fast
+def test_output_metadata_walker_unannotated_step():
+    """Walker with a step that has no _properties.metadata → returns {}."""
+    from v2ecoli.library.output_metadata import output_metadata
+
+    class UnannotatedStep:
+        def outputs(self):
+            return {
+                "listeners": {
+                    "monomer_counts": {"_type": "array[integer]", "_default": []}
+                }
+            }
+
+    state = {
+        "some_step": {
+            "instance": UnannotatedStep(),
+            "outputs": {"listeners": ["listeners"]},
+        }
+    }
+    assert output_metadata(state) == {}
+
+
+@pytest.mark.fast
+def test_output_metadata_walker_annotated_step():
+    """Walker finds _properties.metadata in a step outputs() and remaps to store path."""
+    from v2ecoli.library.output_metadata import output_metadata
+
+    monomer_ids = ["MONOMER_A", "MONOMER_B", "MONOMER_C"]
+
+    class AnnotatedStep:
+        def outputs(self):
+            return {
+                "listeners": {
+                    "monomer_counts": {
+                        "_type": "array[integer]",
+                        "_default": [],
+                        "_properties": {"metadata": monomer_ids},
+                    }
+                }
+            }
+
+    # Wiring: port 'listeners' → store path ['listeners']
+    state = {
+        "some_step": {
+            "instance": AnnotatedStep(),
+            "outputs": {"listeners": ["listeners"]},
+        }
+    }
+    result = output_metadata(state)
+    assert result == {"listeners": {"monomer_counts": monomer_ids}}, (
+        "Expected monomer names at listeners.monomer_counts, got: %r" % result
+    )
+
+
+@pytest.mark.fast
+def test_output_metadata_nested_state():
+    """Walker recurses into nested state (e.g. agents.0.step_name)."""
+    from v2ecoli.library.output_metadata import output_metadata
+
+    names = ["A", "B"]
+
+    class AnnotatedStep:
+        def outputs(self):
+            return {
+                "listeners": {
+                    "monomer_counts": {
+                        "_type": "array[integer]",
+                        "_default": [],
+                        "_properties": {"metadata": names},
+                    }
+                }
+            }
+
+    state = {
+        "agents": {
+            "0": {
+                "some_step": {
+                    "instance": AnnotatedStep(),
+                    "outputs": {"listeners": ["listeners"]},
+                }
+            }
+        }
+    }
+    result = output_metadata(state)
+    assert result == {"listeners": {"monomer_counts": names}}
+
+
+# ---------------------------------------------------------------------------
+# Task 2: CountsDeriver.outputs() carries _properties.metadata for monomer_counts
+# ---------------------------------------------------------------------------
+
+@pytest.mark.fast
+def test_counts_deriver_outputs_carries_monomer_ids_metadata():
+    """After annotation, CountsDeriver.outputs() has _properties.metadata for monomer_counts."""
+    from v2ecoli.steps.derivers.counts_deriver import CountsDeriver
+
+    monomer_ids = ["MONA_[c]", "MONB_[c]", "MONC_[c]"]
+
+    # Build a minimal instance with just the attrs outputs() needs.
+    instance = CountsDeriver.__new__(CountsDeriver)
+    instance.n_monomers = len(monomer_ids)
+    instance.monomer_ids = monomer_ids
+    instance.n_mRNA_TU = 2
+    instance.n_mRNA_cistron = 2
+    instance.n_rRNA_TU = 1
+    instance.n_rRNA_cistron = 1
+
+    schema = instance.outputs()
+    monomer_schema = schema["listeners"]["monomer_counts"]
+    props = monomer_schema.get("_properties", {})
+    assert "metadata" in props, (
+        "monomer_counts schema missing _properties.metadata; schema=%r" % monomer_schema
+    )
+    assert props["metadata"] == monomer_ids
+
+
+@pytest.mark.fast
+def test_output_metadata_walker_with_counts_deriver():
+    """Walker returns monomer_ids at listeners.monomer_counts for a CountsDeriver instance."""
+    from v2ecoli.steps.derivers.counts_deriver import CountsDeriver
+    from v2ecoli.library.output_metadata import output_metadata
+
+    monomer_ids = ["MONA_[c]", "MONB_[c]"]
+
+    instance = CountsDeriver.__new__(CountsDeriver)
+    instance.n_monomers = len(monomer_ids)
+    instance.monomer_ids = monomer_ids
+    instance.n_mRNA_TU = 1
+    instance.n_mRNA_cistron = 1
+    instance.n_rRNA_TU = 1
+    instance.n_rRNA_cistron = 1
+
+    state = {
+        "counts_deriver": {
+            "instance": instance,
+            "outputs": {"listeners": ["listeners"]},
+        }
+    }
+    result = output_metadata(state)
+    assert result.get("listeners", {}).get("monomer_counts") == monomer_ids
+
+
+# ---------------------------------------------------------------------------
+# Task 3: extract_output_metadata_from_state uses names when available
+# ---------------------------------------------------------------------------
+
+@pytest.mark.fast
+def test_extract_output_metadata_prefers_names_over_range():
+    """extract_output_metadata_from_state uses named_metadata instead of range(N)."""
+    from v2ecoli.library.xarray_run import extract_output_metadata_from_state
+    import numpy as np
+
+    monomer_ids = ["MONA", "MONB", "MONC"]
+
+    # Minimal state: listeners.monomer_counts = array of length 3
+    state = {
+        "listeners": {
+            "monomer_counts": np.zeros(3, dtype=int),
+        }
+    }
+    view = [{"root": ("listeners",), "variables": {
+        "monomer_counts": [{"path": "monomer_counts", "dtype": "<f8"}]
+    }}]
+
+    named_metadata = {"listeners": {"monomer_counts": monomer_ids}}
+    result = extract_output_metadata_from_state(state, view, named_metadata=named_metadata)
+    assert result.get("monomer_counts") == monomer_ids, (
+        "Expected named coord for monomer_counts, got: %r" % result
+    )
+
+
+@pytest.mark.fast
+def test_extract_output_metadata_fallback_to_range():
+    """extract_output_metadata_from_state falls back to range(N) for un-annotated vectors."""
+    from v2ecoli.library.xarray_run import extract_output_metadata_from_state
+    import numpy as np
+
+    state = {
+        "listeners": {
+            "monomer_counts": np.zeros(3, dtype=int),
+        }
+    }
+    view = [{"root": ("listeners",), "variables": {
+        "monomer_counts": [{"path": "monomer_counts", "dtype": "<f8"}]
+    }}]
+
+    # No named_metadata for monomer_counts → falls back to [0, 1, 2]
+    result = extract_output_metadata_from_state(state, view)
+    assert result.get("monomer_counts") == [0, 1, 2]
+
+
+# ---------------------------------------------------------------------------
+# Task 4: Config-level golden — names reach the built emitter config
+# ---------------------------------------------------------------------------
+
+@pytest.mark.sim
+def test_golden_monomer_names_in_output_metadata():
+    """Config-level golden: output_metadata(composite_state) carries monomer_ids at
+    listeners.monomer_counts after CountsDeriver annotation.
+
+    Requires out/cache (the simulation cache). Uses the existing cache; never
+    rebuilds ParCa.
+    """
+    import os
+    if not os.path.isdir("out/cache"):
+        pytest.skip("out/cache absent; build via scripts/build_cache.py")
+
+    from v2ecoli import build_composite
+    from v2ecoli.library.output_metadata import output_metadata
+
+    comp = build_composite("baseline", seed=0, cache_dir="out/cache")
+    result = output_metadata(comp.state)
+
+    # The names live at listeners.monomer_counts (store path from CountsDeriver.topology)
+    assert "listeners" in result, "output_metadata missing 'listeners' key"
+    assert "monomer_counts" in result["listeners"], (
+        "output_metadata['listeners'] missing 'monomer_counts'"
+    )
+    names = result["listeners"]["monomer_counts"]
+    assert isinstance(names, list) and len(names) > 0, (
+        "monomer_counts names should be a non-empty list, got: %r" % names
+    )
+    # Spot-check: monomer IDs are molecular IDs like 'MONA_CPLX_RNA_[c]'
+    assert any("[" in n for n in names), (
+        "Expected bracket-containing monomer IDs (e.g. 'MONA[c]'), got sample: %r" % names[:3]
+    )

--- a/tests/test_output_metadata.py
+++ b/tests/test_output_metadata.py
@@ -368,6 +368,64 @@ def test_output_metadata_walker_with_counts_deriver():
 
 
 # ---------------------------------------------------------------------------
+# Step 7: RnapData — rna_init_event_per_cistron uses cistron_ids labels
+# ---------------------------------------------------------------------------
+
+@pytest.mark.fast
+def test_rnap_data_outputs_rna_init_event_per_cistron_is_string_type():
+    """RnapData.outputs() declares rna_init_event_per_cistron as 'rna_init_event_per_cistron_vec'."""
+    from v2ecoli.steps.derivers.rnap_data import RnapData
+
+    cistron_ids = ["cistron_A", "cistron_B", "cistron_C"]
+
+    instance = RnapData.__new__(RnapData)
+    instance.n_TUs = 5
+    instance.n_cistrons = len(cistron_ids)
+    instance.cistron_ids = cistron_ids
+
+    schema = instance.outputs()
+    rnap_schema = schema["listeners"]["rnap_data"]
+    port_type = rnap_schema["rna_init_event_per_cistron"]
+    assert port_type == 'rna_init_event_per_cistron_vec', (
+        "rna_init_event_per_cistron should be 'rna_init_event_per_cistron_vec'; got: %r" % port_type
+    )
+
+
+@pytest.mark.fast
+def test_output_metadata_walker_with_rnap_data():
+    """Walker returns cistron_ids at listeners.rnap_data.rna_init_event_per_cistron."""
+    import numpy as np
+    from v2ecoli.core import build_core
+    from v2ecoli.types.labeled_array import LabeledArray
+    from v2ecoli.steps.derivers.rnap_data import RnapData
+    from v2ecoli.library.output_metadata import output_metadata
+
+    cistron_ids = ("cis_A", "cis_B", "cis_C")
+
+    core = build_core()
+    core.register_type('rna_init_event_per_cistron_vec', LabeledArray(
+        _shape=(len(cistron_ids),), _data=np.dtype('int64'), _labels=tuple(cistron_ids)
+    ))
+
+    instance = RnapData.__new__(RnapData)
+    instance.core = core
+    instance.n_TUs = 5
+    instance.n_cistrons = len(cistron_ids)
+    instance.cistron_ids = list(cistron_ids)
+
+    state = {
+        "rnap_data_listener": {
+            "instance": instance,
+            "outputs": {"listeners": ["listeners"]},
+        }
+    }
+    result = output_metadata(state)
+    assert result.get("listeners", {}).get("rnap_data", {}).get("rna_init_event_per_cistron") == list(cistron_ids), (
+        "Walker should recover cistron_ids; got: %r" % result
+    )
+
+
+# ---------------------------------------------------------------------------
 # Task 3: extract_output_metadata_from_state uses names when available
 # ---------------------------------------------------------------------------
 

--- a/tests/test_output_metadata.py
+++ b/tests/test_output_metadata.py
@@ -2,13 +2,114 @@
 
 TDD for sub-project #1 (readout-coordination): make v2ecoli runs self-describing
 by annotating listener outputs() with element names and harvesting them via a
-walker that mirrors vEcoli's EcoliSim.output_metadata() pattern.
+registry-based walker.
+
+Approach: labels are carried as type-level metadata on LabeledArray (a thin
+Array subtype). Each listener registers a named vec-type (e.g.
+'monomer_counts_vec') in initialize() so output_metadata() can recover element
+labels via core.access(type_name)._labels, without touching per-tick logic.
 """
 import pytest
 
 
 # ---------------------------------------------------------------------------
-# Task 1: output_metadata() walker baseline (before any annotations)
+# Step 2a: LabeledArray type — structural checks
+# ---------------------------------------------------------------------------
+
+@pytest.mark.fast
+def test_labeled_array_is_array_subtype():
+    """LabeledArray is a subclass of bigraph_schema Array."""
+    from bigraph_schema.schema import Array
+    from v2ecoli.types.labeled_array import LabeledArray
+
+    assert issubclass(LabeledArray, Array)
+
+
+@pytest.mark.fast
+def test_labeled_array_labels_not_in_schema_keys():
+    """_labels is absent from _schema_keys so the engine treats it as static metadata."""
+    from v2ecoli.types.labeled_array import LabeledArray
+
+    assert '_labels' not in LabeledArray._schema_keys, (
+        "_labels must NOT be in _schema_keys; it should be invisible to per-tick ops"
+    )
+
+
+@pytest.mark.fast
+def test_labeled_array_default_labels_empty():
+    """LabeledArray() with no args has empty _labels tuple."""
+    from v2ecoli.types.labeled_array import LabeledArray
+
+    la = LabeledArray()
+    assert la._labels == ()
+
+
+@pytest.mark.fast
+def test_labeled_array_stores_labels():
+    """LabeledArray(_labels=(...)) stores the provided tuple."""
+    import numpy as np
+    from v2ecoli.types.labeled_array import LabeledArray
+
+    labels = ('A', 'B', 'C')
+    la = LabeledArray(_shape=(3,), _data=np.dtype('int64'), _labels=labels)
+    assert la._labels == labels
+
+
+# ---------------------------------------------------------------------------
+# Step 2b: core registration — core.access('labeled_array') and named vec-types
+# ---------------------------------------------------------------------------
+
+@pytest.mark.fast
+def test_core_access_labeled_array():
+    """build_core() registers 'labeled_array'; core.access returns a LabeledArray."""
+    from v2ecoli.core import build_core
+    from v2ecoli.types.labeled_array import LabeledArray
+
+    core = build_core()
+    node = core.access('labeled_array')
+    assert isinstance(node, LabeledArray), (
+        "core.access('labeled_array') should return a LabeledArray, got: %r" % type(node)
+    )
+
+
+@pytest.mark.fast
+def test_named_vec_type_roundtrips_labels():
+    """Register a named LabeledArray instance; core.access preserves _labels."""
+    import numpy as np
+    from v2ecoli.core import build_core
+    from v2ecoli.types.labeled_array import LabeledArray
+
+    core = build_core()
+    labels = ('MON-0', 'MON-1', 'MON-2')
+    instance = LabeledArray(_shape=(3,), _data=np.dtype('int64'), _labels=labels)
+    core.register_type('test_labeled_vec', instance)
+
+    recovered = core.access('test_labeled_vec')
+    assert isinstance(recovered, LabeledArray)
+    assert recovered._labels == labels, (
+        "Labels should survive round-trip through registry, got: %r" % (recovered._labels,)
+    )
+
+
+@pytest.mark.fast
+def test_labeled_array_port_resolves_in_core():
+    """core.access on a registered LabeledArray type name works without error."""
+    import numpy as np
+    from v2ecoli.core import build_core
+    from v2ecoli.types.labeled_array import LabeledArray
+
+    labels = tuple(f'MOL-{i}' for i in range(5))
+    core = build_core()
+    core.register_type('test_vec5', LabeledArray(
+        _shape=(5,), _data=np.dtype('int64'), _labels=labels
+    ))
+    node = core.access('test_vec5')
+    assert isinstance(node, LabeledArray)
+    assert node._labels == labels
+
+
+# ---------------------------------------------------------------------------
+# Task 1: output_metadata() walker baseline (unchanged — legacy _properties path)
 # ---------------------------------------------------------------------------
 
 @pytest.mark.fast
@@ -84,7 +185,7 @@ def test_output_metadata_no_instances_returns_empty():
 
 @pytest.mark.fast
 def test_output_metadata_walker_unannotated_step():
-    """Walker with a step that has no _properties.metadata → returns {}."""
+    """Walker with a step that has no labels → returns {}."""
     from v2ecoli.library.output_metadata import output_metadata
 
     class UnannotatedStep:
@@ -105,8 +206,8 @@ def test_output_metadata_walker_unannotated_step():
 
 
 @pytest.mark.fast
-def test_output_metadata_walker_annotated_step():
-    """Walker finds _properties.metadata in a step outputs() and remaps to store path."""
+def test_output_metadata_walker_legacy_properties_path():
+    """Walker still finds _properties.metadata (legacy backward-compat path)."""
     from v2ecoli.library.output_metadata import output_metadata
 
     monomer_ids = ["MONOMER_A", "MONOMER_B", "MONOMER_C"]
@@ -123,7 +224,6 @@ def test_output_metadata_walker_annotated_step():
                 }
             }
 
-    # Wiring: port 'listeners' → store path ['listeners']
     state = {
         "some_step": {
             "instance": AnnotatedStep(),
@@ -132,7 +232,40 @@ def test_output_metadata_walker_annotated_step():
     }
     result = output_metadata(state)
     assert result == {"listeners": {"monomer_counts": monomer_ids}}, (
-        "Expected monomer names at listeners.monomer_counts, got: %r" % result
+        "Legacy _properties.metadata path broken; got: %r" % result
+    )
+
+
+@pytest.mark.fast
+def test_output_metadata_walker_registry_string_port():
+    """Walker extracts labels when port type is a registered LabeledArray name."""
+    import numpy as np
+    from v2ecoli.core import build_core
+    from v2ecoli.types.labeled_array import LabeledArray
+    from v2ecoli.library.output_metadata import output_metadata
+
+    monomer_ids = ("MONA_[c]", "MONB_[c]", "MONC_[c]")
+    core = build_core()
+    core.register_type('test_mon_vec', LabeledArray(
+        _shape=(3,), _data=np.dtype('int64'), _labels=monomer_ids
+    ))
+
+    class RegistryStep:
+        def __init__(self, core):
+            self.core = core
+
+        def outputs(self):
+            return {"listeners": {"monomer_counts": "test_mon_vec"}}
+
+    state = {
+        "some_step": {
+            "instance": RegistryStep(core),
+            "outputs": {"listeners": ["listeners"]},
+        }
+    }
+    result = output_metadata(state)
+    assert result.get("listeners", {}).get("monomer_counts") == list(monomer_ids), (
+        "Walker should recover labels from registry; got: %r" % result
     )
 
 
@@ -170,17 +303,16 @@ def test_output_metadata_nested_state():
 
 
 # ---------------------------------------------------------------------------
-# Task 2: CountsDeriver.outputs() carries _properties.metadata for monomer_counts
+# Step 3: CountsDeriver annotates monomer_counts via registry approach
 # ---------------------------------------------------------------------------
 
 @pytest.mark.fast
-def test_counts_deriver_outputs_carries_monomer_ids_metadata():
-    """After annotation, CountsDeriver.outputs() has _properties.metadata for monomer_counts."""
+def test_counts_deriver_outputs_monomer_counts_is_string_type():
+    """CountsDeriver.outputs() declares monomer_counts as 'monomer_counts_vec' (a string type name)."""
     from v2ecoli.steps.derivers.counts_deriver import CountsDeriver
 
     monomer_ids = ["MONA_[c]", "MONB_[c]", "MONC_[c]"]
 
-    # Build a minimal instance with just the attrs outputs() needs.
     instance = CountsDeriver.__new__(CountsDeriver)
     instance.n_monomers = len(monomer_ids)
     instance.monomer_ids = monomer_ids
@@ -191,24 +323,33 @@ def test_counts_deriver_outputs_carries_monomer_ids_metadata():
 
     schema = instance.outputs()
     monomer_schema = schema["listeners"]["monomer_counts"]
-    props = monomer_schema.get("_properties", {})
-    assert "metadata" in props, (
-        "monomer_counts schema missing _properties.metadata; schema=%r" % monomer_schema
+    assert monomer_schema == 'monomer_counts_vec', (
+        "monomer_counts should be the string 'monomer_counts_vec'; got: %r" % monomer_schema
     )
-    assert props["metadata"] == monomer_ids
 
 
 @pytest.mark.fast
 def test_output_metadata_walker_with_counts_deriver():
     """Walker returns monomer_ids at listeners.monomer_counts for a CountsDeriver instance."""
+    import numpy as np
+    from v2ecoli.core import build_core
+    from v2ecoli.types.labeled_array import LabeledArray
     from v2ecoli.steps.derivers.counts_deriver import CountsDeriver
     from v2ecoli.library.output_metadata import output_metadata
 
-    monomer_ids = ["MONA_[c]", "MONB_[c]"]
+    monomer_ids = ("MONA_[c]", "MONB_[c]")
 
+    # Build a real core and register monomer_counts_vec (simulating initialize()).
+    core = build_core()
+    core.register_type('monomer_counts_vec', LabeledArray(
+        _shape=(len(monomer_ids),), _data=np.dtype('int64'), _labels=tuple(monomer_ids)
+    ))
+
+    # Create a minimal CountsDeriver instance (bypassing full __init__).
     instance = CountsDeriver.__new__(CountsDeriver)
+    instance.core = core  # walker uses instance.core
     instance.n_monomers = len(monomer_ids)
-    instance.monomer_ids = monomer_ids
+    instance.monomer_ids = list(monomer_ids)
     instance.n_mRNA_TU = 1
     instance.n_mRNA_cistron = 1
     instance.n_rRNA_TU = 1
@@ -221,7 +362,9 @@ def test_output_metadata_walker_with_counts_deriver():
         }
     }
     result = output_metadata(state)
-    assert result.get("listeners", {}).get("monomer_counts") == monomer_ids
+    assert result.get("listeners", {}).get("monomer_counts") == list(monomer_ids), (
+        "Walker should recover monomer_ids at listeners.monomer_counts; got: %r" % result
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_output_metadata_parquet.py
+++ b/tests/test_output_metadata_parquet.py
@@ -1,0 +1,328 @@
+"""Tests: output_metadata walker wired into parquet + sqlite run paths.
+
+Fast, config-level proof that self-describing labels flow through the two
+default emitter backends without requiring the ParCa cache or a real
+composite run.
+
+Test level achieved: end-to-end parquet write + DuckDB config-partition
+read-back (the actual config.pq is read and the names are verified via
+``field_metadata()`` and by direct column query). SQLite is tested at the
+``save_simulation_metadata`` + ``load_simulation_metadata`` level (the JSON
+blob path).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+pytest.importorskip("duckdb")
+pytest.importorskip("polars")
+pytest.importorskip("pbg_emitters")
+
+import duckdb  # noqa: E402
+
+from v2ecoli.library.parquet_run import run_multigen_parquet  # noqa: E402
+from v2ecoli.library.sqlite_run import run_multigen_sqlite  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers — stub composite with an annotated step instance
+# ---------------------------------------------------------------------------
+
+def _build_annotated_composite(monomer_ids: list[str]) -> object:
+    """Build a minimal composite-like object whose state includes an annotated
+    step instance (simulating CountsDeriver after initialize()).
+
+    The composite:
+      * registers a ``monomer_counts_vec`` LabeledArray type in its core
+      * exposes a step instance in state whose ``outputs()`` returns the
+        type-string ``"monomer_counts_vec"`` for the ``listeners.monomer_counts``
+        port — exactly the pattern used by CountsDeriver
+      * advances a per-agent ``count`` scalar on each ``run(n)``
+    """
+    from v2ecoli.core import build_core
+    from v2ecoli.types.labeled_array import LabeledArray
+
+    core = build_core()
+    core.register_type(
+        "monomer_counts_vec",
+        LabeledArray(
+            _shape=(len(monomer_ids),),
+            _data=np.dtype("int64"),
+            _labels=tuple(monomer_ids),
+        ),
+    )
+
+    class _AnnotatedStep:
+        """Minimal step that reports monomer_counts as a LabeledArray type."""
+
+        def __init__(self, the_core):
+            self.core = the_core
+
+        def outputs(self):
+            return {"listeners": {"monomer_counts": "monomer_counts_vec"}}
+
+    step_instance = _AnnotatedStep(core)
+
+    class _AnnotatedComposite:
+        def __init__(self):
+            self.core = core
+            self.state = {
+                "agents": {
+                    "0": {
+                        "counts_deriver": {
+                            "instance": step_instance,
+                            "outputs": {"listeners": ["listeners"]},
+                        },
+                        "listeners": {
+                            "monomer_counts": np.zeros(len(monomer_ids), dtype=np.int64),
+                            "mass": {"cell_mass": 1.0},
+                        },
+                    }
+                }
+            }
+            self._tick = 0
+
+        def run(self, n: int) -> None:
+            self._tick += n
+            for aid in self.state["agents"]:
+                self.state["agents"][aid]["listeners"]["mass"]["cell_mass"] += 0.1 * n
+
+        def find_instance_paths(self, *_a, **_kw) -> None:
+            pass
+
+    return _AnnotatedComposite()
+
+
+# ---------------------------------------------------------------------------
+# Test 1: output_metadata ends up in config.pq (parquet path, fast)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.fast
+def test_output_metadata_in_parquet_config(tmp_path):
+    """run_multigen_parquet writes monomer names into the config parquet.
+
+    This is an end-to-end parquet read-back test at the config-partition
+    level. No ParCa cache needed — uses a stub composite with an annotated
+    step instance.
+
+    Verification path:
+      1. Run 10 steps (no division) against the annotated stub composite.
+      2. Open the resulting config.pq with DuckDB.
+      3. Assert the ``output_metadata__listeners__monomer_counts`` column
+         exists and contains the expected monomer IDs.
+      4. Also verify via ``field_metadata()`` (the canonical reader API).
+    """
+    monomer_ids = ["MONA[c]", "MONB[c]", "MONC[c]"]
+    comp = _build_annotated_composite(monomer_ids)
+
+    result = run_multigen_parquet(
+        comp,
+        experiment_id="test-meta",
+        out_dir=tmp_path / "out",
+        emit_paths=["listeners/mass/cell_mass"],
+        max_steps=10,
+        max_generations=1,
+        chunk=5,
+        initial_agent_id="0",
+        batch_size=2,
+        threaded=False,
+        core=comp.core,
+    )
+    assert result["steps"] == 10
+
+    # Locate the config.pq
+    config_pq = (
+        tmp_path / "out" / "test-meta" / "configuration"
+        / "experiment_id=test-meta" / "variant=0" / "lineage_seed=0"
+        / "generation=1" / "agent_id=0" / "config.pq"
+    )
+    assert config_pq.is_file(), f"config.pq not found at {config_pq}"
+
+    # Read via DuckDB and verify the column exists + contains the names.
+    conn = duckdb.connect(":memory:")
+    config_sql = f"SELECT * FROM read_parquet('{config_pq}')"
+
+    # Check column presence (the flatten_dict key for nested output_metadata)
+    cols = [col[0] for col in conn.sql(f"DESCRIBE ({config_sql})").fetchall()]
+    expected_col = "output_metadata__listeners__monomer_counts"
+    assert expected_col in cols, (
+        f"Column '{expected_col}' missing from config.pq. "
+        f"Columns present: {[c for c in cols if 'output' in c.lower() or 'metadata' in c.lower()]}"
+    )
+
+    # Verify the stored names match via direct query.
+    raw_names = conn.sql(
+        f'SELECT "{expected_col}" FROM ({config_sql})'
+    ).fetchone()[0]
+    assert list(raw_names) == monomer_ids, (
+        f"Names mismatch: expected {monomer_ids}, got {list(raw_names)}"
+    )
+
+    # Also verify via the canonical field_metadata() reader API.
+    from pbg_emitters import field_metadata
+    recovered = field_metadata(conn, config_sql, "listeners__monomer_counts")
+    assert recovered == monomer_ids, (
+        f"field_metadata recovered {recovered!r}, expected {monomer_ids!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 2: unannotated composite → no output_metadata key (backward-compat)
+# ---------------------------------------------------------------------------
+
+class _PlainStubComposite:
+    """Minimal composite with NO annotated step instances — backward-compat check."""
+
+    def __init__(self, core, initial_agent_id: str = "0"):
+        self.core = core
+        self.state = {
+            "agents": {
+                initial_agent_id: {
+                    "listeners": {"mass": {"cell_mass": 1.0}, "count": 0},
+                },
+            },
+        }
+        self._tick = 0
+
+    def run(self, n: int) -> None:
+        self._tick += n
+        for aid in self.state["agents"]:
+            self.state["agents"][aid]["listeners"]["count"] += n
+            self.state["agents"][aid]["listeners"]["mass"]["cell_mass"] += 0.1 * n
+
+    def find_instance_paths(self, *_a, **_kw) -> None:
+        pass
+
+
+@pytest.mark.fast
+def test_output_metadata_absent_for_unannotated_composite(tmp_path):
+    """Stub composite with no annotated steps → config.pq has no output_metadata__ cols."""
+    from bigraph_schema import allocate_core
+
+    core = allocate_core()
+    comp = _PlainStubComposite(core, initial_agent_id="0")
+
+    run_multigen_parquet(
+        comp,
+        experiment_id="no-meta",
+        out_dir=tmp_path / "out",
+        emit_paths=["listeners/mass/cell_mass", "listeners/count"],
+        max_steps=10,
+        max_generations=1,
+        chunk=5,
+        initial_agent_id="0",
+        batch_size=2,
+        threaded=False,
+        core=core,
+    )
+
+    config_pq = (
+        tmp_path / "out" / "no-meta" / "configuration"
+        / "experiment_id=no-meta" / "variant=0" / "lineage_seed=0"
+        / "generation=1" / "agent_id=0" / "config.pq"
+    )
+    assert config_pq.is_file()
+
+    conn = duckdb.connect(":memory:")
+    cols = [
+        col[0]
+        for col in conn.sql(
+            f"DESCRIBE (SELECT * FROM read_parquet('{config_pq}'))"
+        ).fetchall()
+    ]
+    output_meta_cols = [c for c in cols if c.startswith("output_metadata__")]
+    assert output_meta_cols == [], (
+        f"Expected no output_metadata__ columns for unannotated composite; got: {output_meta_cols}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 3: sqlite path — output_metadata stored in simulations.metadata JSON
+# ---------------------------------------------------------------------------
+
+@pytest.mark.fast
+def test_output_metadata_in_sqlite_simulations(tmp_path):
+    """run_multigen_sqlite writes output_metadata into simulations.metadata JSON.
+
+    SQLite stores the catalog as a JSON blob (not individual queryable
+    columns like the parquet path). Recoverable via load_simulation_metadata.
+    """
+    monomer_ids = ["MONA[c]", "MONB[c]", "MONC[c]"]
+    comp = _build_annotated_composite(monomer_ids)
+
+    db_file = tmp_path / "sim.db"
+
+    run_multigen_sqlite(
+        comp,
+        run_id="run-meta-test",
+        db_file=db_file,
+        emit_paths=["listeners/mass/cell_mass"],
+        max_steps=10,
+        chunk=5,
+        initial_agent_id="0",
+        core=comp.core,
+    )
+
+    from pbg_emitters.sqlite_emitter import load_simulation_metadata
+    row = load_simulation_metadata(db_file, "run-meta-test")
+    assert row is not None, "No simulations row found"
+    meta = row.get("metadata")
+    assert meta is not None, f"metadata column is null; row={row}"
+    om = meta.get("output_metadata")
+    assert om is not None, f"output_metadata key missing from metadata JSON; meta={meta}"
+    recovered = om.get("listeners", {}).get("monomer_counts")
+    assert recovered == monomer_ids, (
+        f"SQLite output_metadata mismatch: expected {monomer_ids}, got {recovered}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 4: config-level golden — real composite carries names (requires cache)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.sim
+def test_golden_output_metadata_in_parquet_config_real_composite(tmp_path, sim_data_cache):
+    """End-to-end with a real baseline composite: monomer names flow into config.pq.
+
+    Skipped when out/cache is absent. Uses the symlinked cache read-only
+    (tmp_path for writes). Runs 2 steps — just enough to trigger emitter
+    construction and config write, not a full-gen run.
+    """
+    from v2ecoli import build_composite
+    from pbg_emitters import field_metadata
+
+    comp = build_composite("baseline", seed=0, cache_dir=sim_data_cache)
+
+    result = run_multigen_parquet(
+        comp,
+        experiment_id="golden-meta",
+        out_dir=tmp_path / "out",
+        emit_paths=["listeners/mass/cell_mass"],
+        max_steps=2,
+        max_generations=1,
+        chunk=2,
+        initial_agent_id="0",
+        batch_size=10,
+        threaded=False,
+        core=comp.core,
+    )
+    assert result["steps"] == 2
+
+    config_pq = (
+        tmp_path / "out" / "golden-meta" / "configuration"
+        / "experiment_id=golden-meta" / "variant=0" / "lineage_seed=0"
+        / "generation=1" / "agent_id=0" / "config.pq"
+    )
+    assert config_pq.is_file(), f"config.pq not written: {config_pq}"
+
+    conn = duckdb.connect(":memory:")
+    config_sql = f"SELECT * FROM read_parquet('{config_pq}')"
+    recovered = field_metadata(conn, config_sql, "listeners__monomer_counts")
+    assert isinstance(recovered, list) and len(recovered) > 0, (
+        f"Expected non-empty monomer name list; got: {recovered!r}"
+    )
+    assert any("[" in n for n in recovered), (
+        f"Expected bracket-containing IDs (e.g. 'MONA[c]'); sample: {recovered[:3]!r}"
+    )

--- a/v2ecoli/library/output_metadata.py
+++ b/v2ecoli/library/output_metadata.py
@@ -1,18 +1,30 @@
 """
 Output metadata walker for v2ecoli composites.
 
-Mirrors vEcoli's ``ecoli.experiments.ecoli_master_sim.output_metadata()`` /
-``extract_metadata()`` convention: processes annotate their ``outputs()`` port
-schema with ``_properties: {'metadata': <names_list>}``, this module harvests
-those annotations from a live composite state and returns a store-relative dict.
+Makes runs self-describing: each listener process registers a named
+LabeledArray type in its ``initialize()`` carrying the element IDs for its
+fixed-length vector outputs.  This walker reads those labels from the
+type registry and returns a store-relative dict of names that feeds
+XArrayEmitter's coord arrays.
+
+Primary (registry) path
+-----------------------
+When a port type is a **string name** registered in the bigraph-schema core,
+the walker calls ``core.access(type_name)`` and reads ``getattr(node,
+'_labels', None)`` (a plain dataclass field that is **not** in
+``_schema_keys``, so the engine ignores it per-tick).  This is the approach
+used by CountsDeriver / RnapData (and any future listener).
+
+Legacy (backward-compat) path
+-------------------------------
+When a port schema is a dict carrying ``_properties: {'metadata': [...]}``,
+the walker uses the original ``extract_metadata()`` helper so that any code
+that annotates ports the old way still works.
 
 The returned dict feeds into:
   - XArrayEmitter ``output_metadata`` (coord arrays for vector leaves);
   - ParquetEmitter ``config["metadata"]["output_metadata"]`` (written as
     ``output_metadata__<path>`` columns in the configuration parquet).
-
-This mirrors the path described in vEcoli PR #414 / ``ecoli_master_sim.py``
-``:852`` / ``:1011``, grounded to v2ecoli's process-bigraph composite layout.
 """
 from __future__ import annotations
 
@@ -22,7 +34,7 @@ import numpy as np
 
 
 # ---------------------------------------------------------------------------
-# extract_metadata — mirrors vEcoli's extract_metadata() exactly
+# extract_metadata — legacy _properties.metadata path (kept for backward compat)
 # ---------------------------------------------------------------------------
 
 
@@ -62,6 +74,75 @@ def extract_metadata(schema: dict, _properties: bool = False) -> Any:
 
 
 # ---------------------------------------------------------------------------
+# _extract_labels_recursive — primary + legacy walker
+# ---------------------------------------------------------------------------
+
+
+def _extract_labels_recursive(schema: Any, core: Any) -> Any:
+    """Recursively extract element-name labels from a port schema.
+
+    Handles two annotation styles:
+
+    * **Registry (primary)**: port value is a ``str`` type name that resolves
+      to a ``LabeledArray`` (or any node with ``_labels``).  Labels are read
+      via ``core.access(name)._labels``.
+
+    * **Properties (legacy)**: port dict carries ``_properties.metadata``.
+      Delegates to ``extract_metadata()``.
+
+    Args:
+        schema: A port schema value — either a string type name, a typed leaf
+            dict, or a nested port dict.
+        core:   The bigraph-schema Core instance, or ``None`` (registry path
+                skipped when core is unavailable).
+
+    Returns:
+        ``list`` of labels when a port carries them; nested ``dict`` mapping
+        sub-port names to their label lists; or ``None`` when no labels found.
+    """
+    if isinstance(schema, str):
+        # Registry path: look up the type name and check for _labels.
+        if core is not None:
+            try:
+                node = core.access(schema)
+                labels = getattr(node, '_labels', None)
+                if labels:
+                    return list(labels)
+            except Exception:
+                pass
+        return None
+
+    if not isinstance(schema, dict):
+        return None
+
+    # Legacy path: dict carries _properties.metadata.
+    if '_properties' in schema:
+        return extract_metadata(schema)
+
+    # Typed leaf dict (e.g. {'_type': 'overwrite[array[N,integer]]', '_default': []}):
+    # check the _type string for labels (unlikely but handles edge cases).
+    if '_type' in schema:
+        type_str = schema.get('_type')
+        if isinstance(type_str, str) and core is not None:
+            try:
+                node = core.access(type_str)
+                labels = getattr(node, '_labels', None)
+                if labels:
+                    return list(labels)
+            except Exception:
+                pass
+        return None
+
+    # Plain nested port dict: recurse into each sub-key.
+    result: dict = {}
+    for key, val in schema.items():
+        sub = _extract_labels_recursive(val, core)
+        if sub is not None:
+            result[key] = sub
+    return result or None
+
+
+# ---------------------------------------------------------------------------
 # _remap_to_store — simplified inverse_topology for v2ecoli wiring
 # ---------------------------------------------------------------------------
 
@@ -78,7 +159,7 @@ def _remap_to_store(extracted: dict, wiring: dict) -> dict:
     returned store-relative dict.
 
     Args:
-        extracted: Port-relative metadata dict from ``extract_metadata()``.
+        extracted: Port-relative metadata dict from ``_extract_labels_recursive()``.
         wiring: Output wiring dict for a step edge.
 
     Returns:
@@ -143,37 +224,46 @@ def _walk_state(state: dict):
 
 
 def output_metadata(state: dict) -> dict:
-    """Harvest ``_properties.metadata`` from step ``outputs()`` across a composite state.
+    """Harvest element-name labels from step ``outputs()`` schemas across a composite state.
 
-    Mirrors vEcoli's ``EcoliSim.output_metadata()``. Walks all step/process
-    instances in ``state`` (the raw composite state dict — e.g.
-    ``composite.state``, ``doc['state']``, or ``doc['state']['agents']['0']``),
-    calls each instance's ``outputs()`` schema, pulls ``_properties.metadata``
-    leaves, remaps to store-relative paths via the edge's output wiring, and
-    deep-merges all into one dict.
+    For each step/process instance in ``state``, calls ``outputs()`` and
+    extracts element-name labels via two paths (in priority order):
+
+    1. **Registry path** (primary): port type is a ``str`` registered in
+       ``instance.core``; labels come from
+       ``core.access(type_name)._labels``.  Used by CountsDeriver /
+       RnapData after the listener's ``initialize()`` has registered the
+       named ``LabeledArray`` type.
+
+    2. **Properties path** (legacy): port schema dict carries
+       ``_properties: {'metadata': [...]}``; harvested by
+       ``extract_metadata()``.
+
+    Both paths produce the same store-relative output dict so downstream
+    consumers (XArrayEmitter, ParquetEmitter) are unchanged.
 
     Args:
-        state: Composite state dict.  Nested state trees are handled (the walker
-               recurses into non-edge sub-dicts).
+        state: Composite state dict.  Nested state trees are handled (the
+               walker recurses into non-edge sub-dicts).
 
     Returns:
         Store-relative dict mapping paths to name lists; e.g.::
 
-            {'listeners': {'monomer_counts': ['MONA_[c]', 'MONB_[c]', ...]}}
+            {'listeners': {'monomer_counts': ['MONA[c]', 'MONB[c]', ...]}}
 
-        Returns ``{}`` if no process carries ``_properties.metadata`` in its
-        ``outputs()``.
+        Returns ``{}`` if no process carries labels in its ``outputs()``.
     """
     result: dict = {}
     for edge, _name in _walk_state(state):
         instance = edge["instance"]
+        core = getattr(instance, 'core', None)
         try:
             outputs_schema = instance.outputs()
         except Exception:
             continue
         if not isinstance(outputs_schema, dict):
             continue
-        extracted = extract_metadata(outputs_schema)
+        extracted = _extract_labels_recursive(outputs_schema, core)
         if not extracted:
             continue
         wiring = edge.get("outputs", {})

--- a/v2ecoli/library/output_metadata.py
+++ b/v2ecoli/library/output_metadata.py
@@ -1,0 +1,184 @@
+"""
+Output metadata walker for v2ecoli composites.
+
+Mirrors vEcoli's ``ecoli.experiments.ecoli_master_sim.output_metadata()`` /
+``extract_metadata()`` convention: processes annotate their ``outputs()`` port
+schema with ``_properties: {'metadata': <names_list>}``, this module harvests
+those annotations from a live composite state and returns a store-relative dict.
+
+The returned dict feeds into:
+  - XArrayEmitter ``output_metadata`` (coord arrays for vector leaves);
+  - ParquetEmitter ``config["metadata"]["output_metadata"]`` (written as
+    ``output_metadata__<path>`` columns in the configuration parquet).
+
+This mirrors the path described in vEcoli PR #414 / ``ecoli_master_sim.py``
+``:852`` / ``:1011``, grounded to v2ecoli's process-bigraph composite layout.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+
+# ---------------------------------------------------------------------------
+# extract_metadata — mirrors vEcoli's extract_metadata() exactly
+# ---------------------------------------------------------------------------
+
+
+def extract_metadata(schema: dict, _properties: bool = False) -> Any:
+    """Extract ``_properties.metadata`` leaves from a ports schema.
+
+    Mirrors ``ecoli.experiments.ecoli_master_sim.extract_metadata``.
+    Recursively walks ``schema``; returns a dict with the same structure as
+    the schema but with only ``_properties.metadata`` values as leaves.
+    Returns ``None`` if no metadata is found.
+
+    Args:
+        schema: A port schema dict (e.g. the return value of ``outputs()``).
+        _properties: Internal flag — set ``True`` when recursing inside a
+            ``_properties`` sub-dict.
+
+    Returns:
+        Nested dict of metadata or ``None`` if none found.
+    """
+    if "_properties" in schema and isinstance(schema["_properties"], dict):
+        return extract_metadata(schema["_properties"], True)
+
+    if _properties and "metadata" in schema:
+        metadata = schema["metadata"]
+        if isinstance(metadata, np.ndarray):
+            metadata = metadata.tolist()
+        return metadata
+
+    extracted: dict = {}
+    for port, subschema in schema.items():
+        if isinstance(subschema, dict):
+            sub = extract_metadata(subschema)
+            if sub is not None:
+                extracted[port] = sub
+
+    return extracted or None
+
+
+# ---------------------------------------------------------------------------
+# _remap_to_store — simplified inverse_topology for v2ecoli wiring
+# ---------------------------------------------------------------------------
+
+
+def _remap_to_store(extracted: dict, wiring: dict) -> dict:
+    """Map port-relative extracted metadata to store-relative paths.
+
+    In v2ecoli, the ``outputs`` wiring for a step edge maps port names to
+    store path lists (e.g. ``{'listeners': ['listeners']}``), as built by
+    ``make_edge()`` / ``list_paths()`` in ``v2ecoli.composites._helpers``.
+
+    For each top-level port in ``extracted``, this function follows the wiring
+    path to place the port's nested value at the correct location in the
+    returned store-relative dict.
+
+    Args:
+        extracted: Port-relative metadata dict from ``extract_metadata()``.
+        wiring: Output wiring dict for a step edge.
+
+    Returns:
+        Store-relative dict with the same leaf values as ``extracted``.
+    """
+    result: dict = {}
+    for port_name, value in extracted.items():
+        path = wiring.get(port_name)
+        if path is None:
+            continue
+        # Navigate / create nested structure in result following the store path.
+        cursor = result
+        for segment in path[:-1]:
+            cursor = cursor.setdefault(segment, {})
+        last = path[-1]
+        if isinstance(value, dict):
+            existing = cursor.get(last)
+            if isinstance(existing, dict):
+                _deep_merge(existing, value)
+            else:
+                cursor[last] = value
+        else:
+            cursor[last] = value
+    return result
+
+
+def _deep_merge(target: dict, source: dict) -> None:
+    """Merge ``source`` into ``target`` in-place (shallow for non-dict leaves)."""
+    for k, v in source.items():
+        if isinstance(v, dict) and isinstance(target.get(k), dict):
+            _deep_merge(target[k], v)
+        else:
+            target[k] = v
+
+
+# ---------------------------------------------------------------------------
+# _walk_state — yield step/process edges from the composite state tree
+# ---------------------------------------------------------------------------
+
+
+def _walk_state(state: dict):
+    """Yield ``(edge_dict, step_name)`` for each step/process edge in ``state``.
+
+    Recurse into nested state dicts (e.g. ``agents -> '0' -> step_name``).
+    An edge is identified by having an ``'instance'`` key whose value has an
+    ``outputs`` callable (i.e. a Step or Process instance).
+    """
+    for key, value in state.items():
+        if isinstance(value, dict):
+            if "instance" in value and callable(
+                getattr(value["instance"], "outputs", None)
+            ):
+                yield value, key
+            else:
+                # Recurse into nested state (e.g. agents → '0' → steps)
+                yield from _walk_state(value)
+
+
+# ---------------------------------------------------------------------------
+# output_metadata — the public walker API
+# ---------------------------------------------------------------------------
+
+
+def output_metadata(state: dict) -> dict:
+    """Harvest ``_properties.metadata`` from step ``outputs()`` across a composite state.
+
+    Mirrors vEcoli's ``EcoliSim.output_metadata()``. Walks all step/process
+    instances in ``state`` (the raw composite state dict — e.g.
+    ``composite.state``, ``doc['state']``, or ``doc['state']['agents']['0']``),
+    calls each instance's ``outputs()`` schema, pulls ``_properties.metadata``
+    leaves, remaps to store-relative paths via the edge's output wiring, and
+    deep-merges all into one dict.
+
+    Args:
+        state: Composite state dict.  Nested state trees are handled (the walker
+               recurses into non-edge sub-dicts).
+
+    Returns:
+        Store-relative dict mapping paths to name lists; e.g.::
+
+            {'listeners': {'monomer_counts': ['MONA_[c]', 'MONB_[c]', ...]}}
+
+        Returns ``{}`` if no process carries ``_properties.metadata`` in its
+        ``outputs()``.
+    """
+    result: dict = {}
+    for edge, _name in _walk_state(state):
+        instance = edge["instance"]
+        try:
+            outputs_schema = instance.outputs()
+        except Exception:
+            continue
+        if not isinstance(outputs_schema, dict):
+            continue
+        extracted = extract_metadata(outputs_schema)
+        if not extracted:
+            continue
+        wiring = edge.get("outputs", {})
+        if not wiring:
+            continue
+        remapped = _remap_to_store(extracted, wiring)
+        _deep_merge(result, remapped)
+    return result

--- a/v2ecoli/library/parquet_run.py
+++ b/v2ecoli/library/parquet_run.py
@@ -36,6 +36,7 @@ from v2ecoli.library.sqlite_run import (
     _merge_into,
     prune_to_followed_lineage,
 )
+from v2ecoli.library.output_metadata import output_metadata as _get_output_metadata
 
 
 def run_multigen_parquet(
@@ -99,6 +100,17 @@ def run_multigen_parquet(
         _merge_into(emit_schema, _build_emit_schema(root_leaves))
     out_dir = str(Path(out_dir).resolve())
 
+    # Harvest element-name labels from listener outputs() schemas. Labels are
+    # registered in the type core during initialize(), so they are present in
+    # composite.state immediately — no warmup tick required (unlike the xarray
+    # path which also needs vector shapes from live state values).
+    # Un-annotated composites return {} → backward-compat: no output_metadata
+    # key is added and existing runs are unaffected.
+    _named_metadata: dict = _get_output_metadata(composite.state or {})
+    if _named_metadata:
+        print(f"[multigen_parquet] discovered output_metadata labels for: "
+              f"{list(_named_metadata.keys())}")
+
     def _make_emitter(agent_id: str, generation: int) -> ParquetEmitter:
         metadata: dict[str, Any] = {
             "experiment_id": experiment_id,
@@ -111,6 +123,11 @@ def run_multigen_parquet(
             metadata["study_slug"] = study_slug
         if investigation_slug:
             metadata["investigation_slug"] = investigation_slug
+        # Merge element-name labels into config metadata so ParquetEmitter
+        # persists them via flatten_dict as output_metadata__<path> columns
+        # in the configuration parquet. Recoverable via field_metadata().
+        if _named_metadata:
+            metadata["output_metadata"] = _named_metadata
 
         return ParquetEmitter(
             config={

--- a/v2ecoli/library/sqlite_run.py
+++ b/v2ecoli/library/sqlite_run.py
@@ -288,6 +288,8 @@ def run_multigen_sqlite(
         Caller should query the db directly.
     """
     from process_bigraph.emitter import SQLiteEmitter
+    from pbg_emitters.sqlite_emitter import save_simulation_metadata
+    from v2ecoli.library.output_metadata import output_metadata as _get_output_metadata
 
     if division_detector is None:
         def division_detector(prev: set[str], curr: set[str]) -> tuple[bool, str | None]:
@@ -317,6 +319,26 @@ def run_multigen_sqlite(
         "subsample": 1,
         "batch_size": 1,
     }, core=core or composite.core)
+
+    # Harvest element-name labels from listener outputs() schemas and persist
+    # them in the simulations table metadata column (JSON). Recoverable via
+    # load_simulation_metadata(db_file, run_id)["metadata"]["output_metadata"].
+    # Note: SQLiteEmitter has no flatten_dict / METADATA_PREFIX mechanism like
+    # ParquetEmitter — the catalog is stored as a single JSON blob, not as
+    # individual queryable columns. This is a best-effort store; the parquet
+    # path provides richer per-field read-back via field_metadata().
+    _named_metadata: dict = _get_output_metadata(composite.state or {})
+    if _named_metadata:
+        print(f"[multigen_sqlite] persisting output_metadata labels for: "
+              f"{list(_named_metadata.keys())}")
+        try:
+            save_simulation_metadata(
+                db_path,
+                run_id,
+                metadata={"output_metadata": _named_metadata},
+            )
+        except Exception as _e:
+            print(f"[multigen_sqlite] output_metadata persist failed: {_e!r}")
 
     import gc
 

--- a/v2ecoli/library/xarray_run.py
+++ b/v2ecoli/library/xarray_run.py
@@ -455,7 +455,14 @@ def run_multigen_xarray(
     if dropped:
         print(f"[xarray_run] dropped {dropped} view leaf(s) absent from composite state")
     view = filtered_view
-    output_metadata = extract_output_metadata_from_state(state_after_warmup, view)
+    # Harvest element-name labels from listener outputs() schemas via the
+    # registry walker, then feed them to extract_output_metadata_from_state
+    # so XArrayEmitter uses real IDs (e.g. monomer names) as coord arrays
+    # instead of the integer-index fallback.
+    from v2ecoli.library.output_metadata import output_metadata as _get_named_metadata
+    named_metadata = _get_named_metadata(state_after_warmup)
+    output_metadata = extract_output_metadata_from_state(
+        state_after_warmup, view, named_metadata=named_metadata)
     if output_metadata:
         print(f"[xarray_run] discovered vector coord arrays for: "
               f"{list(_flatten_keys(output_metadata))}")

--- a/v2ecoli/library/xarray_run.py
+++ b/v2ecoli/library/xarray_run.py
@@ -105,16 +105,25 @@ def _flatten_keys(d: dict, prefix: str = "") -> Any:
             yield full
 
 
-def extract_output_metadata_from_state(state: dict, view: list[dict]) -> dict:
+def extract_output_metadata_from_state(
+    state: dict,
+    view: list[dict],
+    named_metadata: dict | None = None,
+) -> dict:
     """Inspect a live composite state + a view config; build XArrayEmitter
-    ``output_metadata`` with integer-indexed coord arrays for vector leaves.
+    ``output_metadata`` with coord arrays for vector leaves.
 
     XArrayEmitter consumes ``config["output_metadata"]`` at construction time
     to learn the per-leaf coord arrays (which determine each variable's
     additional dimension beyond the time axis). Scalar leaves get no coord
     (and the storage allocates a scalar slot per emit step). Vector leaves
-    need a coord array — currently defaults to integer indices
-    ``list(range(N))`` where N is the vector length discovered in state.
+    need a coord array.
+
+    When ``named_metadata`` is provided (typically the return value of
+    ``v2ecoli.library.output_metadata.output_metadata(composite.state)``),
+    element names from annotated listener ``outputs()`` schemas are preferred
+    over the default integer-index ``range(N)`` fallback.  Un-annotated vector
+    leaves still get ``range(N)`` so nothing breaks for them.
 
     The returned dict mirrors the view's path structure (so
     ``make_coords`` can resolve each leaf via ``get_in``).
@@ -125,10 +134,20 @@ def extract_output_metadata_from_state(state: dict, view: list[dict]) -> dict:
 
     Output is shaped RELATIVE to the view root: e.g. for view
     ``root=('listeners',)`` with a vector leaf ``monomer_counts``, the result
-    is ``{'monomer_counts': [0..N-1]}`` — NOT ``{'listeners': {...}}``.
+    is ``{'monomer_counts': [0..N-1]}`` (integers, fallback) or
+    ``{'monomer_counts': [name1, name2, ...]}`` (names, when annotated).
     TreeView.make_coords does ``get_in(coords, root.metadata_path)`` where
     metadata_path is ``()`` for plain listener roots, then walks the leaf
     paths from there. So the coords dict must be flat under the view root.
+
+    Args:
+        state: Composite state dict.
+        view: XArrayEmitter view config (list of root/variables dicts).
+        named_metadata: Optional store-relative metadata dict from
+            ``output_metadata(state)``.  When a leaf's full store path
+            (root_path + leaf_input_path) is present in this dict, its value
+            is used as the coord array instead of ``range(N)``.  Pass ``None``
+            (default) to keep the legacy ``range(N)`` behaviour for all leaves.
     """
     cell = (state.get("agents") or {}).get("0") or state
     if not isinstance(cell, dict):
@@ -155,9 +174,28 @@ def extract_output_metadata_from_state(state: dict, view: list[dict]) -> dict:
             arr = np.asarray(value)
             if arr.ndim == 0 or arr.size <= 1:
                 continue  # scalar — no coord needed
-            # Build integer coord = 0..N-1 and nest it under leaf path
-            # (RELATIVE to root — see docstring).
-            coord = list(range(int(arr.shape[0])))
+
+            # Prefer element names from named_metadata when available.
+            # Navigate named_metadata by root_path + leaf_input_path.
+            named_coord: list | None = None
+            if named_metadata is not None:
+                nm: Any = named_metadata
+                for k in root_path:
+                    if not isinstance(nm, dict):
+                        nm = None
+                        break
+                    nm = nm.get(k)
+                for k in leaf_input_path:
+                    if not isinstance(nm, dict):
+                        nm = None
+                        break
+                    nm = nm.get(k)
+                if isinstance(nm, (list, tuple)) and len(nm) == arr.shape[0]:
+                    named_coord = list(nm)
+
+            coord = named_coord if named_coord is not None else list(range(int(arr.shape[0])))
+
+            # Nest coord under leaf path RELATIVE to root (see docstring).
             cursor_out = out
             for k in leaf_input_path[:-1]:
                 cursor_out = cursor_out.setdefault(k, {})

--- a/v2ecoli/steps/derivers/counts_deriver.py
+++ b/v2ecoli/steps/derivers/counts_deriver.py
@@ -126,7 +126,11 @@ class CountsDeriver(Step):
                     'partial_rRNA_counts': {'_type': f'overwrite[array[{self.n_rRNA_TU},integer]]', '_default': []},
                     'partial_rRNA_cistron_counts': {'_type': f'overwrite[array[{self.n_rRNA_cistron},integer]]', '_default': []},
                 },
-                'monomer_counts': {'_type': f'overwrite[array[{self.n_monomers},integer]]', '_default': []},
+                'monomer_counts': {
+                    '_type': f'overwrite[array[{self.n_monomers},integer]]',
+                    '_default': [],
+                    '_properties': {'metadata': list(self.monomer_ids)},
+                },
                 'unique_molecule_counts': 'map[integer]',
             },
         }

--- a/v2ecoli/steps/derivers/counts_deriver.py
+++ b/v2ecoli/steps/derivers/counts_deriver.py
@@ -27,6 +27,7 @@ unique-molecule section.
 import numpy as np
 
 from v2ecoli.library.ecoli_step import EcoliStep as Step
+from v2ecoli.types.labeled_array import LabeledArray
 from v2ecoli.library.schema import attrs, bulk_name_to_idx, counts
 from v2ecoli.library.schema_types import (
     RNA_ARRAY,
@@ -126,11 +127,7 @@ class CountsDeriver(Step):
                     'partial_rRNA_counts': {'_type': f'overwrite[array[{self.n_rRNA_TU},integer]]', '_default': []},
                     'partial_rRNA_cistron_counts': {'_type': f'overwrite[array[{self.n_rRNA_cistron},integer]]', '_default': []},
                 },
-                'monomer_counts': {
-                    '_type': f'overwrite[array[{self.n_monomers},integer]]',
-                    '_default': [],
-                    '_properties': {'metadata': list(self.monomer_ids)},
-                },
+                'monomer_counts': 'monomer_counts_vec',
                 'unique_molecule_counts': 'map[integer]',
             },
         }
@@ -196,6 +193,20 @@ class CountsDeriver(Step):
             )
         )
         self.monomer_idx = None
+
+        # Register the named labeled-array type so the output_metadata walker
+        # can recover monomer IDs without needing sim_data.  Registering in
+        # initialize() (not outputs()) ensures the type is in the core before
+        # Composite() resolves port schemas.
+        if self.core is not None:
+            self.core.register_type(
+                'monomer_counts_vec',
+                LabeledArray(
+                    _shape=(self.n_monomers,),
+                    _data=np.dtype('int64'),
+                    _labels=tuple(self.monomer_ids),
+                ),
+            )
 
         # ---------------- unique-molecule counts ----------------
         self.unique_ids = p["unique_ids"]

--- a/v2ecoli/steps/derivers/rnap_data.py
+++ b/v2ecoli/steps/derivers/rnap_data.py
@@ -9,6 +9,7 @@ import warnings
 from v2ecoli.library.schema import numpy_schema, listener_schema, attrs
 from v2ecoli.library.schema_types import ACTIVE_RNAP_ARRAY, RNA_ARRAY, ACTIVE_RIBOSOME_ARRAY
 from v2ecoli.library.ecoli_step import EcoliStep as Step
+from v2ecoli.types.labeled_array import LabeledArray
 
 # topology_registry removed — topology defined as class attribute
 from v2ecoli.processes.transcript_elongation import get_mapping_arrays
@@ -62,7 +63,7 @@ class RnapData(Step):
         return {
             'listeners': {
                 'rnap_data': {
-                    'rna_init_event_per_cistron': {'_type': f'overwrite[array[{self.n_cistrons},integer]]', '_default': []},
+                    'rna_init_event_per_cistron': 'rna_init_event_per_cistron_vec',
                     'active_rnap_coordinates': {'_type': 'overwrite[array[integer]]', '_default': []},
                     'active_rnap_domain_indexes': {'_type': 'overwrite[array[integer]]', '_default': []},
                     'active_rnap_unique_indexes': {'_type': 'overwrite[array[integer]]', '_default': []},
@@ -80,6 +81,18 @@ class RnapData(Step):
         self.cistron_tu_mapping_matrix = self.parameters["cistron_tu_mapping_matrix"]
         self.n_TUs = self.cistron_tu_mapping_matrix.shape[1]
         self.n_cistrons = len(self.cistron_ids)
+
+        # Register named labeled-array type for rna_init_event_per_cistron so
+        # the output_metadata walker can recover cistron IDs without sim_data.
+        if self.core is not None:
+            self.core.register_type(
+                'rna_init_event_per_cistron_vec',
+                LabeledArray(
+                    _shape=(self.n_cistrons,),
+                    _data=np.dtype('int64'),
+                    _labels=tuple(self.cistron_ids),
+                ),
+            )
 
     def update_condition(self, timestep, states):
         """

--- a/v2ecoli/types/__init__.py
+++ b/v2ecoli/types/__init__.py
@@ -5,6 +5,7 @@ from v2ecoli.types.method import Method
 from v2ecoli.types.bulk_numpy import BulkNumpyUpdate
 from v2ecoli.types.unique_numpy import UniqueNumpyUpdate
 from v2ecoli.types.process import StepInstance, ProcessInstance
+from v2ecoli.types.labeled_array import LabeledArray
 from v2ecoli.types.stores import (
     InPlaceDict, SetStore, DerivedProperties, ListenerStore, AccumulateFloat,
 )
@@ -363,6 +364,10 @@ ECOLI_TYPES = {
     'derived_properties': DerivedProperties,
     'listener_store': DerivedProperties,  # back-compat alias
     'accumulate_float': AccumulateFloat,
+    # Self-describing emitters: base class for named labeled-vector types.
+    # Processes register named instances (e.g. 'monomer_counts_vec') in their
+    # initialize() so the output_metadata walker can recover element labels.
+    'labeled_array': LabeledArray,
 }
 
 # Study-evaluation framework enums (target_class, verdict_result,

--- a/v2ecoli/types/labeled_array.py
+++ b/v2ecoli/types/labeled_array.py
@@ -1,0 +1,50 @@
+"""LabeledArray — an Array subtype that carries static element-name labels.
+
+``_labels`` is a plain dataclass field that is intentionally **absent** from
+``_schema_keys``.  This means ``is_schema_field()`` returns ``False`` for it,
+so the bigraph-schema engine treats it as static metadata:
+
+* ignored by per-tick operations (apply / check / default / serialize)
+* preserved by ``resolve_subclass`` (via ``getattr``)
+* never enters per-tick state
+* readable from the registry via ``core.access(type_name)._labels``
+
+Usage pattern (register a pre-built instance by name)::
+
+    from v2ecoli.types.labeled_array import LabeledArray
+    import numpy as np
+
+    instance = LabeledArray(
+        _shape=(N,), _data=np.dtype('int64'), _labels=tuple(ids)
+    )
+    core.register_type('monomer_counts_vec', instance)
+
+    # In the process's outputs():
+    def outputs(self):
+        return {'monomer_counts': 'monomer_counts_vec'}
+
+    # In the generic walker:
+    node = core.access('monomer_counts_vec')
+    labels = getattr(node, '_labels', None)  # -> tuple of element names
+"""
+from __future__ import annotations
+
+import typing
+from dataclasses import dataclass, field
+
+from bigraph_schema.schema import Array
+
+
+@dataclass(kw_only=True)
+class LabeledArray(Array):
+    """Array subtype carrying static element-name labels.
+
+    ``_labels`` is a dataclass field but intentionally absent from
+    ``_schema_keys``.  The engine ignores it per-tick; the registry
+    preserves it so a generic walker can recover element names from any
+    registered labeled vector type without touching per-tick logic.
+    """
+
+    # NOT added to _schema_keys → is_schema_field() returns False.
+    # Engine treats this as static metadata, not a schema property.
+    _labels: typing.Tuple[str, ...] = field(default_factory=tuple)


### PR DESCRIPTION
Sub-project #1 of the Readout-Coordination program: persist listener-vector element NAMES with the run so the evaluator can resolve readouts/aggregates run-only (no sim_data).

## The bigraph-native mechanism
The vEcoli `_properties.metadata` convention crashes process-bigraph (resolve parses the name strings as type expressions). Instead, names live as **type-level metadata** on a thin `LabeledArray(Array)` subtype: a `_labels` dataclass field deliberately **not** in `_schema_keys`, so `is_schema_field` makes the engine treat it as static metadata — ignored by every per-tick op, preserved through resolve/divide, readable from the registry via `core.access(type)`. One named vec-type is registered per listener, sourcing `_labels` from the listener config; the port just declares the type name.

- `v2ecoli/types/labeled_array.py` — the `LabeledArray` type (in ECOLI_TYPES).
- Annotated: `CountsDeriver.monomer_counts` (4309 real monomer ids), `RnapData.rna_init_event_per_cistron`.
- `output_metadata()` walker reads `_labels` from the registry → `{store_path: [names]}`.
- Wired into `run_multigen_xarray` (names become the `id_<var>` coord instead of `range(N)`).

## Verified (Fable review, by direct execution)
- `_labels` survives `apply`/`serialize`/`check`/`default`/`divide`/multi-writer `resolve` — flagship invariant holds.
- Listener VALUES byte-unchanged (the `DerivedProperties` parent leaf-replaces; the type change cannot alter behavior). 123 fast tests + the sim golden green, zero regressions.

## Remaining (immediate fast-follow, before the evaluator relies on it)
The walker is wired into the **xarray** run path; the workspace default emitter is **parquet** — wire `output_metadata()` into `parquet_run.py` (`config["metadata"]["output_metadata"]` → `output_metadata__<field>`) and `sqlite_run.py`. Same walker, two more call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)