### PR TITLE
fix(ci): never publish an investigation report that fails validation

### DIFF
--- a/scripts/publish_investigation_reports.py
+++ b/scripts/publish_investigation_reports.py
@@ -183,16 +183,23 @@ def export_report(page, base_url: str, slug: str, out_path: Path,
     if state["download"] is None:
         return False, "no report produced within 120s"
 
-    out_path.parent.mkdir(parents=True, exist_ok=True)
-    state["download"].save_as(out_path)
-    html = out_path.read_text(encoding="utf-8", errors="replace")
+    # Validate BEFORE writing out_path. The gh-pages copy step publishes every
+    # file under the output dir, so writing an invalid report here would
+    # OVERWRITE a previously-good published copy with a stripped one (exactly
+    # what happened on the first real run: the pinned CI dashboard generated the
+    # pdmp report with zero figure embeds, and it clobbered the good gh-pages
+    # version). Read from Playwright's temp download and only save_as on success,
+    # so a failed report leaves no file → the copy step preserves the last-good.
+    html = Path(state["download"].path()).read_text(encoding="utf-8", errors="replace")
     size = len(html)
     embeds = html.count("<iframe") + html.count("srcdoc") + html.count("data:image")
     if size < MIN_REPORT_BYTES:
-        return False, f"report too small ({size} B < {MIN_REPORT_BYTES})"
+        return False, f"report too small ({size} B < {MIN_REPORT_BYTES}); not published"
     if expect_figures and embeds == 0:
         return False, (f"{size} B but ZERO figure embeds while studies reference "
-                       f"figures — report was silently stripped")
+                       f"figures — report stripped; not published (kept last-good)")
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    state["download"].save_as(out_path)
     return True, f"{size:,} B, {embeds} embed-markers"
 
 


### PR DESCRIPTION
## Problem
The first real auto-publish run generated the **v2ecoli-pdmp** report with **zero figure embeds** (94KB) under the pinned CI dashboard. Because `export_report` wrote the file *before* validating, the gh-pages copy step published that stripped report, **clobbering the good 9.6MB version**. (gh-pages already restored manually in `2289f50`.)

## Fix
Validate the captured Playwright download (size + figure-embed presence) **before** writing `out_path`. A report that fails validation now leaves **no file**, so the additive gh-pages copy step preserves the last-good published version. The job still exits non-zero to surface the failure for follow-up.

## Not in scope (separate follow-up)
The root cause of the empty pdmp report — the **pinned vivarium-dashboard doesn't embed pdmp's figures** while the editable `vivarium-dashboard-serve` build does (figures are committed and present in CI) — is a dashboard-version issue tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)