### PR TITLE
spine(showcase): render real test outcomes (PASS/PASS/PARTIAL), not PENDING

### DIFF
--- a/workspace/studies/showcase-1-parca/study.yaml
+++ b/workspace/studies/showcase-1-parca/study.yaml
@@ -189,13 +189,21 @@ runs:
   cache_dir: out/cache-showcase
   result: PASS
   outcomes:
-    PARCA-BUILDS-FULL-51-CONDITIONS:
+    # Authored outcome keys are lowercase to match each tests[].name EXACTLY, so
+    # the report (walkthrough.js: out = outcomeByTest[t.name]) surfaces the
+    # PASS/PASS/PARTIAL pills instead of "pending". These are ParCa-artifact
+    # checks (condition_count / artifacts_present / parca_compare) — non-run-data
+    # measure kinds — so the run-data evaluator agent-buckets them and computes
+    # no verdict (this run has no parquet/zarr store, only the ParCa cache); the
+    # authored outcomes below ARE the verdicts. See tests[].classification for
+    # the (authored) primary tagging.
+    parca-builds-full-51-conditions:
       result: PASS
       detail: 51 TF conditions fitted (--mode full, 142.4 s on the mini); 51 = full vs 7 = fast/debug.
-    CACHE-BUNDLE-COMPLETE:
+    cache-bundle-complete:
       result: PASS
       detail: All four artifacts present in out/cache-showcase — initial_state.json (10.39 MB), sim_data_cache.dill (164.92 MB), metadata.json (210 B), cache_version.json (1.1 KB).
