### PR TITLE
Cross-variant comparison analyses (showcase-4)

### DIFF
--- a/scripts/render_variant_comparison.py
+++ b/scripts/render_variant_comparison.py
@@ -1,0 +1,282 @@
+"""Render driver for the cross-variant COMPARISON analyses (showcase-4).
+
+Iterates the eight variant-comparison analyses
+(``v2ecoli/workflow/analyses/{growth_overlay,doubling_time_grouped,
+mass_fraction_grouped,replication_overlay,proteome_delta,fba_flux_overlay,
+regulation_overlay,scorecard}.py``) over a multivariant sweep, passing a real
+``variant_metadata`` int->display-name map, captures each Altair chart (via
+chart_to_html) or matplotlib Figure (via fig_to_html), and renders PNG + SVG.
+
+These analyses overlay / group / delta baseline + variants, so they are only
+meaningful on a MULTI-VARIANT sweep (the real 5-variant sweep).  For local
+read-path testing against the single-variant showcase-2 clean run, pass
+``--synthesize-variants`` to duplicate ``variant=0`` into synthetic
+``variant=1..N`` partitions (the duplicate is perturbed slightly so the
+overlay/delta machinery has non-degenerate data to plot — NOT scientifically
+meaningful, only a code exercise).
+
+Usage
+-----
+    # real 5-variant sweep:
+    python scripts/render_variant_comparison.py \
+        --sweep <sweep_dir> --sim-data out/workflow/simData.cPickle \
+        --out workspace/studies/showcase-4-variant-comparison/charts
+
+    # local read-path smoke test on showcase-2 clean data:
+    python scripts/render_variant_comparison.py --synthesize-variants \
+        --out /tmp/variant_comparison_smoke
+"""
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import shutil
+import sys
+import time
+import warnings
+
+import duckdb
+
+ROOT = os.environ.get("V2ECOLI_ROOT", "/Users/eranagmon/code/v2ecoli")
+DEFAULT_SWEEP = os.path.join(
+    ROOT, ".pbg/runs/showcase2-baseline-clean/sweep/showcase2_baseline")
+DEFAULT_SIM_DATA = os.path.join(ROOT, "out/workflow/simData.cPickle")
+
+# The runner's variant_metadata int->display-name map for the 5-variant sweep.
+VARIANT_METADATA = {
+    0: "baseline",
+    1: "ppgpp-off",
+    2: "dnaA-2x",
+    3: "elong-down",
+    4: "media",
+}
+
+# (analysis name, scale) — all are multivariant comparison analyses.
+COMPARISON_ANALYSES = [
+    ("growth_overlay", "multivariant"),
+    ("doubling_time_grouped", "multivariant"),
+    ("mass_fraction_grouped", "multivariant"),
+    ("replication_overlay", "multivariant"),
+    ("proteome_delta", "multivariant"),
+    ("fba_flux_overlay", "multivariant"),
+    ("regulation_overlay", "multivariant"),
+    ("scorecard", "multivariant"),
+]
+
+sys.path.insert(0, ROOT)
+
+import v2ecoli.workflow.analyses._helpers as helpers  # noqa: E402
+import v2ecoli.workflow.render as rendermod  # noqa: E402
+
+# ---- capture hooks (mirror render_showcase2.py) ------------------------------
+_CAP = {"chart": None, "fig": None}
+_orig_chart_to_html = helpers.chart_to_html
+_orig_fig_to_html = rendermod.fig_to_html
+
+
+def _cap_chart(chart, title=""):
+    _CAP["chart"] = chart
+    return _orig_chart_to_html(chart, title)
+
+
+def _cap_fig(fig, title=""):
+    _CAP["fig"] = fig
+    return _orig_fig_to_html(fig, title)
+
+
+helpers.chart_to_html = _cap_chart
+rendermod.fig_to_html = _cap_fig
+
+# Importing the analyses package registers all analyses AND binds the (now
+# patched) chart_to_html / fig_to_html names into each analysis module.
+import v2ecoli.workflow.analyses as _analyses_pkg  # noqa: E402,F401
+from v2ecoli.workflow.analysis import ANALYSIS_REGISTRY  # noqa: E402
+
+# Re-point the names already imported into each comparison module to the
+# capture hooks (they did `from _helpers import chart_to_html`).
+for _modname in (
+    "growth_overlay", "doubling_time_grouped", "mass_fraction_grouped",
+    "replication_overlay", "proteome_delta", "fba_flux_overlay",
+    "regulation_overlay", "scorecard",
+):
+    _mod = getattr(_analyses_pkg, _modname, None)
+    if _mod is not None and hasattr(_mod, "chart_to_html"):
+        _mod.chart_to_html = _cap_chart
+    if _mod is not None and hasattr(_mod, "fig_to_html"):
+        _mod.fig_to_html = _cap_fig
+
+from bigraph_schema import allocate_core  # noqa: E402
+from v2ecoli.workflow.analysis_runner import (  # noqa: E402
+    _history_from_clause, resolve_validation_data,
+)
+from v2ecoli.library.sim_data import LoadSimData  # noqa: E402
+
+
+def synthesize_variants(src_sweep: str, n_extra: int, dst: str) -> str:
+    """Duplicate ``variant=0`` history into synthetic ``variant=1..n_extra``.
+
+    Copies the parquet tree, rewriting the ``variant=0`` path segment to
+    ``variant=k`` for each synthetic variant, so the multivariant read-path sees
+    several variants.  The duplicates are NOT scientifically distinct (they are
+    copies); this only exercises the color-/group-/delta-by-variant code.
+    """
+    import polars as pl
+
+    hist_src = glob.glob(os.path.join(src_sweep, "**", "history"),
+                         recursive=True)
+    if not hist_src:
+        raise FileNotFoundError(f"no history/ dir under {src_sweep!r}")
+    # Mirror the whole sweep (summary.json etc.) then add synthetic variants.
+    if os.path.exists(dst):
+        shutil.rmtree(dst)
+    shutil.copytree(src_sweep, dst)
+
+    files = glob.glob(os.path.join(dst, "**", "history", "**", "variant=0",
+                                   "**", "*.pq"), recursive=True)
+    if not files:
+        raise FileNotFoundError(
+            f"no variant=0 parquet under copied sweep {dst!r}")
+
+    for k in range(1, n_extra + 1):
+        for f in files:
+            new = f.replace(os.sep + "variant=0" + os.sep,
+                            os.sep + f"variant={k}" + os.sep)
+            os.makedirs(os.path.dirname(new), exist_ok=True)
+            # Perturb a few scalar columns so overlays/deltas are non-degenerate
+            # (purely so the rendering exercises non-zero deltas; not science).
+            # NOTE: ``variant`` is a HIVE-PARTITION column (from the directory
+            # path), not stored in the parquet — the path rewrite above sets it,
+            # so we only perturb the in-file data columns here.
+            df = pl.read_parquet(f)
+            scale = 1.0 + 0.08 * k
+            for col, fac in (
+                ("listeners__mass__instantaneous_growth_rate", 1.0 / scale),
+                ("listeners__mass__cell_mass", scale),
+                ("listeners__mass__protein_mass", scale),
+                ("listeners__growth_limits__ppgpp_conc",
+                 (0.0 if k == 1 else 1.0 / scale)),  # variant 1 = ppGpp-off
+            ):
+                if col in df.columns:
+                    df = df.with_columns((pl.col(col) * fac).alias(col))
+            df.write_parquet(new)
+    return dst
+
+
+def _save_chart_png_svg(chart, base):
+    import vl_convert as vlc
+    spec = json.dumps(chart.to_dict())
+    with open(base + ".png", "wb") as f:
+        f.write(vlc.vegalite_to_png(spec, scale=2))
+    try:
+        with open(base + ".svg", "w", encoding="utf-8") as f:
+            f.write(vlc.vegalite_to_svg(spec))
+    except Exception as e:  # noqa: BLE001
+        print(f"  (svg failed for {os.path.basename(base)}: {e})")
+
+
+def _save_fig_png_svg(fig, base):
+    fig.savefig(base + ".png", dpi=150, bbox_inches="tight")
+    fig.savefig(base + ".svg", bbox_inches="tight")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--sweep", default=DEFAULT_SWEEP)
+    ap.add_argument("--sim-data", default=DEFAULT_SIM_DATA)
+    ap.add_argument("--out", default="/tmp/variant_comparison_charts")
+    ap.add_argument("--synthesize-variants", type=int, nargs="?", const=4,
+                    default=0, metavar="N",
+                    help="duplicate variant=0 into N synthetic variants "
+                         "(read-path smoke test only); default 4 when bare")
+    ap.add_argument("--render-png", action="store_true",
+                    help="also render PNG/SVG via vl_convert (needs vl_convert)")
+    args = ap.parse_args()
+
+    sweep = args.sweep
+    if args.synthesize_variants:
+        tmp = os.path.join(args.out, "_synth_sweep")
+        sweep = synthesize_variants(sweep, args.synthesize_variants, tmp)
+        print(f"synthesized {args.synthesize_variants} extra variants under "
+              f"{sweep}", flush=True)
+
+    os.makedirs(args.out, exist_ok=True)
+    print("loading sim_data ...", flush=True)
+    sim_data = LoadSimData(sim_data_path=args.sim_data).sim_data
+    validation_data = resolve_validation_data(sim_data)
+    print("validation_data:",
+          "present" if validation_data is not None else "None",
+          "| reactionFlux:",
+          "yes" if getattr(validation_data, "reactionFlux", None) is not None
+          else "no", flush=True)
+
+    conn = duckdb.connect()
+    from_clause = _history_from_clause(sweep)
+    # multivariant history_sql = the whole sweep (no WHERE filter).
+    history_sql = f"SELECT * FROM {from_clause} ORDER BY global_time"
+    variants = [r[0] for r in conn.sql(
+        f"SELECT DISTINCT variant FROM {from_clause} ORDER BY 1").fetchall()]
+    print(f"variants in sweep: {variants}", flush=True)
+    core = allocate_core()
+
+    results = {}
+    for name, scale in COMPARISON_ANALYSES:
+        print(f"=== {name} ({scale}) ===", flush=True)
+        _CAP["chart"] = None
+        _CAP["fig"] = None
+        try:
+            step = ANALYSIS_REGISTRY[name]({}, core=core)
+            out = step.update({
+                "conn": conn, "history_sql": history_sql,
+                "config_sql": "", "success_sql": "",
+                "sim_data": sim_data, "validation_data": validation_data,
+                "variant_metadata": VARIANT_METADATA,
+            })
+            view = out.get("view") or ""
+            nonempty_view = bool(view) and "<svg" in view or "vega" in view
+            base = os.path.join(args.out, name)
+            kind = None
+            if args.render_png:
+                if _CAP["chart"] is not None:
+                    _save_chart_png_svg(_CAP["chart"], base)
+                    kind = "altair-png"
+                elif _CAP["fig"] is not None:
+                    _save_fig_png_svg(_CAP["fig"], base)
+                    kind = "matplotlib-png"
+            # Always also write the HTML view (proof of non-empty render).
+            if view:
+                with open(base + ".html", "w", encoding="utf-8") as f:
+                    f.write(view)
+            results[name] = {
+                "status": "OK" if nonempty_view else "EMPTY_VIEW",
+                "kind": kind or ("altair" if _CAP["chart"] is not None
+                                 else "matplotlib" if _CAP["fig"] is not None
+                                 else "none"),
+                "view_bytes": len(view),
+                "data_keys": sorted((out.get("data") or {}).keys()),
+            }
+            print(f"  {results[name]}", flush=True)
+        except Exception as e:  # noqa: BLE001
+            import traceback
+            traceback.print_exc()
+            results[name] = {"status": f"ERROR: {type(e).__name__}: {e}"}
+
+    print("\n=== SUMMARY ===")
+    ok = 0
+    for k, v in results.items():
+        print(f"  {k}: {v.get('status')}  "
+              f"({v.get('kind','-')}, {v.get('view_bytes','-')} bytes)")
+        if v.get("status") == "OK":
+            ok += 1
+    with open(os.path.join(args.out, "render_results.json"), "w") as f:
+        json.dump({"variant_metadata": VARIANT_METADATA,
+                   "sweep": sweep, "variants": variants,
+                   "rendered_at": time.time(), "results": results}, f, indent=2)
+    print(f"\n{ok}/{len(COMPARISON_ANALYSES)} analyses OK")
+    return 0 if ok == len(COMPARISON_ANALYSES) else 1
+
+
+if __name__ == "__main__":
+    warnings.simplefilter("ignore")
+    raise SystemExit(main())

