### PR TITLE
fix(ci): publish-reports waits for domcontentloaded, not networkidle

### DIFF
--- a/scripts/publish_investigation_reports.py
+++ b/scripts/publish_investigation_reports.py
@@ -138,7 +138,12 @@ def export_report(page, base_url: str, slug: str, out_path: Path,
     promise with the HTML and surface any rejection. Failures return in seconds
     with the real error (e.g. a study 404).
     """
-    page.goto(base_url, wait_until="networkidle", timeout=45_000)
+    # Use "domcontentloaded", NOT "networkidle": the dashboard SPA fires
+    # background /api/* calls (the build_core registry subprocess, the live
+    # git-status poll) that may never go idle within the timeout under CI —
+    # which made every report fail with a goto timeout. Readiness is gated
+    # precisely by the wait_for_function below instead.
+    page.goto(base_url, wait_until="domcontentloaded", timeout=45_000)
     page.wait_for_function(
         "typeof window._generateInvestigationReport === 'function' "
         "&& typeof window._openInvestigationDetail === 'function'",


### PR DESCRIPTION
## Problem
The first real run of the auto-publish workflow (on main, after #190) failed: **all 4 investigation reports hit `Page.goto: Timeout 45000ms exceeded`** → 0/4 published.

## Cause
`page.goto(..., wait_until="networkidle")` never resolves under CI — the dashboard SPA fires background `/api/*` calls (the `build_core` registry subprocess, the live git-status poll) that don't let the network go idle within the timeout. Locally it happened to settle; CI is stricter.

## Fix
Wait for `domcontentloaded` instead, and let the existing `wait_for_function` (which already waits up to 30s for `_generateInvestigationReport`/`_openInvestigationDetail`) gate SPA readiness precisely.

## Safety
The failed run published **nothing** (0/4) and the gh-pages copy step only ever adds files, so existing published reports were never touched. Validated locally: colonies + v2ecoli-pdmp still regenerate with full figure embeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)