### PR TITLE
fix(baseline): deep-copy initial_state so a reused bundle isolates samples

### DIFF
--- a/v2ecoli/composites/baseline.py
+++ b/v2ecoli/composites/baseline.py
@@ -578,7 +578,15 @@ def baseline(
 
     if bundle is None:
         bundle = load_cache_bundle(cache_dir)
-    initial_state = bundle["initial_state"]
+    # Deep-copy initial_state: a reused bundle (e.g. one load_cache_bundle()
+    # shared across many baseline() calls, as in parameter sweeps / UQ ensembles)
+    # otherwise hands every composite the SAME initial_state arrays. v2ecoli's
+    # in-place bulk arrays then mutate that shared state during run(), so each
+    # subsequent build resumes from the previous run's advanced state (mass
+    # accumulates across samples, eventually triggering a spurious mid-run
+    # division). configs is already deep-copied below for the same reason —
+    # initial_state needs the same isolation.
+    initial_state = copy.deepcopy(bundle["initial_state"])
     configs = bundle["configs"]
     if config_overrides:
         # Deep-copy before patching: load_cache_bundle returns the cache dict


### PR DESCRIPTION
## The bug

`baseline()` deep-copies `configs` before applying `config_overrides` (so overrides don't corrupt the `lru_cache`-shared cache dict), but took **`initial_state` by reference**:

```python
initial_state = bundle["initial_state"]   # <-- shared across all callers of this bundle
...
configs = copy.deepcopy(configs)          # configs IS isolated
```

When a caller reuses **one** `load_cache_bundle()` across many `baseline()` calls — the natural pattern for parameter sweeps and UQ ensembles — every composite received the **same** `initial_state` arrays. v2ecoli's in-place bulk arrays then mutate that shared state during `run()`, so each subsequent sample **resumed from the previous run's advanced state**.

## Symptom (evidence)

Same `config_overrides` every sample, reusing one bundle:

| | dry_mass |
|---|---|
| shared `initial_state` (current) | 382.68 → 383.80 → 386.58 → 389.86 → 393.76 … (climbs) |
| deep-copied `initial_state` (this PR) | 382.68 → 382.68 → 382.68 → 382.68 → 382.68 (constant ✓) |

The accumulated mass eventually (~58 reuses) pushes the cell over its **division threshold mid-run**, producing a 2-agent state that the single-agent XArray-emitter view can't write → `ValueError: shape mismatch: value array of shape (2,2) could not be broadcast to indexing result of shape (0,2)`, after which the run yields zero observables.

## The fix

One line — mirror the existing `configs` isolation for `initial_state`:

```python
initial_state = copy.deepcopy(bundle["initial_state"])
```

Reproduced and verified via a forward-UQ ensemble (pbg-uq) over the baseline composite; with the deep-copy, identical params → identical output and samples are independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)