### PR TITLE
fix(multigen): end every generation at its division (last-gen mislabeling)

### DIFF
--- a/tests/test_multigen_last_generation.py
+++ b/tests/test_multigen_last_generation.py
@@ -1,0 +1,144 @@
+"""Regression: the multigen runners must end EVERY generation at its division.
+
+Root cause (showcase-2 baseline, 2026-06): the inner Division step always names
+its mother ``"0"`` (``agent_id`` defaults to "0" in both
+``v2ecoli/steps/division.py`` and ``composites/_helpers.py``), so a division
+produces daughters ``"00"`` / ``"01"`` regardless of the mother's lineage id.
+
+Generation 1 (followed ``"0"``) divides into ``"00"`` / ``"01"`` — the followed
+id ``"0"`` vanishes, so ``run_multigen_parquet`` / ``run_multigen_xarray``
+caught it.  But generation 2 (followed ``"00"``) divides into ``"00"`` / ``"01"``
+— the followed id ``"00"`` is REUSED by a daughter, so ``followed in agents``
+stayed True, the division-handler branch never fired, and the gen-3 daughter was
+emitted under gen-2's generation/agent_id partition (a mid-partition dry-mass
+fold-change reset).
+
+These tests drive the runners with a tiny fake composite that reproduces the
+id-reuse division so the bug is exercised without a real ParCa cell.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from v2ecoli.library.parquet_run import run_multigen_parquet
+
+
+class _FakeComposite:
+    """Single-cell composite that "divides" on a schedule, reusing the mother
+    id for daughter ``…0`` exactly like the real inner Division step.
+
+    Each ``run(n)`` advances ``n`` ticks; dry_mass ramps linearly and a division
+    fires when the followed cell's local age crosses ``divide_period``.  At a
+    division the followed agent ``m`` is removed and ``m0`` / ``m1`` are added —
+    so for mother ``"0"`` the daughter is ``"00"`` (vanishes) and for mother
+    ``"00"`` the daughter is ``"000"``… NO: the real step uses agent_id="0"
+    always, so daughters are ALWAYS ``"00"`` / ``"01"``.  We model that exactly.
+    """
+
+    def __init__(self, divide_period: int = 200, dry0: float = 350.0):
+        self.divide_period = divide_period
+        self.dry0 = dry0
+        self._age = 0  # ticks since this cell's birth
+        self._t = 0
+        # The inner composite always names its sole cell "0".
+        self.state = {"agents": {"0": self._cell(dry0)}, "global_time": 0.0}
+
+    @staticmethod
+    def _cell(dry_mass: float) -> dict:
+        return {
+            "listeners": {"mass": {"dry_mass": float(dry_mass)}},
+            "bulk": np.array([(b"X", 10)], dtype=[("id", "S1"), ("count", "i8")]),
+        }
+
+    def run(self, n: int) -> None:
+        for _ in range(int(n)):
+            self._age += 1
+            self._t += 1
+            agents = self.state["agents"]
+            # Only one agent is ever present (single-cell composite + pruning).
+            cur_id = next(iter(agents))
+            if self._age >= self.divide_period:
+                # DIVISION: remove mother, add daughters "00"/"01" (agent_id="0").
+                self._age = 0
+                del agents[cur_id]
+                agents["00"] = self._cell(self.dry0)
+                agents["01"] = self._cell(self.dry0)
+            else:
+                dry = self.dry0 + self._age * 2.0
+                agents[cur_id]["listeners"]["mass"]["dry_mass"] = dry
+        self.state["global_time"] = float(self._t)
+
+    # prune_to_followed_lineage pokes this; a no-op fake is fine.
+    def find_instance_paths(self, state):
+        return {}
+
+    core = None
+
+
+def _gens_in_partitions(out_dir: str, experiment_id: str) -> dict[int, dict]:
+    """Read the hive parquet and return {generation: {agent_id, t_min, t_max,
+    dry_min, dry_max, n_fold_resets}} where a "fold reset" is a dry_mass drop
+    between consecutive rows (the mid-partition daughter signature)."""
+    import glob
+    import polars as pl
+
+    base = f"{out_dir}/{experiment_id}/history/experiment_id={experiment_id}"
+    out: dict[int, dict] = {}
+    for gdir in sorted(glob.glob(base + "/variant=*/lineage_seed=*/generation=*")):
+        gen = int(gdir.split("generation=")[1].split("/")[0])
+        files = glob.glob(gdir + "/agent_id=*/*.pq")
+        if not files:
+            continue
+        agent_id = files[0].split("agent_id=")[1].split("/")[0]
+        df = pl.read_parquet(files).sort("global_time")
+        dry = df["listeners__mass__dry_mass"].to_numpy()
+        resets = int(np.sum(np.diff(dry) < -50.0))  # a halving is a big drop
+        out[gen] = {
+            "agent_id": agent_id,
+            "t_min": float(df["global_time"].min()),
+            "t_max": float(df["global_time"].max()),
+            "dry_min": float(dry.min()),
+            "dry_max": float(dry.max()),
+            "n_fold_resets": resets,
+        }
+    return out
+
+
+def test_every_generation_ends_at_its_division(tmp_path):
+    """PASS criteria: each generation partition holds exactly ONE cell — a
+    monotonic dry_mass ramp with NO mid-partition fold-change reset — and the
+    3rd cell is its own generation=3 partition, never folded into gen-2."""
+    from v2ecoli.core import build_core
+    core = build_core()
+    comp = _FakeComposite(divide_period=200, dry0=350.0)
+    res = run_multigen_parquet(
+        comp,
+        experiment_id="regress",
+        out_dir=str(tmp_path),
+        emit_paths=["listeners.mass.dry_mass"],
+        max_steps=650,            # crosses 3 divisions (at 200/400/600)
+        max_generations=4,
+        chunk=20,
+        single_daughters=True,
+        threaded=False,
+        core=core,
+    )
+
+    # Before the fix: generations == [1, 2] (gen-2 ran to max_steps with the
+    # gen-3 daughter folded in).  After: at least [1, 2, 3].
+    assert res["generations"][:3] == [1, 2, 3], res["generations"]
+
+    gens = _gens_in_partitions(str(tmp_path), "regress")
+    assert set(gens) >= {1, 2, 3}, f"missing generations: {sorted(gens)}"
+
+    # Each generation partition is a single cell: no mid-partition halving.
+    for g, info in gens.items():
+        assert info["n_fold_resets"] == 0, (
+            f"generation={g} partition contains a mid-partition dry_mass reset "
+            f"(daughter folded in): {info}")
+
+    # agent_id increments per generation: 0 -> 00 -> 000 ...
+    assert gens[1]["agent_id"] == "0"
+    assert gens[2]["agent_id"] == "00"
+    assert gens[3]["agent_id"] == "000"

--- a/v2ecoli/library/parquet_run.py
+++ b/v2ecoli/library/parquet_run.py
@@ -146,15 +146,45 @@ def run_multigen_parquet(
         )
 
     import gc
+    from v2ecoli.steps.division import daughter_phylogeny_id
 
     max_steps = int(max_steps)
+    # ``followed`` = the key the inner composite uses for the cell we track.
+    # The inner Division step always names its mother "0", so EVERY division
+    # produces daughters "00"/"01" regardless of lineage depth — the followed
+    # key can be REUSED by a daughter ("00" -> "00"/"01"). So we must NOT detect
+    # division by ``followed in agents`` (it stays True when a daughter reuses
+    # the id) — that bug folded the last generation's post-division daughter
+    # into the parent generation's partition. Instead detect division
+    # structurally (a new agent id appeared = an ``_add`` = a division this
+    # chunk) and carry a SEPARATE ``partition_agent_id`` that increments along
+    # the true phylogeny ("0" -> "00" -> "000") for the hive layout.
     followed = initial_agent_id
+    partition_agent_id = initial_agent_id
     gen = int(initial_generation)
     done = 0
     gens_seen = [gen]
     prev_ids = set(((composite.state or {}).get("agents") or {}).keys())
 
-    em = _make_emitter(followed, gen)
+    def _emit(agents_map: dict, agent_key: str, emitter) -> None:
+        if agent_key not in agents_map:
+            return
+        payload = _filter_agent_state(agents_map[agent_key], leaves)
+        # ParquetEmitter takes the flat tick state directly — no
+        # `agents/<id>/` wrapper (which is sqlite-only convention).
+        update_state: dict = {"global_time": float(done), **payload}
+        if root_leaves:
+            _merge_into(
+                update_state,
+                _filter_root_state(composite.state or {}, root_leaves),
+            )
+        try:
+            emitter.update(update_state)
+        except Exception as e:
+            print(f"[multigen_parquet] emit failed at tick {done}: "
+                  f"{type(e).__name__}: {str(e)[:120]}")
+
+    em = _make_emitter(partition_agent_id, gen)
 
     try:
         while done < max_steps:
@@ -169,65 +199,66 @@ def run_multigen_parquet(
             agents = (composite.state or {}).get("agents") or {}
             curr_ids = set(agents.keys())
 
-            if followed in agents:
-                payload = _filter_agent_state(agents[followed], leaves)
-                # ParquetEmitter takes the flat tick state directly — no
-                # `agents/<id>/` wrapper (which is sqlite-only convention).
-                update_state: dict = {"global_time": float(done), **payload}
-                if root_leaves:
-                    _merge_into(
-                        update_state,
-                        _filter_root_state(composite.state or {}, root_leaves),
-                    )
-                try:
-                    em.update(update_state)
-                except Exception as e:
-                    print(f"[multigen_parquet] emit failed at tick {done}: "
-                          f"{type(e).__name__}: {str(e)[:120]}")
-            else:
-                # Followed agent disappeared — division. Pick daughter if we
-                # have generations left, else stop.
-                if gen >= max_generations:
-                    break
-                divided, daughter = division_detector(prev_ids, curr_ids)
-                if not divided or daughter is None:
-                    remaining = sorted(curr_ids)
-                    if not remaining:
-                        break
-                    daughter = remaining[0]
+            # A division this chunk = a new agent id surfaced (an ``_add``).
+            # This is robust to the inner step reusing the followed id for a
+            # daughter (the case that previously slipped past ``followed in
+            # agents`` and ran the last generation past its own division).
+            divided, _detected_daughter = division_detector(prev_ids, curr_ids)
+            new_ids = curr_ids - prev_ids
+            if not divided and new_ids:
+                divided = True
 
-                # Rotate the emitter: close the current generation's hive,
-                # open a fresh one keyed on the new generation + daughter.
-                em.close(success=True)
-                followed = daughter
-                gen += 1
-                gens_seen.append(gen)
-                em = _make_emitter(followed, gen)
-
-                if single_daughters:
-                    dropped = prune_to_followed_lineage(composite, followed)
+            if not divided:
+                # No division: emit the followed cell into this generation's
+                # partition.
+                _emit(agents, followed, em)
+                prev_ids = curr_ids
+                if single_daughters and n >= 50:
                     gc.collect()
-                    print(f"[multigen_parquet] gen {gen} → following agent "
-                          f"{followed!r} at tick {done} (single_daughters: "
-                          f"dropped {dropped} sibling agent(s) + ran gc)")
-                else:
-                    print(f"[multigen_parquet] gen {gen} → following agent "
-                          f"{followed!r} at tick {done}")
+                continue
 
-                # Emit the gen-handoff marker.
-                if followed in agents:
-                    payload = _filter_agent_state(agents[followed], leaves)
-                    update_state = {"global_time": float(done), **payload}
-                    if root_leaves:
-                        _merge_into(
-                            update_state,
-                            _filter_root_state(composite.state or {}, root_leaves),
-                        )
-                    try:
-                        em.update(update_state)
-                    except Exception:
-                        pass
-            prev_ids = curr_ids
+            # --- DIVISION: end this generation here. The parent's partition
+            # must NOT receive the post-division daughter row. ---
+            if gen >= max_generations:
+                # Generation cap reached: stop following. The daughter is
+                # intentionally dropped (its generation wasn't requested) rather
+                # than folded into the parent partition.
+                break
+
+            # Choose the inner survivor to follow: prefer a daughter whose id
+            # ends in "0" (vEcoli single-daughter convention), else any agent.
+            survivors = sorted(curr_ids)
+            inner_next = next((i for i in survivors if i.endswith("0")), None)
+            if inner_next is None:
+                inner_next = survivors[0] if survivors else None
+            if inner_next is None:
+                break
+
+            # Rotate the emitter: close the parent generation's hive, open a
+            # fresh one keyed on the next generation + the true phylogeny id
+            # ("0" -> "00" -> "000"), independent of the inner key's reuse.
+            em.close(success=True)
+            followed = inner_next
+            partition_agent_id = daughter_phylogeny_id(partition_agent_id)[0]
+            gen += 1
+            gens_seen.append(gen)
+            em = _make_emitter(partition_agent_id, gen)
+
+            if single_daughters:
+                dropped = prune_to_followed_lineage(composite, followed)
+                gc.collect()
+                print(f"[multigen_parquet] gen {gen} → following inner agent "
+                      f"{followed!r} (partition agent_id={partition_agent_id!r}) "
+                      f"at tick {done} (single_daughters: dropped {dropped} "
+                      f"sibling agent(s) + ran gc)")
+            else:
+                print(f"[multigen_parquet] gen {gen} → following inner agent "
+                      f"{followed!r} (partition agent_id={partition_agent_id!r}) "
+                      f"at tick {done}")
+
+            # Emit the daughter's birth row into the NEW generation's partition.
+            _emit((composite.state or {}).get("agents") or {}, followed, em)
+            prev_ids = set(((composite.state or {}).get("agents") or {}).keys())
             if single_daughters and n >= 50:
                 gc.collect()
     finally:

--- a/v2ecoli/library/xarray_run.py
+++ b/v2ecoli/library/xarray_run.py
@@ -467,11 +467,23 @@ def run_multigen_xarray(
         print(f"[xarray_run] discovered vector coord arrays for: "
               f"{list(_flatten_keys(output_metadata))}")
 
+    from v2ecoli.steps.division import daughter_phylogeny_id
+
+    # ``followed`` = the inner-composite key for the tracked cell. The inner
+    # Division step always names its mother "0", so EVERY division yields
+    # daughters "00"/"01" regardless of lineage depth — the followed key can be
+    # REUSED by a daughter ("00" -> "00"/"01"). Detecting division by
+    # ``followed in agents`` (which stays True on reuse) folded the last
+    # generation's post-division daughter into the parent partition. Detect
+    # division structurally (a NEW agent id appeared = an ``_add`` this chunk)
+    # and carry a SEPARATE ``partition_agent_id`` along the true phylogeny
+    # ("0" -> "00" -> "000") for the zarr generation/agent_id metadata.
     followed = initial_agent_id
+    partition_agent_id = initial_agent_id
     gen = 1
     em = _build_emitter(
         core=core, store_path=store_path, view=view,
-        metadata_base=metadata_base, generation=gen, agent_id=followed,
+        metadata_base=metadata_base, generation=gen, agent_id=partition_agent_id,
         output_metadata=output_metadata,
     )
     # ``done`` counts ticks already advanced past tick 0 (we used 1 for the
@@ -479,6 +491,16 @@ def run_multigen_xarray(
     done = 1
     gens_seen = [gen]
     prev_ids = set(((composite.state or {}).get("agents") or {}).keys())
+
+    def _emit_followed(emitter, agents_map, key):
+        if key not in agents_map:
+            return
+        payload = _filter_agent_state(agents_map[key], view)
+        emitter.update({
+            "time": float(done),
+            "global_time": float(done),
+            "agents": {key: payload},
+        })
 
     while done < max_steps and gen <= max_generations:
         try:
@@ -490,29 +512,42 @@ def run_multigen_xarray(
         agents = (composite.state or {}).get("agents") or {}
         curr_ids = set(agents.keys())
 
-        if followed in agents:
-            payload = _filter_agent_state(agents[followed], view)
-            em.update({
-                "time": float(done),
-                "global_time": float(done),
-                "agents": {followed: payload},
-            })
+        divided, _detected_daughter = division_detector(prev_ids, curr_ids)
+        new_ids = curr_ids - prev_ids
+        if not divided and new_ids:
+            divided = True
 
-        divided, daughter = division_detector(prev_ids, curr_ids)
-        if divided and daughter:
-            em.close(success=True)
-            followed = daughter
-            gen += 1
-            gens_seen.append(gen)
-            if gen > max_generations:
-                break
-            em = _build_emitter(
-                core=core, store_path=store_path, view=view,
-                metadata_base=metadata_base, generation=gen, agent_id=followed,
-                output_metadata=output_metadata,
-            )
+        if not divided:
+            _emit_followed(em, agents, followed)
+            prev_ids = curr_ids
+            continue
 
-        prev_ids = curr_ids
+        # --- DIVISION: end this generation here; the parent partition must NOT
+        # receive the post-division daughter row. ---
+        if gen >= max_generations:
+            # Generation cap reached: stop (don't fold the daughter in).
+            break
+
+        survivors = sorted(curr_ids)
+        inner_next = next((i for i in survivors if i.endswith("0")), None)
+        if inner_next is None:
+            inner_next = survivors[0] if survivors else None
+        if inner_next is None:
+            break
+
+        em.close(success=True)
+        followed = inner_next
+        partition_agent_id = daughter_phylogeny_id(partition_agent_id)[0]
+        gen += 1
+        gens_seen.append(gen)
+        em = _build_emitter(
+            core=core, store_path=store_path, view=view,
+            metadata_base=metadata_base, generation=gen,
+            agent_id=partition_agent_id, output_metadata=output_metadata,
+        )
+        # Emit the daughter's birth row into the NEW generation's store.
+        _emit_followed(em, (composite.state or {}).get("agents") or {}, followed)
+        prev_ids = set(((composite.state or {}).get("agents") or {}).keys())
 
     try:
         em.close(success=True)


### PR DESCRIPTION
## The bug

In the showcase-2 baseline run, the on-disk `generation=2`/`agent_id=00` parquet
partition physically contained **two cells**: the gen-2 cell (ramps to ~669 fg)
**and** its gen-3 daughter (resets to ~336 fg and ramps again), with a division
mid-partition (`dry_mass` halves, `dry_mass_fold_change` resets 1.90→1.00). The
per-seed completion logged `gens=[1,2]` — generation 3 was never recorded; its
daughter was emitted under the gen-2 label/agent_id. Only the **last** generation
was affected.

## Root cause (exact)

The library multigen runners — `run_multigen_parquet` and `run_multigen_xarray`
— detected division by the followed agent disappearing from the agents map
(`followed in agents` → False).

But the inner `Division` step **always names its mother `"0"`**: `agent_id`
defaults to `"0"` in both `v2ecoli/steps/division.py` and
`v2ecoli/composites/_helpers.py:1279`. So **every** division produces daughters
`"00"`/`"01"` regardless of lineage depth.

- **Gen 1** (followed `"0"`): daughters `"00"`/`"01"` → `"0"` vanishes →
  division caught → rotates to gen 2 correctly.
- **Gen 2+** (followed `"00"`): daughters `"00"`/`"01"` → the followed id `"00"`
  is **reused** by a daughter → `followed in agents` stays True → the
  rotation branch never fires → the cell runs to `max_steps` with its
  post-division daughter emitted under the parent's generation/agent_id.

This is why both the parquet and the xarray store reported `[1, 2]` even though
`max_generations=3`. The hypothesis in the issue (last gen runs past its division
because no successor is sought) was *directionally* right but the precise
mechanism is **id reuse defeating the division detector**, not the generation
cap.

## Fix

Detect division **structurally** — a new agent id appeared this chunk (an
`_add`) — instead of by the followed id surviving. Carry a separate
`partition_agent_id` that increments along the true phylogeny
(`"0"`→`"00"`→`"000"`) for the hive layout, decoupled from the inner key's reuse.
On division, rotate the emitter **before** emitting the daughter's birth row so
it lands in the new generation's partition; on the generation cap, stop
following (drop the daughter) rather than folding it into the parent. Non-last
generations keep their existing correct behavior.

## Verification

A new regression test (`tests/test_multigen_last_generation.py`) reproduces the
showcase symptom (`gens=[1,2]`) with a fake id-reusing composite and asserts each
partition holds exactly one cell, no mid-partition mass reset, and agent_ids
`0`/`00`/`000`. A real-cell before/after table (1 seed, 6500 steps) is in the PR
thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)