### PR TITLE
ci: cap job runtimes so a hang fails in minutes, not 6 hours

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ concurrency:
 jobs:
   fast-tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 
@@ -59,6 +60,10 @@ jobs:
 
   behavior-tests:
     runs-on: ubuntu-latest
+    # Job cap so a hang (e.g. an import/collection hang from a dep bump) fails
+    # in minutes, not GitHub's 6h default. Normal run is ~9 min; cold ParCa
+    # cache build adds headroom.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 
@@ -108,6 +113,10 @@ jobs:
         run: uv run python scripts/build_cache.py
 
       - name: Run simulation-based behavior tests
+        # Tight step cap: the 7 sim tests target ~9 min. A hang here (test body,
+        # or an import/collection hang at pytest startup that pytest-timeout's
+        # per-test cap can't catch) fails fast at 15 min instead of running on.
+        timeout-minutes: 15
         env:
           CI: 'true'
         # -n auto: pytest-xdist parallelism. The 7 behavior tests are
@@ -132,6 +141,7 @@ jobs:
     # scripts/validate_status.py for the 7 rules. Runs in parallel with
     # the test jobs; ~1s total — no uv sync needed, just PyYAML.
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
The behavior-tests CI job had **no `timeout-minutes`**, so when a dependency bump (#163) caused a hang (likely an import/collection hang from `pbg-superpowers` 0.10→0.14, which the per-test `pytest-timeout` can't catch), it ran to GitHub's **6-hour default** before failing.

Adds layered caps:
| job | cap |
|---|---|
| fast-tests | 15m |
| behavior-tests | 30m (job) + **15m on the test-run step** |
| validate-status | 10m |

Normal behavior-tests run ~9 min (#165); the 30m job cap leaves headroom for a cold ParCa-cache build, and the 15m step cap fails a test/import hang fast.

Note: this makes hangs **fail fast** — it does not fix the underlying #163 framework-bump regression (held, needs separate investigation into what the new framework versions broke).

🤖 Generated with [Claude Code](https://claude.com/claude-code)