### PR TITLE
feat(ptools): ptools_launch.sh — paint a run's TSV onto the EcoCyc Cellular Overview

### DIFF
--- a/docs/native-analyses-status-and-roadmap.md
+++ b/docs/native-analyses-status-and-roadmap.md
@@ -118,6 +118,20 @@ scripts/ptools_server.sh status    # is it up?
 scripts/ptools_server.sh restart   # force a clean container (use this, not `docker start` — see gotchas)
 ```
 
+To **paint a run's ptools TSV** onto the EcoCyc Cellular Overview (auto-loaded,
+no manual upload), pass one of the emitted `ptools/*.tsv` (or a `ptools_overview_*`
+file) to the launcher:
+
+```sh
+scripts/ptools_launch.sh <sweep>/ptools/ptools_rna__<group>.tsv   # class inferred → opens the painted map
+```
+
+It stages the file into the server (this image's Omics Viewer only loads
+server-local files) and opens `celOv.shtml?omics=t&url=…&class=…&column1=1-N`.
+(The vivarium-dashboard "Launch ptools" button does the same thing for a study
+run once `ui.ptools_server_url` is set; locally the launcher script is the
+reliable path since the data must live on the PTools server.)
+
 The manual steps below explain what that script does and why.
 
 **1. A container runtime.** On macOS without Docker Desktop, colima gives a

--- a/scripts/ptools_launch.sh
+++ b/scripts/ptools_launch.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Paint a ptools omics TSV onto the EcoCyc Cellular Overview of the local
+# sms-ptools server and open it auto-loaded (no manual upload).
+#
+#   scripts/ptools_launch.sh <file.tsv> [class] [orgid]
+#     class: gene | reaction | protein | compound
+#            (default: inferred from the filename — ptools_rxns→reaction,
+#             ptools_proteins→protein, ptools_rna/other→gene)
+#     orgid: PGDB organism id (default: ECOLI)
+#
+# Why it stages the file INTO the container: this sms-ptools image's Omics
+# Viewer only loads data files that are LOCAL to the Pathway Tools server
+# (verified — a remote url=http://… is not fetched), so we docker-cp the TSV
+# into the server's htdocs and point url=file://… at it. The viewer auto-loads
+# via celOv.shtml?omics=t&url=…&class=…&column1=1-N, animating across timepoints.
+#
+# Companion to scripts/ptools_server.sh (which starts the server).
+set -euo pipefail
+
+NAME="sms-ptools"
+SERVER="${PTOOLS_SERVER_URL:-http://localhost:1555}"
+HTDOCS="/app/ptools/aic-export/htdocs"
+
+tsv="${1:?usage: scripts/ptools_launch.sh <file.tsv> [class] [orgid]}"
+[ -f "$tsv" ] || { echo "file not found: $tsv" >&2; exit 1; }
+
+infer_class() {
+  case "$(basename "$1" | tr '[:upper:]' '[:lower:]')" in
+    *rxn*|*reaction*)        echo reaction ;;
+    *protein*)               echo protein ;;
+    *metabolite*|*compound*) echo compound ;;
+    *)                       echo gene ;;
+  esac
+}
+cls="${2:-$(infer_class "$tsv")}"
+orgid="${3:-ECOLI}"
+
+docker ps --filter "name=$NAME" --format '{{.Names}}' | grep -qx "$NAME" || {
+  echo "ptools server '$NAME' is not running. Start it:  scripts/ptools_server.sh up" >&2
+  exit 1
+}
+
+# Timepoint columns = fields after the ID on the first non-comment line.
+# column1=1-N animates the overlay across all timepoints; 1 if single-column.
+# Single awk (no pipe) avoids a SIGPIPE that would trip `set -o pipefail`.
+ncol=$(awk -F'\t' '!/^[#;]/ && NF { print NF - 1; exit }' "$tsv")
+if [ -n "${ncol:-}" ] && [ "$ncol" -gt 1 ] 2>/dev/null; then
+  cols="1-$ncol"
+else
+  cols="1"
+fi
+
+dest="ptools_launch_$(basename "$tsv")"
+docker cp "$tsv" "$NAME:$HTDOCS/$dest" >/dev/null
+url="$SERVER/overviewsWeb/celOv.shtml?omics=t&url=file://$dest&orgid=$orgid&class=$cls&column1=$cols"
+
+echo "staged $(basename "$tsv") -> $NAME:$HTDOCS/$dest"
+echo "class=$cls  column1=$cols"
+echo "$url"
+if command -v open >/dev/null 2>&1; then
+  open "$url"
+else
+  echo "Open the URL above in a browser."
+fi


### PR DESCRIPTION
Adds `scripts/ptools_launch.sh`, a companion to the merged `scripts/ptools_server.sh`.

Given a ptools omics TSV (e.g. `<sweep>/ptools/ptools_rna__<group>.tsv` or a `ptools_overview_*` file), it:
- stages the file **into** the running `sms-ptools` container — this image's Omics Viewer only loads data files local to the Pathway Tools server (a remote `url=http://…` is not fetched), and
- opens the **verified auto-load URL** `celOv.shtml?omics=t&url=…&class=…&column1=1-N`, so the overlay paints and animates across timepoints with no manual upload.

Object `class` is inferred from the filename (`ptools_rxns`→reaction, `ptools_proteins`→protein, else gene); `column1=1-N` from the TSV's column count. Verified end-to-end against `sms-ptools:0.8.2`.

This is the reliable **local** equivalent of the vivarium-dashboard "Launch ptools" button (whose default URL template is fixed in vivarium-dashboard#214) — locally the data must live on the PTools server, which the button's dashboard-served URL can't satisfy.

Docs: a short usage note added to `docs/native-analyses-status-and-roadmap.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)