### PR TITLE
feat: run_analyses accepts explicit sim_data_path

### DIFF
--- a/tests/test_analysis_runner_duckdb.py
+++ b/tests/test_analysis_runner_duckdb.py
@@ -86,3 +86,41 @@ def test_proving_set_end_to_end(tmp_path):
 
     # analysis.json written
     assert _os.path.isfile(str(sweep / "analysis.json"))
+
+
+@_pytest.mark.skipif(_ref_history_dir() is None or not _os.path.isfile(_PAIRED_SIMDATA),
+                     reason="reference sweep parquet or paired sim_data absent")
+def test_explicit_sim_data_path(tmp_path):
+    """run_analyses with an explicit sim_data_path uses that pickle (no glob).
+
+    The sweep directory has the parquet history symlinked in but NO sim_data
+    pickle at the sweep root — so resolve_sim_data(sweep_dir) would raise
+    FileNotFoundError.  Providing sim_data_path bypasses the glob entirely.
+    """
+    import v2ecoli.workflow.analyses  # noqa: F401  (register ports)
+    from v2ecoli.workflow.analysis_runner import run_analyses
+
+    sweep = tmp_path / "sweep_explicit_simdata"
+    sweep.mkdir()
+    # Link in the history parquet but deliberately omit any sim_data pickle
+    # at the sweep root — this proves the explicit path is used, not the glob.
+    (sweep / "history").symlink_to(_os.path.abspath(_ref_history_dir()))
+
+    opts = {
+        "single": {"ptools_rna": {"n_tp": 8}},
+    }
+    # Pass the sim_data path explicitly; the sweep dir has no co-located pickle.
+    res = run_analyses(str(sweep), opts, sim_data_path=_PAIRED_SIMDATA)
+
+    rna = res["single"]["ptools_rna"]
+    assert rna, "ptools_rna produced no per-group result"
+    first = next(iter(rna.values()))
+    assert "error" not in first, f"ptools_rna errored with explicit sim_data_path: {first}"
+    assert first.get("filename") == "ptools_rna.tsv"
+
+    # TSV written via the explicit sim_data path
+    rna_tsvs = _glob.glob(str(sweep / "ptools" / "ptools_rna__*.tsv"))
+    assert rna_tsvs, "no ptools_rna TSV written when using explicit sim_data_path"
+
+    # analysis.json present
+    assert _os.path.isfile(str(sweep / "analysis.json"))

--- a/v2ecoli/workflow/analysis_runner.py
+++ b/v2ecoli/workflow/analysis_runner.py
@@ -201,9 +201,24 @@ def _group_key_str(scale: str, key: tuple) -> str:
     return "all"
 
 
-def run_analyses(sweep_dir: str, analysis_options: dict) -> dict:
+def run_analyses(sweep_dir: str, analysis_options: dict,
+                 sim_data_path: str | None = None) -> dict:
     """Run the analyses named in ``analysis_options`` over the sweep's cells,
-    write ``analysis.json``, and return the nested results."""
+    write ``analysis.json``, and return the nested results.
+
+    Parameters
+    ----------
+    sweep_dir:
+        Directory containing the sweep's history parquet and (optionally) a
+        co-located sim_data pickle.
+    analysis_options:
+        ``{scale: {name: params}}`` mapping selecting which analyses to run.
+    sim_data_path:
+        Optional explicit path to a sim_data pickle.  When provided, the
+        pickle is loaded directly (no glob search under ``sweep_dir``).
+        When ``None`` (default), ``resolve_sim_data(sweep_dir)`` is called
+        as before.
+    """
     from bigraph_schema import allocate_core
     from v2ecoli.workflow.analysis import Analysis, ANALYSIS_REGISTRY, ANALYSIS_SCALES
 
@@ -220,7 +235,11 @@ def run_analyses(sweep_dir: str, analysis_options: dict) -> dict:
             import duckdb
             _ctx["conn"] = duckdb.connect()
             _ctx["from_clause"] = _history_from_clause(sweep_dir)
-            _ctx["sim_data"] = resolve_sim_data(sweep_dir)
+            if sim_data_path is not None:
+                from v2ecoli.library.sim_data import LoadSimData
+                _ctx["sim_data"] = LoadSimData(sim_data_path=sim_data_path).sim_data
+            else:
+                _ctx["sim_data"] = resolve_sim_data(sweep_dir)
             _ctx["validation_data"] = resolve_validation_data(_ctx["sim_data"])
         return (_ctx["conn"], _ctx["from_clause"],
                 _ctx["sim_data"], _ctx["validation_data"])


### PR DESCRIPTION
## Summary

- Add optional `sim_data_path: str | None = None` parameter to `run_analyses()` in `v2ecoli/workflow/analysis_runner.py`.
- When provided, the pickle is loaded via `LoadSimData(sim_data_path=...)` directly — no glob search under `sweep_dir`. Falls back to `resolve_sim_data(sweep_dir)` when `None`.
- CLI `main()` is unchanged (passes `None` implicitly).
- New test `test_explicit_sim_data_path` in `tests/test_analysis_runner_duckdb.py` verifies that ptools_rna runs correctly when the sweep dir has **no** co-located pickle (proving the explicit path is used rather than the glob).

## Motivation

The vivarium-dashboard post-run analysis hook (Part B) runs analyses after a study run whose emitter parquet is written to a per-run directory. The workspace `simData.cPickle` lives elsewhere (e.g. `out/workflow/`), so `run_analyses` needs to accept an explicit path rather than globbing under the sweep dir.

## Test plan

- [ ] `pytest tests/test_analysis_runner_duckdb.py -q` — all 5 tests green (3 SQL-shape unit tests + `test_proving_set_end_to_end` + `test_explicit_sim_data_path`). The two end-to-end tests are gated on the reference parquet + `out/workflow/simData.cPickle` existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)