### PR TITLE
feat(ci): auto-list every published investigation on the landing page

### DIFF
--- a/.github/workflows/publish-reports.yml
+++ b/.github/workflows/publish-reports.yml
@@ -88,12 +88,32 @@ jobs:
           git worktree add /tmp/ghp gh-pages
           mkdir -p /tmp/ghp/investigations
           cp reports/published/investigations/*.html /tmp/ghp/investigations/
+          # Regenerate the landing-page investigation list (between the
+          # auto-investigations markers in index.html) so the root gallery lists
+          # every investigation with a published report — no hand-curation.
+          frag="$PWD/reports/published/investigations_index.html"
+          if [ -f "$frag" ] && [ -f /tmp/ghp/index.html ]; then
+            python3 - "$frag" /tmp/ghp/index.html <<'PY'
+import pathlib, sys
+frag = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8").strip()
+idx = pathlib.Path(sys.argv[2])
+html = idx.read_text(encoding="utf-8")
+begin_tag, end_tag = "<!-- BEGIN auto-investigations", "<!-- END auto-investigations -->"
+b, e = html.find(begin_tag), html.find(end_tag)
+if b != -1 and e != -1:
+    b_close = html.find("-->", b) + 3
+    idx.write_text(html[:b_close] + "\n" + frag + "\n" + html[e:], encoding="utf-8")
+    print("index.html investigation list regenerated")
+else:
+    print("auto-investigations markers not found; index.html left unchanged")
+PY
+          fi
           cd /tmp/ghp
-          git add investigations/*.html
+          git add investigations/*.html index.html
           if git diff --cached --quiet; then
             echo "no report content changed; skipping commit"
           else
-            git commit -m "gh-pages: republish investigation reports (automated, ${GITHUB_SHA::7})"
+            git commit -m "gh-pages: republish investigation reports + landing list (automated, ${GITHUB_SHA::7})"
             git push origin gh-pages
             echo "published $(ls investigations/*.html | wc -l) investigation reports"
           fi

--- a/.github/workflows/publish-reports.yml
+++ b/.github/workflows/publish-reports.yml
@@ -91,23 +91,8 @@ jobs:
           # Regenerate the landing-page investigation list (between the
           # auto-investigations markers in index.html) so the root gallery lists
           # every investigation with a published report — no hand-curation.
-          frag="$PWD/reports/published/investigations_index.html"
-          if [ -f "$frag" ] && [ -f /tmp/ghp/index.html ]; then
-            python3 - "$frag" /tmp/ghp/index.html <<'PY'
-import pathlib, sys
-frag = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8").strip()
-idx = pathlib.Path(sys.argv[2])
-html = idx.read_text(encoding="utf-8")
-begin_tag, end_tag = "<!-- BEGIN auto-investigations", "<!-- END auto-investigations -->"
-b, e = html.find(begin_tag), html.find(end_tag)
-if b != -1 and e != -1:
-    b_close = html.find("-->", b) + 3
-    idx.write_text(html[:b_close] + "\n" + frag + "\n" + html[e:], encoding="utf-8")
-    print("index.html investigation list regenerated")
-else:
-    print("auto-investigations markers not found; index.html left unchanged")
-PY
-          fi
+          python3 scripts/inject_index_fragment.py \
+            reports/published/investigations_index.html /tmp/ghp/index.html
           cd /tmp/ghp
           git add investigations/*.html index.html
           if git diff --cached --quiet; then

--- a/scripts/inject_index_fragment.py
+++ b/scripts/inject_index_fragment.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Inject the auto-generated investigation list into the gh-pages landing page.
+
+Replaces the content between the ``auto-investigations`` HTML markers in
+``index.html`` with the fragment produced by
+``publish_investigation_reports.py`` (``investigations_index.html``). Leaves the
+file untouched if the markers are absent.
+
+Usage: inject_index_fragment.py <fragment.html> <index.html>
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+BEGIN = "<!-- BEGIN auto-investigations"
+END = "<!-- END auto-investigations -->"
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print("usage: inject_index_fragment.py <fragment.html> <index.html>",
+              file=sys.stderr)
+        return 2
+    frag_path, index_path = Path(sys.argv[1]), Path(sys.argv[2])
+    if not frag_path.is_file() or not index_path.is_file():
+        print("fragment or index missing; nothing to inject")
+        return 0
+    fragment = frag_path.read_text(encoding="utf-8").strip()
+    html = index_path.read_text(encoding="utf-8")
+    begin, end = html.find(BEGIN), html.find(END)
+    if begin == -1 or end == -1:
+        print("auto-investigations markers not found; index.html left unchanged")
+        return 0
+    begin_close = html.find("-->", begin) + 3
+    new_html = html[:begin_close] + "\n" + fragment + "\n" + html[end:]
+    index_path.write_text(new_html, encoding="utf-8")
+    print("index.html investigation list regenerated")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/publish_investigation_reports.py
+++ b/scripts/publish_investigation_reports.py
@@ -57,6 +57,59 @@ def discover_investigations(ws_root: Path) -> list[str]:
     )
 
 
+def _load_investigation_yaml(ws_root: Path, slug: str) -> dict:
+    """Read an investigation's investigation.yaml (nested or flat layout)."""
+    for base in (ws_root / "workspace" / "investigations", ws_root / "investigations"):
+        p = base / slug / "investigation.yaml"
+        if p.is_file():
+            return yaml.safe_load(p.read_text(encoding="utf-8")) or {}
+    return {}
+
+
+def build_index_fragment(ws_root: Path, slugs: list[str]) -> str:
+    """Build the ``<div class="invest">`` blocks for the gh-pages landing page.
+
+    Generated from each investigation.yaml (title, status, a short description,
+    study list) so the root gallery lists EVERY investigation that has a
+    published report — no hand-curation. Injected between the
+    ``auto-investigations`` markers in ``index.html`` by the publish workflow.
+    """
+    import html as _h
+
+    blocks: list[str] = []
+    for slug in slugs:
+        spec = _load_investigation_yaml(ws_root, slug)
+        title = str(spec.get("title") or slug)
+        status_raw = str(spec.get("status") or "").strip()
+        status_label = status_raw.replace("_", " ") or "—"
+        status_class = status_raw or "in_progress"
+
+        # Description: prefer executive.what_is_this, else the question; collapse
+        # whitespace and truncate so the gallery card stays compact.
+        execu = spec.get("executive") if isinstance(spec.get("executive"), dict) else {}
+        desc = str(execu.get("what_is_this") or spec.get("question") or "").strip()
+        desc = " ".join(desc.split())
+        if len(desc) > 300:
+            desc = desc[:297].rstrip() + "…"
+
+        studies = [s.get("name") if isinstance(s, dict) else s
+                   for s in (spec.get("studies") or [])]
+        studies = [str(s) for s in studies if s]
+        meta = f"{len(studies)} stud{'y' if len(studies) == 1 else 'ies'}"
+        if 0 < len(studies) <= 4:
+            meta += " · " + " · ".join(studies)
+
+        blocks.append(
+            '<div class="invest">\n'
+            f'  <h3><a href="investigations/{_h.escape(slug)}.html">{_h.escape(title)}</a>\n'
+            f'      <span class="pill {_h.escape(status_class)}">{_h.escape(status_label)}</span></h3>\n'
+            f'  <p>{_h.escape(desc)}</p>\n'
+            f'  <p class="meta">{_h.escape(meta)}</p>\n'
+            '</div>'
+        )
+    return "\n\n".join(blocks)
+
+
 def study_figure_count(ws_root: Path, slug: str) -> int:
     """How many figure HTMLs the investigation's studies reference on disk.
 
@@ -258,6 +311,16 @@ def main() -> int:
                 proc.wait(timeout=10)
             except subprocess.TimeoutExpired:
                 proc.kill()
+
+    # Regenerate the landing-page investigation list from ALL discovered
+    # investigations (not just this run's --only subset), so the gh-pages root
+    # gallery always lists every investigation with a published report.
+    all_slugs = discover_investigations(ws_root)
+    fragment = build_index_fragment(ws_root, all_slugs)
+    index_fragment_path = out_dir / "investigations_index.html"
+    index_fragment_path.write_text(fragment + "\n", encoding="utf-8")
+    print(f"wrote landing-page fragment ({len(all_slugs)} investigations) to "
+          f"{index_fragment_path}")
 
     failed = [s for s, (ok, _) in results.items() if not ok]
     print(f"\n{len(results) - len(failed)}/{len(results)} reports published to "


### PR DESCRIPTION
## Summary
The gh-pages root landing page (`index.html`) had a **hand-maintained** "📑 Investigation reports" list, so newly published reports (units-atlas, ketchup) existed at `investigations/<slug>.html` but were never linked from the root — you'd see them only by direct URL. This makes that list **auto-regenerate** on every publish, so every investigation with a published report appears automatically.

- `publish_investigation_reports.py` now emits `reports/published/investigations_index.html` — one `<div class="invest">` card per discovered investigation (title, status pill, short description, study list), built from each `investigation.yaml`. Uses **all** discovered investigations (not just the `--only` subset), since failed ones keep their last-good published report.
- `scripts/inject_index_fragment.py` replaces the content between the `<!-- BEGIN/END auto-investigations -->` markers in `index.html` with that fragment (no-op if markers absent).
- `publish-reports.yml` calls the injector after copying reports and commits `index.html` alongside them.
- The markers were added to the live gh-pages `index.html` (which already lists all 5 investigations as of this change).

Net: the original "automatically show all published investigation reports" requirement is now fully closed — discovery → report render → landing-page link are all automatic on push to main.

## Test Plan
- [x] `publish-reports.yml` parses as valid YAML; both scripts compile.
- [x] `build_index_fragment` discovers all 5 investigations and links each `investigations/<slug>.html`.
- [x] `inject_index_fragment.py` regenerates the marked block end-to-end against the live `index.html` (units-atlas + ketchup present).
- [ ] After merge: a publish run rewrites the landing-page list automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)