-    SIM_DATA-REPRODUCES-PARCA-COMPARISON:
+    sim_data-reproduces-parca-comparison:
       result: PARTIAL
       detail: |
         Verified at structural-inventory + simulation-readiness level (4538 genes /
@@ -204,6 +212,8 @@ runs:
         parca_compare HTML diff was not re-run — it needs vivarium-ecoli
         --save-intermediates reference checkpoints, absent on the mini this session.
 
+  computed_outcomes:
+    _status: store_unresolved
 visualizations:
 - name: source-file manifest
   address: image:charts/showcase1_source_manifest.png

--- a/workspace/studies/showcase-2-baseline-figures/study.yaml
+++ b/workspace/studies/showcase-2-baseline-figures/study.yaml
@@ -246,22 +246,24 @@ runs:
   parquet: .pbg/runs/showcase2-baseline-clean/sweep/showcase2_baseline
   result: PASS
   outcomes:
-    # NOTE: the two runnable tests' authored keys are lowercase to match their
-    # tests[].name exactly, so the evaluator's computed_outcomes reconcile
-    # (keyed by test.name) produces agree/divergent instead of no_authored.
-    # The two correlation tests stay UPPERCASE (they are agent-bucketed —
-    # correlation is not a supported run-data op — so reconcile is no_authored
-    # for them regardless of key case).
+    # NOTE: ALL authored outcome keys are lowercase to match their tests[].name
+    # EXACTLY. For the two runnable tests (doubling-time / mass-fraction) this
+    # lets the evaluator's computed_outcomes reconcile (keyed by test.name)
+    # produce agree/divergent. For the two correlation tests (agent-bucketed —
+    # correlation is not a supported run-data op, so computed_outcomes is
+    # no_authored) the lowercase key is what lets the REPORT surface the authored
+    # PASS pill: walkthrough.js does out = outcomeByTest[t.name], so an
+    # UPPERCASE-keyed authored outcome would render as "pending" instead of PASS.
     doubling-time-in-band:
       result: PASS
       detail: "Divided-generation division times: gen-1 = 43 min (both seeds), gen-2 = 43 min (seed 0) / 52 min (seed 1) → mean of divided gens ≈ 46 min; cap-immune instantaneous-growth measure (runnable test) = 52.4 min over the full lineage. In-band for the baseline glucose condition. The old ~104 min gen-2 step-cap over-report is resolved by #173; the final gen-3 cell is truncated at the 6500-step cap (raw span ~10–19 min) so it is excluded from the division-time headline."
     mass-fraction-physiological:
       result: PASS
       detail: "Average dry-mass fractions: protein 0.461 (per-gen 0.477 / 0.453 / 0.442), rRNA 0.105, tRNA 0.019, DNA 0.018 — physiological E. coli composition (mean dry mass ≈467 fg, cell mass ≈1556 fg)."
-    FBA-FLUX-CORRELATES-TOYA2010:
+    fba-flux-correlates-toya2010:
       result: PASS
       detail: "Baseline central-carbon FBA fluxes vs Toya 2010 C13-MFA measured fluxes — Pearson R = 0.6990 (p = 2.1e-4) over 23 reactions (central_carbon_metabolism_scatter, multiseed over 2 seeds). Toya flat file (toya_2010_central_carbon_fluxes.tsv) restored; validation_data.reactionFlux.toya2010fluxes now built by build_validation_data."
-    PROTEOME-CORRELATES-SCHMIDT-WISNIEWSKI:
+    proteome-correlates-schmidt-wisniewski:
       result: PASS
       detail: log10 average monomer counts vs measured proteomics — Schmidt 2015 Pearson r = 0.728 (n=2228 overlapping monomers), Wisniewski 2014 r = 0.602 (n=2226) (protein_counts_validation, multiseed over 2 seeds).
 


### PR DESCRIPTION
## Problem

In the `v2ecoli-baseline-showcase` investigation report, `showcase-1-parca`'s three tests rendered as **⏳ PENDING** / **UNCLASSIFIED** instead of their real verified results (PASS / PASS / PARTIAL).

## Root cause (two independent defects)

1. **PENDING** — the report (`walkthrough.js`) keys a run's outcomes by the **exact** `tests[].name` (`out = outcomeByTest[t.name]`). showcase-1 authored `runs[].outcomes` with **UPPERCASE** keys (`PARCA-BUILDS-FULL-51-CONDITIONS`) while `tests[].name` is lowercase → the lookup missed → every authored verdict rendered as pending. (Same key-case mismatch the showcase-2 runnable tests had already worked around.)

2. **UNCLASSIFIED** — the dashboard's `behavior_tests` legacy projection dropped `classification`, so *every* v4 test rendered unclassified. This is a render-code gap, fixed separately in **vivarium-dashboard PR #209**.

## Fix (this PR — the spine data)

Re-keyed the authored `runs[].outcomes` to lowercase matching `tests[].name`, via a ruamel round-trip (research-log comments preserved):

- **showcase-1-parca** → renders **PASS / PASS / PARTIAL**. These are ParCa-artifact checks (`condition_count` / `artifacts_present` / `parca_compare`) — non-run-data measure kinds with no parquet/zarr store — so they are **authored, not code-runnable**: `compute_outcomes` honestly writes `computed_outcomes: {_status: store_unresolved}` and the authored outcomes are the verdicts.
- **showcase-2-baseline-figures** → re-keyed the 2 correlation tests (also agent-bucketed) so their authored **PASS** renders instead of pending; updated the now-stale comment.
- **showcase-3-variant-decide** — no data change needed: it is a decide-phase study with `runs: []`; its single `reviewer_decision` test correctly renders **PENDING** / `decision` (decision-pending, not broken). The UNCLASSIFIED→`decision` fix comes from PR #209.

Ran `pbg compute_outcomes` on all three. Report linter: 72 → 68 findings (4 fewer "renders pending" warnings), no new findings.

## Verification

Rendered the v4 study-detail spec (what `walkthrough.js` consumes) against the dashboard projection + the JS test-card logic:

| study | before | after (this PR) | after + #209 |
|---|---|---|---|
| showcase-1 | 3× ⏳ pending / unclassified | **PASS / PASS / PARTIAL** | + `primary` chips |
| showcase-2 | 2 PASS + 2 pending / unclassified | **4× PASS** | + `primary` chips |
| showcase-3 | ⏳ pending / unclassified | ⏳ pending (decision) | + `decision` chip |

Honest split: the **PENDING** fix is this PR's data change alone (verified against the unpatched dashboard). The **UNCLASSIFIED** chip needs dashboard PR #209.

🤖 Generated with [Claude Code](https://claude.com/claude-code)