### PR TITLE
fix(ci): build dashboard inside activated venv, not `uv run`

### DIFF
--- a/.github/workflows/publish-dashboard.yml
+++ b/.github/workflows/publish-dashboard.yml
@@ -63,7 +63,14 @@ jobs:
       - name: Build dashboard snapshot
         # Builds the static SPA bundle (all investigations + studies) and strips
         # bigraph-loom source maps. No sim run / ParCa cache needed.
-        run: uv run scripts/publish_dashboard.sh reports/published/dashboard
+        #
+        # Run inside the activated venv rather than via `uv run`: `uv run`
+        # re-syncs the env to uv.lock first, which would UNDO the previous step's
+        # ad-hoc install of vivarium-dashboard@main and drop the
+        # `vivarium-dashboard-publish` console script (-> exit 127).
+        run: |
+          source .venv/bin/activate
+          bash scripts/publish_dashboard.sh reports/published/dashboard
 
       - name: Publish to gh-pages
         # Surgical: replace ONLY dashboard/ on gh-pages via a worktree. Never


### PR DESCRIPTION
The `publish-dashboard.yml` build step (added in #196) failed with **exit 127**: `vivarium-dashboard-publish: command not found`.

**Cause:** `uv run` re-syncs the project env to `uv.lock` before executing, which undid the previous step's ad-hoc `uv pip install vivarium-dashboard@main` and dropped the `vivarium-dashboard-publish` console script. (The lock pins a dashboard commit predating the publish CLI, so the upgrade is required.)

**Fix:** `source .venv/bin/activate` and run the script directly — no `uv run` re-sync, so the upgraded dashboard (and its console script) survives.

**Validated:** dispatched `publish-dashboard.yml` on this branch via workflow_dispatch — the full job passed end-to-end (Build ✓, Publish to gh-pages ✓), republishing the dashboard from main with all 5 investigations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)