--- a/tests/test_variant_comparison_analyses.py
+++ b/tests/test_variant_comparison_analyses.py
@@ -1,0 +1,145 @@
+"""Tests for the cross-variant COMPARISON analyses (showcase-4).
+
+These analyses overlay / group / delta baseline + variants and are registered at
+``multivariant`` scale.  We assert (1) registration + scale, (2) the
+variant-label helpers, and (3) that the color-/group-by-variant read-path runs
+over a small synthetic 2-variant DuckDB table and yields a NON-EMPTY view for
+the analyses that need no sim_data; the sim_data-dependent analyses
+(proteome_delta / fba_flux_overlay / scorecard validation columns) are covered
+by the registration + helper checks here and by the
+``scripts/render_variant_comparison.py`` smoke run on real data.
+"""
+
+from __future__ import annotations
+
+import duckdb
+import pytest
+from bigraph_schema import allocate_core
+
+COMPARISON = [
+    "growth_overlay",
+    "doubling_time_grouped",
+    "mass_fraction_grouped",
+    "replication_overlay",
+    "proteome_delta",
+    "fba_flux_overlay",
+    "regulation_overlay",
+    "scorecard",
+]
+
+
+def test_all_comparison_analyses_registered_multivariant():
+    import v2ecoli.workflow.analyses  # noqa: F401  (registers everything)
+    from v2ecoli.workflow.analysis import ANALYSIS_REGISTRY, Analysis
+
+    for name in COMPARISON:
+        cls = ANALYSIS_REGISTRY[name]
+        assert issubclass(cls, Analysis), name
+        assert cls.scale == "multivariant", (name, cls.scale)
+
+
+def test_variant_label_map_ignores_config_keys():
+    from v2ecoli.workflow.analyses._helpers import variant_label_map
+
+    m = variant_label_map({0: "baseline", "1": "ppgpp-off", "skip_n_gens": 8})
+    assert m == {0: "baseline", 1: "ppgpp-off"}
+    assert variant_label_map(None) == {}
+
+
+def test_variant_display_expr_escapes_and_falls_back():
+    from v2ecoli.workflow.analyses._helpers import variant_display_expr
+
+    e = variant_display_expr({0: "baseline", 1: "d'naA"})
+    assert "WHEN 0 THEN 'baseline'" in e
+    assert "d''naA" in e  # single quote doubled
+    assert e.endswith("AS variant_name")
+    # empty map -> CASE-free fallback expression
+    e2 = variant_display_expr({})
+    assert "CASE" not in e2 and "variant " in e2
+
+
+def test_variant_sort_order_ascending_by_id():
+    from v2ecoli.workflow.analyses._helpers import variant_sort_order
+
+    order = variant_sort_order(
+        [2, 0, 1], {0: "baseline", 1: "ppgpp-off", 2: "dnaA-2x"})
+    assert order == ["baseline", "ppgpp-off", "dnaA-2x"]
+    # unmapped variants fall back to "variant N"
+    assert variant_sort_order([5, 0], {0: "baseline"}) == ["baseline", "variant 5"]
+
+
+@pytest.fixture()
+def two_variant_history():
+    """A tiny in-memory history_sql spanning variant 0 and variant 1.
+
+    Mirrors the parquet schema columns the no-sim_data comparison analyses read
+    (variant + the mass / growth / replication / regulation scalar listeners).
+    """
+    conn = duckdb.connect()
+    # 2 variants x 2 timepoints; variant 1 has zero ppGpp (the ppgpp-off shape).
+    conn.sql("""
+        CREATE TABLE hist AS
+        SELECT * FROM (VALUES
+            (0, 0, 1, '0', 60.0, 400.0, 180.0, 30.0, 20.0, 8.0, 0.0003, 2, 50.0, 0.95),
+            (0, 0, 1, '0', 120.0, 450.0, 200.0, 32.0, 22.0, 9.0, 0.0004, 4, 52.0, 0.96),
+            (1, 0, 1, '0', 60.0, 420.0, 200.0, 31.0, 21.0, 8.5, 0.0002, 2, 0.0, 0.90),
+            (1, 0, 1, '0', 120.0, 470.0, 220.0, 33.0, 23.0, 9.5, 0.0003, 4, 0.0, 0.91)
+        ) AS t(variant, lineage_seed, generation, agent_id, global_time,
+               listeners__mass__dry_mass, listeners__mass__protein_mass,
+               listeners__mass__rRna_mass, listeners__mass__tRna_mass,
+               listeners__mass__smallMolecule_mass,
+               listeners__mass__instantaneous_growth_rate,
+               listeners__replication_data__number_of_oric,
+               listeners__growth_limits__ppgpp_conc,
+               listeners__growth_limits__fraction_trna_charged)
+    """)
+    # cell_mass + dna_mass are read by some analyses; add as views.
+    conn.sql("""
+        CREATE VIEW hist2 AS
+        SELECT *, listeners__mass__dry_mass * 3.0 AS listeners__mass__cell_mass,
+               listeners__mass__dry_mass * 0.05 AS listeners__mass__dna_mass
+        FROM hist
+    """)
+    return conn, "SELECT * FROM hist2"
+
+
+@pytest.mark.parametrize("name", [
+    "growth_overlay",
+    "doubling_time_grouped",
+    "mass_fraction_grouped",
+    "replication_overlay",
+    "regulation_overlay",
+])
+def test_no_simdata_comparison_renders_nonempty_two_variants(
+        name, two_variant_history):
+    """The color-/group-by-variant read-path runs over 2 variants and the view
+    is non-empty (contains a Vega-Lite spec)."""
+    import v2ecoli.workflow.analyses  # noqa: F401
+    from v2ecoli.workflow.analysis import ANALYSIS_REGISTRY
+
+    conn, history_sql = two_variant_history
+    core = allocate_core()
+    step = ANALYSIS_REGISTRY[name]({}, core=core)
+    out = step.update({
+        "conn": conn, "history_sql": history_sql,
+        "config_sql": "", "success_sql": "",
+        "sim_data": None, "validation_data": None,
+        "variant_metadata": {0: "baseline", 1: "ppgpp-off"},
+    })
+    view = out.get("view") or ""
+    assert view, f"{name} produced empty view"
+    assert ("vega" in view or "<svg" in view), f"{name} view has no chart"
+
+
+def test_regulation_overlay_separates_ppgpp_off(two_variant_history):
+    """The ppgpp-off variant's ppGpp trace should be ~zero while baseline is
+    non-zero (the headline separation), so the analysis must surface both."""
+    import duckdb as _ddb  # noqa: F401
+    conn, history_sql = two_variant_history
+    # baseline mean ppGpp > 0, variant-1 ppGpp == 0
+    rows = conn.sql("""
+        SELECT variant, avg(listeners__growth_limits__ppgpp_conc) AS m
+        FROM (%s) GROUP BY variant ORDER BY variant
+    """ % history_sql).fetchall()
+    means = {int(v): float(m) for v, m in rows}
+    assert means[0] > 0 and means[1] == 0.0

