### PR TITLE
fix(deps): bump vivarium-dashboard pin to restore figure embeds

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -4220,7 +4220,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/3e/87/794e0b4c5dccbca30
 [[package]]
 name = "vivarium-dashboard"
 version = "0.1.0"
-source = { git = "https://github.com/vivarium-collective/vivarium-dashboard.git?branch=main#c929e75705f32a53f713506c871e704bab678781" }
+source = { git = "https://github.com/vivarium-collective/vivarium-dashboard.git?branch=main#a5f33925a3c873953dfa0080cce80685fbff7e99" }
 dependencies = [
     { name = "bigraph-loom" },
     { name = "bigraph-schema" },


### PR DESCRIPTION
## Root cause (reproduced)
The auto-publish workflow generated the **v2ecoli-pdmp** report with **zero figure embeds** in CI. Root-caused by serving the workspace with the pinned dashboard (`c929e757`) locally: its `/api/study/<name>` returns **0 `embed_visualizations`** (the figure auto-discovery/merge into the study spec was fixed in a later commit). Current main (`1ed0f1a`) returns the full set → 149 embeds. The figures themselves serve fine (HTTP 200) on both; the old spec just had nothing to embed.

## Fix
Bump the pinned `vivarium-dashboard` from `c929e757` → `a5f33925` (current main, which includes the embed-population fix). Only `uv.lock` changes.

## Verification
The publish-reports workflow runs on merge and will regenerate all four reports — pdmp should now publish with full embeds. (With #193's no-regress guard, if anything still fails it preserves the last-good report rather than clobbering it.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)