### PR TITLE
deps: un-pin bigraph-schema (pbg-emitters #8 fixed the hang)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,13 +100,7 @@ packages = { find = { where = ["."], include = ["v2ecoli*", "pbg_v2ecoli*"] } }
 
 [tool.uv.sources]
 process-bigraph = { git = "https://github.com/vivarium-collective/process-bigraph.git", branch = "main" }
-# PINNED (not branch=main): bigraph-schema main @ d9a92adb regresses — it makes
-# the pbg-emitters ParquetEmitter.close() hang on last_batch_future.result()
-# (a sim behavior test that passes in ~17s on 25e78d04 hangs indefinitely).
-# Bisected 2026-06-10: reverting ONLY bigraph-schema to 25e78d04 fixes it while
-# process-bigraph 1.4.17 / pbg-superpowers 0.14 / pbg-emitters stay bumped.
-# Re-point to branch=main once the upstream bigraph-schema regression is fixed.
-bigraph-schema = { git = "https://github.com/vivarium-collective/bigraph-schema.git", rev = "25e78d041f092a273d9c538ceb8b2474f3609fb8" }
+bigraph-schema = { git = "https://github.com/vivarium-collective/bigraph-schema.git", branch = "main" }
 pbg-superpowers = { git = "https://github.com/vivarium-collective/pbg-superpowers.git", branch = "main" }
 pbg-copasi = { git = "https://github.com/vivarium-collective/pbg-copasi.git", branch = "main" }
 pbg-emitters = { git = "https://github.com/vivarium-collective/pbg-emitters.git", branch = "main" }

--- a/uv.lock
+++ b/uv.lock
@@ -314,11 +314,10 @@ source = { git = "https://github.com/vivarium-collective/bigraph-loom.git?rev=ma
 [[package]]
 name = "bigraph-schema"
 version = "1.4.1"
-source = { git = "https://github.com/vivarium-collective/bigraph-schema.git?rev=25e78d041f092a273d9c538ceb8b2474f3609fb8#25e78d041f092a273d9c538ceb8b2474f3609fb8" }
+source = { git = "https://github.com/vivarium-collective/bigraph-schema.git?branch=main#d9a92adb2409921b1a0bf104da37b436fa1f5860" }
 dependencies = [
     { name = "fire" },
     { name = "numpy" },
-    { name = "orjson" },
     { name = "pandas" },
     { name = "parsimonious" },
     { name = "pint" },
@@ -2594,7 +2593,7 @@ dependencies = [
 [[package]]
 name = "pbg-emitters"
 version = "0.1.0"
-source = { git = "https://github.com/vivarium-collective/pbg-emitters.git?branch=main#6cf046129f4be1b5183991df0b8ee3c6421b08c8" }
+source = { git = "https://github.com/vivarium-collective/pbg-emitters.git?branch=main#2e5b4afc027ce61521fffd860d1df7c9bfdb7868" }
 dependencies = [
     { name = "bigraph-schema" },
     { name = "numpy" },
@@ -4078,7 +4077,7 @@ ray = [
 
 [package.metadata]
 requires-dist = [
-    { name = "bigraph-schema", git = "https://github.com/vivarium-collective/bigraph-schema.git?rev=25e78d041f092a273d9c538ceb8b2474f3609fb8" },
+    { name = "bigraph-schema", git = "https://github.com/vivarium-collective/bigraph-schema.git?branch=main" },
     { name = "biopython" },
     { name = "cvxpy" },
     { name = "dill", specifier = ">=0.3" },


### PR DESCRIPTION
Removes the temporary `bigraph-schema` pin from #163. The hang it worked around was a **pbg-emitters** bug (`ParquetEmitter.__del__` blocking on the write future → re-entrant-GC deadlock during composite build), now fixed upstream in **pbg-emitters [#8](https://github.com/vivarium-collective/pbg-emitters/pull/8)**. bigraph-schema's `allocate_core` isolation change was correct all along.

- `[tool.uv.sources]` bigraph-schema: `rev = 25e78d04` → `branch = "main"`
- re-locked: bigraph-schema → `d9a92adb`, pbg-emitters → `2e5b4afc` (the #8 fix)

**Verified locally:** the previously-hanging `test_polypeptide_elongation_parity` passes, and the full behavior suite is green (17 passed, 11 data-gated skips) with no hang and no slowdown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)