--- a/v2ecoli/workflow/analyses/__init__.py
+++ b/v2ecoli/workflow/analyses/__init__.py
@@ -23,3 +23,14 @@ from v2ecoli.workflow.analyses import new_gene_counts  # noqa: F401
 from v2ecoli.workflow.analyses import average_monomer_counts  # noqa: F401
 from v2ecoli.workflow.analyses import subgenerational_expression_table  # noqa: F401
 from v2ecoli.workflow.analyses import protein_counts_validation  # noqa: F401
+
+# Cross-variant COMPARISON analyses (variant-comparison study, showcase-4):
+# overlay / group / delta baseline + variants instead of one-panel-per-variant.
+from v2ecoli.workflow.analyses import growth_overlay  # noqa: F401
+from v2ecoli.workflow.analyses import doubling_time_grouped  # noqa: F401
+from v2ecoli.workflow.analyses import mass_fraction_grouped  # noqa: F401
+from v2ecoli.workflow.analyses import replication_overlay  # noqa: F401
+from v2ecoli.workflow.analyses import proteome_delta  # noqa: F401
+from v2ecoli.workflow.analyses import fba_flux_overlay  # noqa: F401
+from v2ecoli.workflow.analyses import regulation_overlay  # noqa: F401
+from v2ecoli.workflow.analyses import scorecard  # noqa: F401

--- a/v2ecoli/workflow/analyses/_helpers.py
+++ b/v2ecoli/workflow/analyses/_helpers.py
@@ -328,6 +328,65 @@ def chart_to_html(chart, title: str = "") -> str:
     return f'<div class="analysis-view">{html}</div>'
 
 
+def variant_label_map(variant_metadata: Optional[dict] = None) -> dict[int, str]:
+    """Extract an ``int variant -> display name`` map from ``variant_metadata``.
+
+    The analysis runner passes the per-analysis config dict through as
+    ``variant_metadata`` (analysis_runner.py ~line 281).  For the
+    variant-comparison analyses the caller is expected to supply the runner's
+    ``variant_metadata`` int->name mapping (e.g.
+    ``{0: "baseline", 1: "ppgpp-off", ...}``); the keys may arrive as ints or
+    as JSON-stringified ints.  Any non-int-like keys (ordinary config options
+    such as ``skip_n_gens``) are ignored.
+
+    Returns ``{}`` when no variant entries are present — callers should then
+    fall back to labelling variants by their integer id.
+    """
+    out: dict[int, str] = {}
+    for k, v in (variant_metadata or {}).items():
+        try:
+            ik = int(k)
+        except (TypeError, ValueError):
+            continue
+        out[ik] = str(v)
+    return out
+
+
+def variant_display_expr(
+    variant_metadata: Optional[dict] = None,
+    col: str = "variant",
+    out_name: str = "variant_name",
+) -> str:
+    """A DuckDB CASE expression mapping ``col`` (int variant) to a display name.
+
+    Falls back to ``'variant ' || CAST(col AS VARCHAR)`` for any variant not
+    present in the map, so every variant always gets a legible label.
+    """
+    label_map = variant_label_map(variant_metadata)
+    whens = " ".join(
+        f"WHEN {int(k)} THEN '{str(v).replace(chr(39), chr(39) * 2)}'"
+        for k, v in sorted(label_map.items())
+    )
+    fallback = f"'variant ' || CAST({col} AS VARCHAR)"
+    if not whens:
+        return f"{fallback} AS {out_name}"
+    return f"CASE {col} {whens} ELSE {fallback} END AS {out_name}"
+
+
+def variant_sort_order(df_variants, variant_metadata: Optional[dict] = None) -> list[str]:
+    """Display-name sort order for a set of variant ints (ascending by id).
+
+    ``df_variants`` is any iterable of variant integers present in the data.
+    Returns the corresponding display names in ascending-variant order, so
+    baseline (variant 0) sorts first and Altair legends/x-axes are stable.
+    """
+    label_map = variant_label_map(variant_metadata)
+    order: list[str] = []
+    for v in sorted({int(x) for x in df_variants}):
+        order.append(label_map.get(v, f"variant {v}"))
+    return order
+
+
 def ptools_heatmap_view(
     df: "pd.DataFrame",  # noqa: F821
     title: str,

--- a/v2ecoli/workflow/analyses/doubling_time_grouped.py
+++ b/v2ecoli/workflow/analyses/doubling_time_grouped.py
@@ -1,0 +1,137 @@
+"""Cross-variant doubling-time comparison (variant-comparison study, showcase-4).
+
+Grouped box/bar of per-cell doubling time, one group per variant.  Unlike
+``doubling_time_hist`` (which collapses the variant axis into a single
+histogram), this contrasts the doubling-time DISTRIBUTION across baseline + each
+variant side by side.  Registered as ``"doubling_time_grouped"`` (scale:
+``"multivariant"``).
+
+Cap-immune measure (matches PR #184)
+------------------------------------
+A simple ``max(time) - min(time)`` doubling time is biased by the simulation's
+run cap: a cell that never divides reports the cap, not its true cycle time.
+Following PR #184 we instead derive a **cap-immune** doubling time from the
+instantaneous growth rate, ``T_double = ln(2) / mean(mu)``, where ``mu`` is
+``listeners.mass.instantaneous_growth_rate`` averaged over the cell's
+timeseries (units of 1/s -> minutes).  This is independent of when (or whether)
+division was reached.  When the growth-rate listener is unavailable we fall
+back to the elapsed-time measure (and say so in the title).
+
+Colors by variant via the ``variant`` hive-partition column mapped to display
+names through the runner's ``variant_metadata``.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import polars as pl
+from duckdb import DuckDBPyConnection
+
+from v2ecoli.workflow.analysis import Analysis, ANALYSIS_REGISTRY  # noqa: F401
+from v2ecoli.workflow.analyses._helpers import (
+    aliased_history,
+    available_columns,
+    cast_decimals,
+    chart_to_html,
+    variant_display_expr,
+    variant_sort_order,
+)
+
+LN2 = math.log(2.0)
+
+
+class DoublingTimeGrouped(Analysis):
+    """Grouped doubling-time distribution per variant (cap-immune ln2/mu)."""
+
+    name = "doubling_time_grouped"
+    scale = "multivariant"
+
+    def analyze(
+        self,
+        *,
+        conn: DuckDBPyConnection,
+        history_sql: str,
+        sim_data=None,
+        variant_metadata: dict[str, Any] | None = None,
+        **ctx,
+    ) -> dict:
+        import altair as alt
+
+        base = aliased_history(history_sql)
+        avail = available_columns(conn, history_sql)
+        vexpr = variant_display_expr(variant_metadata)
+        gr_col = "listeners__mass__instantaneous_growth_rate"
+        cap_immune = gr_col in avail
+
+        if cap_immune:
+            # Per-cell mean growth rate (1/s) -> doubling time in minutes.
+            # Exclude non-positive growth-rate rows from the mean so dead/edge
+            # rows don't bias mu toward 0 (which would inflate T_double).
+            df = conn.sql(f"""
+                WITH per_cell AS (
+                    SELECT variant, lineage_seed, generation, agent_id,
+                           avg({gr_col}) FILTER (WHERE {gr_col} > 0) AS mu
+                    FROM ({base})
+                    GROUP BY variant, lineage_seed, generation, agent_id
+                )
+                SELECT variant, {vexpr},
+                       {LN2} / mu / 60 AS doubling_time_min
+                FROM per_cell
+                WHERE mu IS NOT NULL AND mu > 0
+            """).pl()
+            measure = "cap-immune ln(2)/mean(mu)"
+        else:
+            df = conn.sql(f"""
+                WITH per_cell AS (
+                    SELECT variant, lineage_seed, generation, agent_id,
+                           (max(time) - min(time)) / 60 AS dt
+                    FROM ({base})
+                    GROUP BY variant, lineage_seed, generation, agent_id
+                )
+                SELECT variant, {vexpr}, dt AS doubling_time_min
+                FROM per_cell
+                WHERE dt > 0
+            """).pl()
+            measure = "elapsed max-min time (growth-rate listener unavailable)"
+
+        if df.is_empty():
+            raise ValueError("doubling_time_grouped: no doubling times computed")
+        df = cast_decimals(df)
+
+        order = variant_sort_order(df["variant"].to_list(), variant_metadata)
+        n_per_variant = df.group_by("variant").len().height
+
+        # Box plot per variant, with the per-cell points overlaid (jittered via
+        # the boxplot's own outlier marks). With few cells per variant a bar of
+        # the mean is clearer, so render both: box (distribution) is primary.
+        box = (
+            alt.Chart(df)
+            .mark_boxplot(extent="min-max")
+            .encode(
+                x=alt.X("variant_name:N", title="Variant", sort=order),
+                y=alt.Y("doubling_time_min:Q", title="Doubling time (min)"),
+                color=alt.Color("variant_name:N", title="Variant", sort=order),
+            )
+            .properties(
+                title=f"Doubling time per variant — {measure}",
+                width=max(360, 90 * max(1, n_per_variant)),
+                height=320,
+            )
+        )
+
+        means = df.group_by("variant_name").agg(
+            pl.col("doubling_time_min").mean().alias("pl_mean")
+        )
+        per_variant_mean = {
+            row["variant_name"]: float(row["pl_mean"]) for row in means.iter_rows(named=True)
+        }
+
+        return {
+            "view": chart_to_html(box, title="Doubling time per variant"),
+            "data": {
+                "measure": measure,
+                "per_variant_mean_min": per_variant_mean,
+            },
+        }

--- a/v2ecoli/workflow/analyses/fba_flux_overlay.py
+++ b/v2ecoli/workflow/analyses/fba_flux_overlay.py
@@ -1,0 +1,207 @@
+"""Cross-variant FBA flux overlay (variant-comparison study, showcase-4).
+
+The media headline.  For each variant computes the central-carbon reaction
+fluxes from ``listeners.fba_results.base_reaction_fluxes`` and reports:
+
+  * per-variant Toya-2010 Pearson r (flux-quality vs experiment) as a small
+    table — present only when ``validation_data.reactionFlux`` is available; and
+  * a delta-vs-baseline grouped bar of mean flux for the central-carbon
+    reactions (Toya reactions when validation is present, else the top reactions
+    by |mean baseline flux|), so a media change that re-routes central carbon
+    shows up as bars departing from baseline.
+
+Registered as ``"fba_flux_overlay"`` (scale: ``"multivariant"``).
+
+Colors by variant: each variant is a colored series in the delta bar and a row
+in the Toya-r table, keyed by the ``variant`` hive-partition column mapped to a
+display name via the runner's ``variant_metadata``.  Flux unit conversion
+(mmol/gDW/s -> mmol/gDW/h) follows the ``central_carbon_metabolism_scatter``
+port.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pandas as pd
+from duckdb import DuckDBPyConnection
+from scipy.stats import pearsonr
+
+from wholecell.utils import units
+from v2ecoli.workflow.analysis import Analysis, ANALYSIS_REGISTRY  # noqa: F401
+from v2ecoli.workflow.analyses._helpers import (
+    aliased_history,
+    available_columns,
+    chart_to_html,
+    variant_label_map,
+)
+
+_DENSITY_UNITS = units.g / units.L
+
+
+class FbaFluxOverlay(Analysis):
+    """Per-variant Toya r + central-carbon flux delta-vs-baseline."""
+
+    name = "fba_flux_overlay"
+    scale = "multivariant"
+
+    def _variant_mean_fluxes(self, conn, base, sim_data) -> dict[int, np.ndarray]:
+        """Per-variant mean converted flux vector over all rows/cells."""
+        flux_col = "listeners__fba_results__base_reaction_fluxes"
+        df = conn.sql(f"""
+            SELECT variant, {flux_col} AS flux,
+                   listeners__mass__cell_mass AS cell_mass,
+                   listeners__mass__dry_mass AS dry_mass
+            FROM ({base})
+            WHERE len({flux_col}) > 0
+        """).df()
+        if df.empty:
+            raise ValueError("fba_flux_overlay: no non-empty FBA flux rows")
+
+        density = sim_data.constants.cell_density.asNumber(_DENSITY_UNITS)
+        out: dict[int, np.ndarray] = {}
+        for v, sub in df.groupby("variant"):
+            fluxes = np.stack(sub["flux"].values)
+            coeff = sub["dry_mass"].values / sub["cell_mass"].values * density
+            converted = fluxes / coeff[:, np.newaxis] * 3600
+            out[int(v)] = converted.mean(axis=0)
+        return out
+
+    def analyze(
+        self,
+        *,
+        conn: DuckDBPyConnection,
+        history_sql: str,
+        sim_data,
+        validation_data=None,
+        variant_metadata: dict[str, Any] | None = None,
+        **ctx,
+    ) -> dict:
+        import altair as alt
+
+        base = aliased_history(history_sql)
+        avail = available_columns(conn, history_sql)
+        if "listeners__fba_results__base_reaction_fluxes" not in avail:
+            raise ValueError("fba_flux_overlay: base_reaction_fluxes not emitted")
+
+        base_reaction_ids = list(sim_data.process.metabolism.base_reaction_ids)
+        rid_to_idx = {r: i for i, r in enumerate(base_reaction_ids)}
+        labels = variant_label_map(variant_metadata)
+        mean_by_variant = self._variant_mean_fluxes(conn, base, sim_data)
+
+        width = len(next(iter(mean_by_variant.values())))
+        if width != len(base_reaction_ids):
+            raise ValueError(
+                f"fba_flux_overlay: flux width {width} != base_reaction_ids "
+                f"{len(base_reaction_ids)}; sim_data does not pair with this "
+                "parquet (use out/workflow/simData.cPickle)")
+
+        variants = sorted(mean_by_variant)
+        baseline_v = 0 if 0 in mean_by_variant else variants[0]
+
+        def vname(v: int) -> str:
+            return labels.get(v, f"variant {v}")
+
+        has_toya = (validation_data is not None
+                    and getattr(validation_data, "reactionFlux", None) is not None)
+
+        # --- choose the central-carbon reaction set --------------------------
+        if has_toya:
+            mmol_per_g_per_h = units.mmol / units.g / units.h
+            toya = validation_data.reactionFlux.toya2010fluxes
+            toya_ids = list(toya["reactionID"])
+            toya_flux = {r: f.asNumber(mmol_per_g_per_h)
+                         for r, f in zip(toya_ids, toya["reactionFlux"])}
+            cc_rxns = [r for r in toya_ids if r in rid_to_idx]
+        else:
+            base_mean = mean_by_variant[baseline_v]
+            top = np.argsort(np.abs(base_mean))[-20:][::-1]
+            cc_rxns = [base_reaction_ids[i] for i in top]
+            toya_flux = {}
+
+        if not cc_rxns:
+            raise ValueError("fba_flux_overlay: no central-carbon reactions found")
+
+        # --- delta-vs-baseline bar -------------------------------------------
+        base_mean = mean_by_variant[baseline_v]
+        rows = []
+        for v in variants:
+            mv = mean_by_variant[v]
+            for r in cc_rxns:
+                i = rid_to_idx[r]
+                rows.append({
+                    "variant_name": vname(v),
+                    "reaction": r,
+                    "flux": float(mv[i]),
+                    "delta_vs_baseline": float(mv[i] - base_mean[i]),
+                })
+        bar_df = pd.DataFrame(rows)
+
+        delta_bar = (
+            alt.Chart(bar_df)
+            .mark_bar()
+            .encode(
+                y=alt.Y("reaction:N", title="Central-carbon reaction",
+                        sort=cc_rxns),
+                x=alt.X("delta_vs_baseline:Q",
+                        title="Mean flux Δ vs baseline [mmol/gDW/hr]"),
+                yOffset=alt.YOffset("variant_name:N"),
+                color=alt.Color("variant_name:N", title="Variant"),
+                tooltip=["variant_name:N", "reaction:N",
+                         alt.Tooltip("flux:Q", format=".3f"),
+                         alt.Tooltip("delta_vs_baseline:Q", format=".3f")],
+            )
+            .properties(width=420, height=max(300, 22 * len(cc_rxns)),
+                        title="Central-carbon flux Δ vs baseline")
+        )
+
+        # --- per-variant Toya r table ----------------------------------------
+        r_rows = []
+        if has_toya:
+            for v in variants:
+                mv = mean_by_variant[v]
+                model, exp = [], []
+                for r in cc_rxns:
+                    model.append(mv[rid_to_idx[r]])
+                    exp.append(toya_flux[r])
+                if len(model) >= 2:
+                    r_rows.append({"variant_name": vname(v),
+                                   "toya_r": float(pearsonr(model, exp)[0])})
+
+        if r_rows:
+            r_df = pd.DataFrame(r_rows)
+            r_view = (
+                alt.Chart(r_df)
+                .mark_rect()
+                .encode(
+                    x=alt.value(0),
+                    y=alt.Y("variant_name:N", title="Variant"),
+                    color=alt.Color("toya_r:Q", title="Toya r",
+                                    scale=alt.Scale(scheme="viridis")),
+                )
+                .properties(width=120, height=30 * max(1, len(r_rows)),
+                            title="Toya-2010 r")
+            )
+            r_text = (
+                alt.Chart(r_df)
+                .mark_text()
+                .encode(y="variant_name:N",
+                        text=alt.Text("toya_r:Q", format=".2f"))
+            )
+            combined = alt.hconcat(delta_bar, (r_view + r_text))
+            title = "FBA flux overlay (Toya r + Δ vs baseline)"
+        else:
+            combined = delta_bar
+            title = ("FBA flux overlay (Δ vs baseline; "
+                     "validation_data unavailable — Toya r omitted)")
+
+        return {
+            "view": chart_to_html(combined, title=title),
+            "data": {
+                "baseline_variant": baseline_v,
+                "central_carbon_reactions": cc_rxns,
+                "toya_r": r_rows,
+                "has_validation": has_toya,
+            },
+        }

--- a/v2ecoli/workflow/analyses/growth_overlay.py
+++ b/v2ecoli/workflow/analyses/growth_overlay.py
@@ -1,0 +1,114 @@
+"""Cross-variant growth overlay (variant-comparison study, showcase-4).
+
+Overlays ``listeners.mass.cell_mass`` and
+``listeners.mass.instantaneous_growth_rate`` vs. time as one COLORED LINE PER
+VARIANT (not one panel per variant).  Registered as ``"growth_overlay"``
+(scale: ``"multivariant"``).
+
+How it colors by variant
+------------------------
+The multivariant ``history_sql`` spans every variant.  We map the ``variant``
+hive-partition column to a display name via :func:`variant_display_expr`
+(using the runner's ``variant_metadata`` int->name map) and encode that name as
+the Altair ``color`` channel, so baseline + each variant become separate
+colored lines on a shared axis.
+
+Time axis: ``global_time`` resets per generation in v2ecoli, so for a clean
+overlay across variants we average each metric across cells at each
+``global_time`` within a variant (mean over seeds/agents at that time).  This
+keeps a single trace per variant even when multiple seeds/generations are
+present.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import polars as pl
+from duckdb import DuckDBPyConnection
+
+from v2ecoli.workflow.analysis import Analysis, ANALYSIS_REGISTRY  # noqa: F401
+from v2ecoli.workflow.analyses._helpers import (
+    aliased_history,
+    available_columns,
+    cast_decimals,
+    chart_to_html,
+    variant_display_expr,
+    variant_sort_order,
+)
+
+
+class GrowthOverlay(Analysis):
+    """Cell mass + instantaneous growth rate vs time, one line per variant."""
+
+    name = "growth_overlay"
+    scale = "multivariant"
+
+    def analyze(
+        self,
+        *,
+        conn: DuckDBPyConnection,
+        history_sql: str,
+        sim_data=None,
+        variant_metadata: dict[str, Any] | None = None,
+        **ctx,
+    ) -> dict:
+        import altair as alt
+
+        base = aliased_history(history_sql)
+        avail = available_columns(conn, history_sql)
+        vexpr = variant_display_expr(variant_metadata)
+
+        metrics = [
+            ("listeners__mass__cell_mass", "Cell mass (fg)"),
+            ("listeners__mass__instantaneous_growth_rate",
+             "Instantaneous growth rate (1/s)"),
+        ]
+        present = [(c, lbl) for c, lbl in metrics if c in avail]
+        if not present:
+            raise ValueError(
+                "growth_overlay: neither cell_mass nor instantaneous_growth_rate "
+                "present in history_sql")
+
+        # Mean over cells (seeds/agents/gens) at each (variant, time).
+        # Use safe SQL aliases (metric_0, ...) so the field names carry no
+        # spaces/parens — Vega-Lite shorthand treats "[" / "(" as access-path
+        # syntax and vl_convert PNG export fails on label-as-field-name. The
+        # human label is applied via the axis title instead.
+        safe = [(c, lbl, f"metric_{i}") for i, (c, lbl) in enumerate(present)]
+        sel_metrics = ", ".join(f"avg({c}) AS {alias}" for c, _, alias in safe)
+        df = conn.sql(f"""
+            SELECT variant, {vexpr}, time, {sel_metrics}
+            FROM ({base})
+            GROUP BY variant, time
+            ORDER BY variant, time
+        """).pl()
+
+        if df.is_empty():
+            raise ValueError("growth_overlay: no rows after aggregation")
+        df = cast_decimals(df)
+
+        order = variant_sort_order(df["variant"].to_list(), variant_metadata)
+
+        panels = []
+        for _, lbl, alias in safe:
+            panels.append(
+                alt.Chart(df)
+                .mark_line(strokeWidth=2)
+                .encode(
+                    x=alt.X("time:Q", title="Time (s, per-generation clock)"),
+                    y=alt.Y(f"{alias}:Q", title=lbl),
+                    color=alt.Color("variant_name:N", title="Variant",
+                                    sort=order),
+                    tooltip=["variant_name:N", "time:Q",
+                             alt.Tooltip(f"{alias}:Q", title=lbl)],
+                )
+                .properties(title=lbl, width=560, height=200)
+            )
+
+        chart = alt.vconcat(*panels).resolve_scale(color="shared")
+        return {
+            "view": chart_to_html(chart, title="Growth overlay (per variant)"),
+            "data": {"n_variants": int(df["variant"].n_unique()),
+                     "variants": order},
+        }

--- a/v2ecoli/workflow/analyses/mass_fraction_grouped.py
+++ b/v2ecoli/workflow/analyses/mass_fraction_grouped.py
@@ -1,0 +1,114 @@
+"""Cross-variant mass-fraction comparison (variant-comparison study, showcase-4).
+
+Grouped bars of the time-averaged mass fractions (protein / rRNA / tRNA / DNA /
+small-molecule, each over dry mass), grouped BY VARIANT.  Contrasts proteome /
+RNA allocation across baseline + each variant on one chart.  Registered as
+``"mass_fraction_grouped"`` (scale: ``"multivariant"``).
+
+Colors/groups by variant via the ``variant`` hive-partition column mapped to a
+display name through the runner's ``variant_metadata``.  Each mass-fraction
+category is an x-axis group; the bars within a group are colored per variant.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import polars as pl
+from duckdb import DuckDBPyConnection
+
+from v2ecoli.workflow.analysis import Analysis, ANALYSIS_REGISTRY  # noqa: F401
+from v2ecoli.workflow.analyses._helpers import (
+    aliased_history,
+    available_columns,
+    cast_decimals,
+    chart_to_html,
+    variant_display_expr,
+    variant_sort_order,
+)
+
+# (mass column, fraction display label)
+_FRACTIONS = [
+    ("listeners__mass__protein_mass", "protein"),
+    ("listeners__mass__rRna_mass", "rRNA"),
+    ("listeners__mass__tRna_mass", "tRNA"),
+    ("listeners__mass__dna_mass", "DNA"),
+    ("listeners__mass__smallMolecule_mass", "small-mol"),
+]
+
+
+class MassFractionGrouped(Analysis):
+    """Time-averaged mass fractions, grouped bars per variant."""
+
+    name = "mass_fraction_grouped"
+    scale = "multivariant"
+
+    def analyze(
+        self,
+        *,
+        conn: DuckDBPyConnection,
+        history_sql: str,
+        sim_data=None,
+        variant_metadata: dict[str, Any] | None = None,
+        **ctx,
+    ) -> dict:
+        import altair as alt
+
+        base = aliased_history(history_sql)
+        avail = available_columns(conn, history_sql)
+        if "listeners__mass__dry_mass" not in avail:
+            raise ValueError("mass_fraction_grouped: dry_mass not in history_sql")
+        present = [(c, lbl) for c, lbl in _FRACTIONS if c in avail]
+        if not present:
+            raise ValueError("mass_fraction_grouped: no mass-component columns present")
+
+        vexpr = variant_display_expr(variant_metadata)
+        # Per (variant, time) fraction, then mean across time within a variant.
+        # We compute fraction at the row level (dry_mass > 0) and average.
+        frac_exprs = ", ".join(
+            f"avg({c} / listeners__mass__dry_mass) "
+            f"FILTER (WHERE listeners__mass__dry_mass > 0) AS \"{lbl}\""
+            for c, lbl in present
+        )
+        wide = conn.sql(f"""
+            SELECT variant, {vexpr}, {frac_exprs}
+            FROM ({base})
+            GROUP BY variant
+            ORDER BY variant
+        """).pl()
+
+        if wide.is_empty():
+            raise ValueError("mass_fraction_grouped: no rows after aggregation")
+        wide = cast_decimals(wide)
+
+        order = variant_sort_order(wide["variant"].to_list(), variant_metadata)
+        labels = [lbl for _, lbl in present]
+        long = wide.unpivot(
+            on=labels,
+            index=["variant", "variant_name"],
+            variable_name="component",
+            value_name="fraction",
+        )
+
+        chart = (
+            alt.Chart(long)
+            .mark_bar()
+            .encode(
+                x=alt.X("component:N", title="Mass component",
+                        sort=labels, axis=alt.Axis(labelAngle=0)),
+                xOffset=alt.XOffset("variant_name:N", sort=order),
+                y=alt.Y("fraction:Q", title="Mean fraction of dry mass"),
+                color=alt.Color("variant_name:N", title="Variant", sort=order),
+                tooltip=["variant_name:N", "component:N",
+                         alt.Tooltip("fraction:Q", format=".3f")],
+            )
+            .properties(
+                title="Mass fractions per variant (mean over time)",
+                width=560, height=320,
+            )
+        )
+
+        return {
+            "view": chart_to_html(chart, title="Mass fractions per variant"),
+            "data": {"components": labels, "variants": order},
+        }

--- a/v2ecoli/workflow/analyses/proteome_delta.py
+++ b/v2ecoli/workflow/analyses/proteome_delta.py
@@ -1,0 +1,210 @@
+"""Cross-variant proteome delta (variant-comparison study, showcase-4).
+
+For each non-baseline variant, scatters its per-monomer average count against
+the BASELINE (variant 0) average count (log10-log10), so points off the parity
+line are the proteins a variant up-/down-regulates.  Adds a small table of each
+variant's Schmidt-2015 and Wisniewski-2014 Pearson r (proteome-quality vs the
+literature), so a variant that breaks the proteome shows up as a dropped r.
+Registered as ``"proteome_delta"`` (scale: ``"multivariant"``).
+
+Uses the corrected SET ``listeners.monomer_counts`` (PR #185): each row already
+holds the cell's instantaneous monomer vector (not an accumulating sum), so a
+plain per-position average over rows is the mean proteome.
+
+Colors by variant: each non-baseline variant is one colored series in the
+ratio scatter (faceted/colored by variant_name); baseline (variant 0) is the
+reference axis, not a series.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import polars as pl
+from duckdb import DuckDBPyConnection
+from scipy.stats import pearsonr
+
+from v2ecoli.workflow.analysis import Analysis, ANALYSIS_REGISTRY  # noqa: F401
+from v2ecoli.workflow.analyses._helpers import (
+    aliased_history,
+    available_columns,
+    chart_to_html,
+    variant_label_map,
+)
+from v2ecoli.workflow.analyses.protein_counts_validation import (
+    _get_simulated_validation_counts,
+)
+
+
+class ProteomeDelta(Analysis):
+    """Per-variant monomer-count ratio-vs-baseline + validation Pearson r."""
+
+    name = "proteome_delta"
+    scale = "multivariant"
+
+    def _avg_counts_by_variant(self, conn, base) -> dict[int, np.ndarray]:
+        """Per-variant mean monomer-count vector (1-D, indexed by position)."""
+        df = conn.sql(f"""
+            WITH flat AS (
+                SELECT variant,
+                       unnest(listeners__monomer_counts) AS cnt,
+                       generate_subscripts(listeners__monomer_counts, 1) AS idx
+                FROM ({base})
+                WHERE len(listeners__monomer_counts) > 0
+            )
+            SELECT variant, idx, avg(cnt) AS avg_cnt
+            FROM flat GROUP BY variant, idx ORDER BY variant, idx
+        """).pl()
+        out: dict[int, np.ndarray] = {}
+        for v in df["variant"].unique().to_list():
+            sub = df.filter(pl.col("variant") == v).sort("idx")
+            out[int(v)] = sub["avg_cnt"].to_numpy()
+        return out
+
+    def analyze(
+        self,
+        *,
+        conn: DuckDBPyConnection,
+        history_sql: str,
+        sim_data,
+        validation_data=None,
+        variant_metadata: dict[str, Any] | None = None,
+        **ctx,
+    ) -> dict:
+        import altair as alt
+
+        base = aliased_history(history_sql)
+        avail = available_columns(conn, history_sql)
+        if "listeners__monomer_counts" not in avail:
+            raise ValueError("proteome_delta: listeners__monomer_counts not emitted")
+
+        labels = variant_label_map(variant_metadata)
+        by_variant = self._avg_counts_by_variant(conn, base)
+        if not by_variant:
+            raise ValueError("proteome_delta: no monomer_counts rows found")
+
+        variants = sorted(by_variant)
+        baseline_v = 0 if 0 in by_variant else variants[0]
+        baseline = by_variant[baseline_v]
+
+        sim_monomer_ids = list(sim_data.process.translation.monomer_data["id"])
+        if len(baseline) != len(sim_monomer_ids):
+            raise ValueError(
+                f"proteome_delta: monomer vector width {len(baseline)} != "
+                f"sim monomer_ids {len(sim_monomer_ids)}; sim_data does not pair "
+                "with this parquet (use out/workflow/simData.cPickle)")
+
+        def vname(v: int) -> str:
+            return labels.get(v, f"variant {v}")
+
+        # --- ratio-vs-baseline scatter (log10 baseline vs log10 variant) ------
+        rows = []
+        for v in variants:
+            if v == baseline_v:
+                continue
+            cur = by_variant[v]
+            for b, c in zip(baseline, cur):
+                rows.append({
+                    "variant_name": vname(v),
+                    "baseline_log10": float(np.log10(b + 1)),
+                    "variant_log10": float(np.log10(c + 1)),
+                })
+        if rows:
+            sc_df = pl.DataFrame(rows)
+            max_val = max(sc_df["baseline_log10"].max(), sc_df["variant_log10"].max())
+            scatter = (
+                alt.Chart(sc_df)
+                .mark_point(opacity=0.25, size=12)
+                .encode(
+                    x=alt.X("baseline_log10:Q",
+                            title=f"log10({vname(baseline_v)} count + 1)"),
+                    y=alt.Y("variant_log10:Q", title="log10(variant count + 1)"),
+                    color=alt.Color("variant_name:N", title="Variant"),
+                    tooltip=["variant_name:N", "baseline_log10:Q", "variant_log10:Q"],
+                )
+                .properties(width=420, height=420,
+                            title="Per-variant proteome vs baseline")
+            )
+            parity = (
+                alt.Chart(pl.DataFrame({"x": np.linspace(0, float(max_val), 50)}))
+                .mark_line(color="red", strokeDash=[5, 5])
+                .encode(x="x", y="x")
+            )
+            scatter_chart = (scatter + parity)
+        else:
+            # Only baseline present (single-variant test data): show baseline
+            # self-distribution so the view is non-empty.
+            self_df = pl.DataFrame({
+                "baseline_log10": np.log10(baseline + 1),
+            })
+            scatter_chart = (
+                alt.Chart(self_df)
+                .mark_bar()
+                .encode(
+                    x=alt.X("baseline_log10:Q", bin=alt.Bin(maxbins=40),
+                            title=f"log10({vname(baseline_v)} count + 1)"),
+                    y=alt.Y("count()", title="monomers"),
+                )
+                .properties(width=420, height=320,
+                            title="Baseline proteome (only variant present)")
+            )
+
+        # --- per-variant validation Pearson r table --------------------------
+        r_rows = []
+        if validation_data is not None:
+            schmidt_ids = validation_data.protein.schmidt2015Data["monomerId"]
+            schmidt_counts = validation_data.protein.schmidt2015Data["glucoseCounts"]
+            wis_ids = validation_data.protein.wisniewski2014Data["monomerId"]
+            wis_counts = validation_data.protein.wisniewski2014Data["avgCounts"]
+            for v in variants:
+                avg = by_variant[v]
+                sim_s, val_s = _get_simulated_validation_counts(
+                    schmidt_counts, avg, schmidt_ids, sim_monomer_ids)
+                sim_w, val_w = _get_simulated_validation_counts(
+                    wis_counts, avg, wis_ids, sim_monomer_ids)
+                r_rows.append({
+                    "variant_name": vname(v),
+                    "schmidt_r": float(pearsonr(
+                        np.log10(sim_s + 1), np.log10(val_s + 1))[0]),
+                    "wisniewski_r": float(pearsonr(
+                        np.log10(sim_w + 1), np.log10(val_w + 1))[0]),
+                })
+
+        if r_rows:
+            r_df = pl.DataFrame(r_rows).unpivot(
+                on=["schmidt_r", "wisniewski_r"],
+                index="variant_name",
+                variable_name="dataset", value_name="pearson_r",
+            )
+            table = (
+                alt.Chart(r_df)
+                .mark_rect()
+                .encode(
+                    x=alt.X("dataset:N", title="Validation set"),
+                    y=alt.Y("variant_name:N", title="Variant"),
+                    color=alt.Color("pearson_r:Q", title="Pearson r",
+                                    scale=alt.Scale(scheme="viridis")),
+                )
+                .properties(width=200, height=30 * max(1, len(r_rows)),
+                            title="Proteome validation r per variant")
+            )
+            text = (
+                alt.Chart(r_df)
+                .mark_text(baseline="middle")
+                .encode(x="dataset:N", y="variant_name:N",
+                        text=alt.Text("pearson_r:Q", format=".2f"))
+            )
+            r_view = (table + text)
+            combined = alt.hconcat(scatter_chart, r_view)
+        else:
+            combined = scatter_chart
+
+        return {
+            "view": chart_to_html(combined, title="Proteome delta (per variant)"),
+            "data": {
+                "baseline_variant": baseline_v,
+                "n_variants": len(variants),
+                "validation_r": r_rows,
+            },
+        }

--- a/v2ecoli/workflow/analyses/regulation_overlay.py
+++ b/v2ecoli/workflow/analyses/regulation_overlay.py
@@ -1,0 +1,114 @@
+"""Cross-variant regulation overlay (variant-comparison study, showcase-4).
+
+The ppGpp-off headline.  Overlays ``listeners.growth_limits.ppgpp_conc`` and
+``listeners.growth_limits.fraction_trna_charged`` vs. time as one COLORED LINE
+PER VARIANT.  In the ppGpp-off variant the ppGpp trace should collapse toward
+zero, visibly separating from baseline.  Registered as
+``"regulation_overlay"`` (scale: ``"multivariant"``).
+
+How it colors by variant
+------------------------
+Maps the ``variant`` hive-partition column to a display name via the runner's
+``variant_metadata`` and encodes it as the Altair ``color`` channel.  Each
+metric is averaged across cells at each ``global_time`` within a variant.
+
+Note: ``fraction_trna_charged`` is emitted per-tRNA-family (a list); we reduce
+it to a scalar mean charged fraction per row before aggregating.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from duckdb import DuckDBPyConnection
+
+from v2ecoli.workflow.analysis import Analysis, ANALYSIS_REGISTRY  # noqa: F401
+from v2ecoli.workflow.analyses._helpers import (
+    aliased_history,
+    available_columns,
+    cast_decimals,
+    chart_to_html,
+    variant_display_expr,
+    variant_sort_order,
+)
+
+
+class RegulationOverlay(Analysis):
+    """ppGpp + tRNA-charged fraction vs time, one line per variant."""
+
+    name = "regulation_overlay"
+    scale = "multivariant"
+
+    def analyze(
+        self,
+        *,
+        conn: DuckDBPyConnection,
+        history_sql: str,
+        sim_data=None,
+        variant_metadata: dict[str, Any] | None = None,
+        **ctx,
+    ) -> dict:
+        import altair as alt
+
+        base = aliased_history(history_sql)
+        avail = available_columns(conn, history_sql)
+        vexpr = variant_display_expr(variant_metadata)
+
+        # fraction_trna_charged may be a scalar or a per-family list; build a
+        # scalar mean expression that works for either.
+        ftc = "listeners__growth_limits__fraction_trna_charged"
+        ppgpp = "listeners__growth_limits__ppgpp_conc"
+
+        # (label, SQL value expr); rendered with safe metric_N aliases so
+        # vl_convert PNG export does not mis-parse label-as-field-name.
+        specs: list[tuple[str, str]] = []
+        if ppgpp in avail:
+            specs.append(("ppGpp conc", f"avg({ppgpp})"))
+        if ftc in avail:
+            # detect list vs scalar from the column type
+            typ = conn.sql(
+                f"SELECT typeof({ftc}) FROM ({base}) LIMIT 1").fetchone()
+            is_list = bool(typ and typ[0] and "[" in str(typ[0]))
+            charged_expr = (f"list_avg({ftc})" if is_list else ftc)
+            specs.append(("Fraction tRNA charged", f"avg({charged_expr})"))
+
+        if not specs:
+            raise ValueError(
+                "regulation_overlay: neither ppgpp_conc nor "
+                "fraction_trna_charged present in history_sql")
+
+        labels = [lbl for lbl, _ in specs]
+        safe = [(lbl, expr, f"metric_{i}") for i, (lbl, expr) in enumerate(specs)]
+        sel_parts = [f"{expr} AS {alias}" for _, expr, alias in safe]
+
+        df = conn.sql(f"""
+            SELECT variant, {vexpr}, time, {", ".join(sel_parts)}
+            FROM ({base})
+            GROUP BY variant, time
+            ORDER BY variant, time
+        """).pl()
+        if df.is_empty():
+            raise ValueError("regulation_overlay: no rows after aggregation")
+        df = cast_decimals(df)
+
+        order = variant_sort_order(df["variant"].to_list(), variant_metadata)
+        panels = []
+        for lbl, _, alias in safe:
+            panels.append(
+                alt.Chart(df)
+                .mark_line(strokeWidth=2)
+                .encode(
+                    x=alt.X("time:Q", title="Time (s, per-generation clock)"),
+                    y=alt.Y(f"{alias}:Q", title=lbl),
+                    color=alt.Color("variant_name:N", title="Variant", sort=order),
+                    tooltip=["variant_name:N", "time:Q",
+                             alt.Tooltip(f"{alias}:Q", title=lbl)],
+                )
+                .properties(title=lbl, width=560, height=200)
+            )
+
+        chart = alt.vconcat(*panels).resolve_scale(color="shared")
+        return {
+            "view": chart_to_html(chart, title="Regulation overlay (per variant)"),
+            "data": {"metrics": labels, "variants": order},
+        }

--- a/v2ecoli/workflow/analyses/replication_overlay.py
+++ b/v2ecoli/workflow/analyses/replication_overlay.py
@@ -1,0 +1,102 @@
+"""Cross-variant replication overlay (variant-comparison study, showcase-4).
+
+The dnaA-2x headline: overlays ``listeners.replication_data.number_of_oric``
+(and ``critical_mass_per_oric`` when emitted) vs. time as one COLORED LINE PER
+VARIANT.  Registered as ``"replication_overlay"`` (scale: ``"multivariant"``).
+
+How it colors by variant
+------------------------
+Maps the ``variant`` hive-partition column to a display name via the runner's
+``variant_metadata`` and encodes it as the Altair ``color`` channel.  oriC count
+is averaged across cells at each ``global_time`` within a variant, so a
+dnaA-overexpression variant (more frequent initiation -> more oriC) separates
+visibly from baseline.
+
+v2ecoli note: ``listeners.replication_data.critical_mass_per_oric`` is not
+emitted by every v2ecoli build (see the ``replication`` port note), so that
+panel is included only when the column is present.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from duckdb import DuckDBPyConnection
+
+from v2ecoli.workflow.analysis import Analysis, ANALYSIS_REGISTRY  # noqa: F401
+from v2ecoli.workflow.analyses._helpers import (
+    aliased_history,
+    available_columns,
+    cast_decimals,
+    chart_to_html,
+    variant_display_expr,
+    variant_sort_order,
+)
+
+
+class ReplicationOverlay(Analysis):
+    """Number of oriC (+ critical mass/oriC) vs time, one line per variant."""
+
+    name = "replication_overlay"
+    scale = "multivariant"
+
+    def analyze(
+        self,
+        *,
+        conn: DuckDBPyConnection,
+        history_sql: str,
+        sim_data=None,
+        variant_metadata: dict[str, Any] | None = None,
+        **ctx,
+    ) -> dict:
+        import altair as alt
+
+        base = aliased_history(history_sql)
+        avail = available_columns(conn, history_sql)
+        vexpr = variant_display_expr(variant_metadata)
+
+        metrics = [
+            ("listeners__replication_data__number_of_oric", "Number of oriC"),
+            ("listeners__replication_data__critical_mass_per_oric",
+             "Critical mass per oriC"),
+        ]
+        present = [(c, lbl) for c, lbl in metrics if c in avail]
+        if not present:
+            raise ValueError(
+                "replication_overlay: number_of_oric not present in history_sql")
+
+        # Safe SQL aliases (no spaces/parens) so vl_convert PNG export does not
+        # mis-parse label-as-field-name; human label via axis title.
+        safe = [(c, lbl, f"metric_{i}") for i, (c, lbl) in enumerate(present)]
+        sel = ", ".join(f"avg({c}) AS {alias}" for c, _, alias in safe)
+        df = conn.sql(f"""
+            SELECT variant, {vexpr}, time, {sel}
+            FROM ({base})
+            GROUP BY variant, time
+            ORDER BY variant, time
+        """).pl()
+        if df.is_empty():
+            raise ValueError("replication_overlay: no rows after aggregation")
+        df = cast_decimals(df)
+
+        order = variant_sort_order(df["variant"].to_list(), variant_metadata)
+        panels = []
+        for _, lbl, alias in safe:
+            panels.append(
+                alt.Chart(df)
+                .mark_line(strokeWidth=2)
+                .encode(
+                    x=alt.X("time:Q", title="Time (s, per-generation clock)"),
+                    y=alt.Y(f"{alias}:Q", title=lbl),
+                    color=alt.Color("variant_name:N", title="Variant", sort=order),
+                    tooltip=["variant_name:N", "time:Q",
+                             alt.Tooltip(f"{alias}:Q", title=lbl)],
+                )
+                .properties(title=lbl, width=560, height=200)
+            )
+
+        chart = alt.vconcat(*panels).resolve_scale(color="shared")
+        return {
+            "view": chart_to_html(chart, title="Replication overlay (per variant)"),
+            "data": {"metrics": [lbl for _, lbl in present], "variants": order},
+        }

--- a/v2ecoli/workflow/analyses/scorecard.py
+++ b/v2ecoli/workflow/analyses/scorecard.py
@@ -1,0 +1,268 @@
+"""Cross-variant scorecard (variant-comparison study, showcase-4).
+
+One summary heatmap: rows = variants, columns = headline metrics
+(doubling time, dry mass, protein fraction, max oriC, mean ppGpp, Toya r,
+Schmidt r).  Each cell is colored by its Δ vs the baseline variant (signed,
+per-column-normalised), so at a glance you see which variant moves which metric
+and in which direction.  The raw value is printed in each cell.  Registered as
+``"scorecard"`` (scale: ``"multivariant"``).
+
+Colors by variant: variants are the heatmap rows (keyed by the ``variant``
+hive-partition column mapped to a display name via the runner's
+``variant_metadata``); the color encodes Δ-vs-baseline per column.
+
+Each metric degrades gracefully: a metric whose source column / validation set
+is unavailable is simply omitted from the columns rather than failing the whole
+scorecard.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import numpy as np
+import pandas as pd
+from duckdb import DuckDBPyConnection
+
+from v2ecoli.workflow.analysis import Analysis, ANALYSIS_REGISTRY  # noqa: F401
+from v2ecoli.workflow.analyses._helpers import (
+    aliased_history,
+    available_columns,
+    chart_to_html,
+    variant_label_map,
+)
+
+LN2 = math.log(2.0)
+_DENSITY_UNITS = None  # set lazily to avoid importing units when unused
+
+
+class Scorecard(Analysis):
+    """Per-variant summary heatmap with Δ-vs-baseline coloring."""
+
+    name = "scorecard"
+    scale = "multivariant"
+
+    def analyze(
+        self,
+        *,
+        conn: DuckDBPyConnection,
+        history_sql: str,
+        sim_data=None,
+        validation_data=None,
+        variant_metadata: dict[str, Any] | None = None,
+        **ctx,
+    ) -> dict:
+        import altair as alt
+
+        base = aliased_history(history_sql)
+        avail = available_columns(conn, history_sql)
+        labels = variant_label_map(variant_metadata)
+
+        # ---- mass/growth/replication/regulation metrics per variant --------
+        sel = ["variant"]
+        col_specs: list[tuple[str, str]] = []  # (metric label, select expr alias)
+
+        def add(label, expr):
+            sel.append(expr)
+            col_specs.append((label, label))
+
+        if "listeners__mass__instantaneous_growth_rate" in avail:
+            add("doubling time (min)",
+                f"{LN2} / avg(listeners__mass__instantaneous_growth_rate) "
+                "FILTER (WHERE listeners__mass__instantaneous_growth_rate > 0) "
+                "/ 60 AS \"doubling time (min)\"")
+        if "listeners__mass__dry_mass" in avail:
+            add("dry mass (fg)", "avg(listeners__mass__dry_mass) AS \"dry mass (fg)\"")
+        if "listeners__mass__protein_mass" in avail and \
+                "listeners__mass__dry_mass" in avail:
+            add("protein fraction",
+                "avg(listeners__mass__protein_mass / listeners__mass__dry_mass) "
+                "FILTER (WHERE listeners__mass__dry_mass > 0) AS \"protein fraction\"")
+        if "listeners__replication_data__number_of_oric" in avail:
+            add("max oriC",
+                "max(listeners__replication_data__number_of_oric) AS \"max oriC\"")
+        if "listeners__growth_limits__ppgpp_conc" in avail:
+            add("mean ppGpp",
+                "avg(listeners__growth_limits__ppgpp_conc) AS \"mean ppGpp\"")
+
+        if len(sel) == 1:
+            raise ValueError("scorecard: no scalar metric columns present")
+
+        agg = conn.sql(f"""
+            SELECT {", ".join(sel)}
+            FROM ({base})
+            GROUP BY variant
+            ORDER BY variant
+        """).df()
+
+        metric_cols = [lbl for lbl, _ in col_specs]
+        scorecard = agg.set_index("variant")[metric_cols].copy()
+
+        # ---- validation metrics (Toya r, Schmidt r) per variant ------------
+        self._add_validation_metrics(
+            conn, base, sim_data, validation_data, scorecard, avail)
+
+        # ---- rename variant rows to display names --------------------------
+        scorecard.index = [labels.get(int(v), f"variant {v}")
+                           for v in scorecard.index]
+        baseline_v = 0 if 0 in agg["variant"].values else int(agg["variant"].min())
+        baseline_name = labels.get(baseline_v, f"variant {baseline_v}")
+
+        # ---- build Δ-vs-baseline (per-column normalised) -------------------
+        long_rows = []
+        for col in scorecard.columns:
+            base_val = (scorecard.loc[baseline_name, col]
+                        if baseline_name in scorecard.index else np.nan)
+            col_vals = scorecard[col].astype(float)
+            spread = float(np.nanmax(np.abs(col_vals - base_val))) or 1.0
+            for variant_name, val in col_vals.items():
+                delta = float(val) - float(base_val) if not np.isnan(base_val) else 0.0
+                long_rows.append({
+                    "variant_name": variant_name,
+                    "metric": col,
+                    "value": float(val),
+                    "delta_norm": delta / spread,
+                })
+        long = pd.DataFrame(long_rows)
+
+        row_order = list(scorecard.index)
+        col_order = list(scorecard.columns)
+
+        heat = (
+            alt.Chart(long)
+            .mark_rect(stroke="white")
+            .encode(
+                x=alt.X("metric:N", title="Metric", sort=col_order,
+                        axis=alt.Axis(labelAngle=-30)),
+                y=alt.Y("variant_name:N", title="Variant", sort=row_order),
+                color=alt.Color(
+                    "delta_norm:Q", title="Δ vs baseline (norm.)",
+                    scale=alt.Scale(scheme="blueorange", domainMid=0)),
+                tooltip=["variant_name:N", "metric:N",
+                         alt.Tooltip("value:Q", format=".4g"),
+                         alt.Tooltip("delta_norm:Q", format=".2f")],
+            )
+            .properties(width=90 * max(1, len(col_order)),
+                        height=44 * max(1, len(row_order)),
+                        title=f"Variant scorecard (Δ vs {baseline_name})")
+        )
+        text = (
+            alt.Chart(long)
+            .mark_text(baseline="middle", fontSize=10)
+            .encode(x="metric:N", y="variant_name:N",
+                    text=alt.Text("value:Q", format=".3g"))
+        )
+
+        return {
+            "view": chart_to_html(heat + text, title="Variant scorecard"),
+            "data": {
+                "baseline_variant": baseline_v,
+                "metrics": col_order,
+                "table": scorecard.reset_index().rename(
+                    columns={"index": "variant_name"}).to_dict(orient="records"),
+            },
+        }
+
+    def _add_validation_metrics(self, conn, base, sim_data, validation_data,
+                                scorecard, avail):
+        """Append Toya r and Schmidt r columns to ``scorecard`` if available."""
+        if validation_data is None or sim_data is None:
+            return
+
+        import numpy as np
+        from scipy.stats import pearsonr
+
+        variants = list(scorecard.index)
+
+        # --- Schmidt r (proteome) ---
+        if "listeners__monomer_counts" in avail and \
+                getattr(validation_data, "protein", None) is not None:
+            try:
+                from v2ecoli.workflow.analyses.protein_counts_validation import (
+                    _get_simulated_validation_counts,
+                )
+                df = conn.sql(f"""
+                    WITH flat AS (
+                        SELECT variant,
+                               unnest(listeners__monomer_counts) AS cnt,
+                               generate_subscripts(
+                                   listeners__monomer_counts, 1) AS idx
+                        FROM ({base})
+                        WHERE len(listeners__monomer_counts) > 0
+                    )
+                    SELECT variant, idx, avg(cnt) AS avg_cnt
+                    FROM flat GROUP BY variant, idx ORDER BY variant, idx
+                """).df()
+                sim_ids = list(sim_data.process.translation.monomer_data["id"])
+                schmidt_ids = validation_data.protein.schmidt2015Data["monomerId"]
+                schmidt_counts = \
+                    validation_data.protein.schmidt2015Data["glucoseCounts"]
+                rmap = {}
+                for v in df["variant"].unique():
+                    avg = (df[df["variant"] == v].sort_values("idx")["avg_cnt"]
+                           .to_numpy())
+                    if len(avg) != len(sim_ids):
+                        continue
+                    sim_s, val_s = _get_simulated_validation_counts(
+                        schmidt_counts, avg, schmidt_ids, sim_ids)
+                    rmap[int(v)] = float(pearsonr(
+                        np.log10(sim_s + 1), np.log10(val_s + 1))[0])
+                self._attach(scorecard, "Schmidt r", rmap)
+            except Exception:  # noqa: BLE001
+                pass
+
+        # --- Toya r (flux) ---
+        if "listeners__fba_results__base_reaction_fluxes" in avail and \
+                getattr(validation_data, "reactionFlux", None) is not None:
+            try:
+                from wholecell.utils import units
+                density = sim_data.constants.cell_density.asNumber(
+                    units.g / units.L)
+                base_ids = list(sim_data.process.metabolism.base_reaction_ids)
+                rid_to_idx = {r: i for i, r in enumerate(base_ids)}
+                mmol = units.mmol / units.g / units.h
+                toya = validation_data.reactionFlux.toya2010fluxes
+                toya_flux = {r: f.asNumber(mmol) for r, f in zip(
+                    toya["reactionID"], toya["reactionFlux"])}
+                cc = [r for r in toya["reactionID"] if r in rid_to_idx]
+
+                fdf = conn.sql(f"""
+                    SELECT variant,
+                           listeners__fba_results__base_reaction_fluxes AS flux,
+                           listeners__mass__cell_mass AS cm,
+                           listeners__mass__dry_mass AS dm
+                    FROM ({base})
+                    WHERE len(listeners__fba_results__base_reaction_fluxes) > 0
+                """).df()
+                rmap = {}
+                for v, sub in fdf.groupby("variant"):
+                    fl = np.stack(sub["flux"].values)
+                    coeff = sub["dm"].values / sub["cm"].values * density
+                    conv = (fl / coeff[:, np.newaxis] * 3600).mean(axis=0)
+                    model = [conv[rid_to_idx[r]] for r in cc]
+                    exp = [toya_flux[r] for r in cc]
+                    if len(model) >= 2:
+                        rmap[int(v)] = float(pearsonr(model, exp)[0])
+                self._attach(scorecard, "Toya r", rmap)
+            except Exception:  # noqa: BLE001
+                pass
+
+    @staticmethod
+    def _attach(scorecard, col, rmap_by_variant_int):
+        """Attach a per-variant metric keyed by the integer variant id.
+
+        ``scorecard``'s index has already been renamed to display names, so we
+        re-key by position: scorecard rows are in ascending variant order, the
+        same order produced by the GROUP BY ... ORDER BY variant queries here.
+        """
+        import numpy as np
+        ordered = sorted(rmap_by_variant_int)
+        if len(ordered) != len(scorecard.index):
+            # partial coverage: fill by position where possible, else NaN
+            vals = [rmap_by_variant_int.get(v, np.nan) for v in ordered]
+            # pad/truncate to row count
+            vals = (vals + [np.nan] * len(scorecard.index))[:len(scorecard.index)]
+        else:
+            vals = [rmap_by_variant_int[v] for v in ordered]
+        scorecard[col] = vals


### PR DESCRIPTION
## What

Eight **cross-variant COMPARISON** analyses for the variant-comparison study (showcase-4). The existing multivariant analyses render one panel per variant or collapse the variant axis; these **overlay / group / delta** baseline + variants to contrast them. Every analysis is `scale="multivariant"` and colors/groups by the `variant` hive-partition column mapped to a display name via the runner's `variant_metadata` int→name map.

| analysis | what it plots | color-by-variant |
|---|---|---|
| `growth_overlay` | `cell_mass` & `instantaneous_growth_rate` vs time | one colored line per variant (overlay) |
| `doubling_time_grouped` | cap-immune `ln(2)/mean(mu)` doubling time (PR #184) | grouped box per variant |
| `mass_fraction_grouped` | protein/rRNA/tRNA/DNA/small-mol fractions | grouped bars × variant |
| `replication_overlay` | `number_of_oric` (+ `critical_mass_per_oric` when emitted) vs time | colored line per variant (dnaA-2x) |
| `proteome_delta` | per-variant `monomer_counts` ratio-vs-baseline scatter + per-variant Schmidt/Wisniewski r | colored series per variant |
| `fba_flux_overlay` | per-variant Toya-2010 r + central-carbon flux Δ-vs-baseline bars | colored series + r table per variant (media) |
| `regulation_overlay` | `ppgpp_conc` & `fraction_trna_charged` vs time | colored line per variant (ppGpp collapses for ppgpp-off) |
| `scorecard` | variants × (doubling time, dry mass, protein fraction, max oriC, mean ppGpp, Toya r, Schmidt r) | heatmap rows = variants, Δ-vs-baseline coloring |

Shared helpers in `analyses/_helpers.py`: `variant_label_map` / `variant_display_expr` / `variant_sort_order` (extract the int→name map ignoring config keys, build a DuckDB `CASE` label expr with fallback + quote-escaping, stable ascending sort). Overlay charts use safe `metric_N` SQL aliases (Vega-Lite shorthand mis-parses `(`/`[` in field names → vl_convert PNG export fails) and `cast_decimals` (Altair can't serialize DuckDB `DECIMAL`). All analyses degrade gracefully when `validation_data` or a metric column is absent.

## Harness

`scripts/render_variant_comparison.py` — generalized PNG/SVG/HTML export harness that iterates the eight analyses over a multivariant sweep, passing a real `variant_metadata={0:baseline,1:ppgpp-off,2:dnaA-2x,3:elong-down,4:media}`. For local read-path testing on single-variant data it can `--synthesize-variants N` (duplicate `variant=0` into perturbed `variant=1..N` partitions — not science, only exercises the color/group/delta code).

## Test evidence

Tested against the showcase-2 clean 3-gen run (`out/workflow/simData.cPickle` pairs: 4309 monomers / 2820 base reactions; `validation_data.reactionFlux` present):
- **8/8** render non-empty Altair views + PNGs on a synthesized 5-variant sweep
- **8/8** on the single-variant sweep (proteome_delta falls back to baseline self-histogram; fba/scorecard handle one variant)
- **8/8** with `validation_data=None` (Toya/Schmidt columns omitted, `has_validation=False`)
- `tests/test_variant_comparison_analyses.py`: 10 tests (registration + scale, helpers, 2-variant non-empty render, ppGpp-off separation) pass; existing analysis suite (20 tests) unaffected.

## Honesty note

The committed code is fully exercised, but **the figures are only scientifically meaningful on the real 5-variant sweep** — the local tests run on synthesized/duplicated variants (perturbed copies of baseline), so the cross-variant *differences* shown here are synthetic. The parent should render the real figures via `scripts/render_variant_comparison.py --sweep <real 5-variant sweep>` once it finishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)