### PR TITLE
feat(dashboard): ecoli-sources page, registry scope, navigable parca composite

### DIFF
--- a/v2ecoli/composites/parca.py
+++ b/v2ecoli/composites/parca.py
@@ -103,4 +103,9 @@ def parca(core: Any = None, *, debug: bool = False, cpus: int = 1,
     """
     if core is not None:
         register_parca_core(core)
-    return {"state": build_parca_document(debug=debug, cpus=cpus, cache_dir=cache_dir)}
+    # include_store_skeleton=True so the dashboard explorer renders the 9 steps
+    # as a connected pipeline (empty store nodes give loom layout anchors)
+    # rather than collapsing them onto the origin. The committed models/parca.pbg
+    # stays steps-only (build_parca_document default).
+    return {"state": build_parca_document(
+        debug=debug, cpus=cpus, cache_dir=cache_dir, include_store_skeleton=True)}

--- a/v2ecoli/dashboard_sources.py
+++ b/v2ecoli/dashboard_sources.py
@@ -1,0 +1,115 @@
+"""Dashboard data-source provider: the ecoli-sources bundle, with links.
+
+Surfaces every canonical "ecoli-source" v2ecoli draws on (the ParCa/reconstruction
+input bundle) on the dashboard's **Sources** page, each with a hyperlink:
+
+* inherited files  -> the pinned ``ecoli-sources`` GitHub commit
+  (``raw.githubusercontent.com/...``)
+* v2ecoli overrides (diverged locally under ``flat_overrides/``) -> a GitHub
+  blob link into this repo.
+
+Wired via ``workspace.yaml``::
+
+    dashboard:
+      data_sources:
+        provider: "v2ecoli.dashboard_sources:enumerate_sources"
+        label: "ecoli-sources"
+
+The dashboard server calls ``enumerate_sources()`` (no args) and renders each
+entry's ``url`` as a link — the only access path that works in the published
+read-only snapshot. Link logic mirrors ``reports/ecoli_sources_report.py``.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_PYPROJECT = _REPO_ROOT / "pyproject.toml"
+_ECOLI_SOURCES_RAW_BASE = (
+    "https://raw.githubusercontent.com/vivarium-collective/ecoli-sources"
+)
+_V2ECOLI_BLOB_BASE = "https://github.com/vivarium-collective/v2ecoli/blob/main"
+
+
+def _ecoli_sources_rev() -> str | None:
+    """Pinned ``rev`` SHA for ecoli-sources from ``[tool.uv.sources]``.
+
+    Returns None if pinned to a branch (no ``rev``) — then inherited files get
+    no link (raw URLs only resolve against an immutable commit).
+    """
+    try:
+        try:
+            import tomllib  # py3.11+
+        except ModuleNotFoundError:  # pragma: no cover
+            import tomli as tomllib  # type: ignore
+        with open(_PYPROJECT, "rb") as f:
+            data = tomllib.load(f)
+        src = (data.get("tool", {}).get("uv", {})
+               .get("sources", {}).get("ecoli-sources", {}))
+        rev = src.get("rev") if isinstance(src, dict) else None
+        return str(rev) if rev else None
+    except Exception:
+        return None
+
+
+def _category(key: str) -> str:
+    """Group key: the prefix before ``__`` (matches the standalone report)."""
+    parts = key.split("__")
+    return parts[0] if len(parts) > 1 else "root"
+
+
+def enumerate_sources() -> list[dict]:
+    """Return the ecoli-sources bundle as dashboard data-source entries.
+
+    Each entry: ``{key, path, category, kind, size_bytes, url}``. Never raises
+    (the dashboard wraps providers defensively, but we stay quiet regardless).
+    """
+    try:
+        from v2ecoli.processes.parca.reconstruction.ecoli.sources import SourceBundle
+        from ecoli_sources import DATA_DIR
+    except Exception:
+        return []
+
+    rev = _ecoli_sources_rev()
+    data_dir = Path(DATA_DIR).resolve()
+
+    def _raw_url(p: Path) -> str:
+        """Pinned GitHub raw URL for an inherited file (empty if unmappable)."""
+        if not rev:
+            return ""
+        try:
+            rel = p.resolve().relative_to(data_dir).as_posix()
+        except Exception:
+            return ""
+        return f"{_ECOLI_SOURCES_RAW_BASE}/{rev}/ecoli_sources/data/{rel}"
+
+    def _override_url(p: Path) -> str:
+        """GitHub blob link into this repo for a local override (empty if unmappable)."""
+        try:
+            rel = p.resolve().relative_to(_REPO_ROOT).as_posix()
+        except Exception:
+            return ""
+        return f"{_V2ECOLI_BLOB_BASE}/{rel}"
+
+    try:
+        index = SourceBundle()._index  # {canonical_key: Path}
+    except Exception:
+        return []
+
+    entries: list[dict] = []
+    for key, p in index.items():
+        is_override = "flat_overrides" in str(p)
+        try:
+            size = p.stat().st_size if p.exists() else 0
+        except Exception:
+            size = 0
+        entries.append({
+            "key": key,
+            "path": str(p),
+            "category": _category(key),
+            "kind": "override" if is_override else "inherited",
+            "size_bytes": size,
+            "url": _override_url(p) if is_override else _raw_url(p),
+        })
+    entries.sort(key=lambda e: (e["kind"] != "override", e["category"], e["key"]))
+    return entries

--- a/v2ecoli/processes/parca/composite.py
+++ b/v2ecoli/processes/parca/composite.py
@@ -171,13 +171,44 @@ def _build_step_slots(raw_data, debug, cpus, cache_dir, _elong):
     }
 
 
-def build_parca_document(debug=False, cpus=1, cache_dir=''):
+def _store_skeleton():
+    """Empty store nodes for every wire target in ``STORE_PATH``.
+
+    The 9 steps wire their ports to nested store paths (e.g.
+    ``['process','transcription']``, ``['mass']``, ``tick_0..tick_9``), but
+    those stores are normally only materialized when the pipeline runs. For a
+    STRUCTURAL document (serialization / the dashboard's composite explorer)
+    the stores are absent, so the viewer (bigraph-loom) sees zero store nodes
+    and skips process layout entirely — collapsing all 9 steps onto the origin
+    as one unreadable blob. Materializing the store skeleton as empty nodes
+    gives the layout anchors, so the steps render as a connected pipeline.
+    """
+    skeleton: dict = {}
+    for path in STORE_PATH.values():
+        cursor = skeleton
+        for seg in path[:-1]:
+            nxt = cursor.get(seg)
+            if not isinstance(nxt, dict):
+                nxt = cursor[seg] = {}
+            cursor = nxt
+        cursor.setdefault(path[-1], {})
+    return skeleton
+
+
+def build_parca_document(debug=False, cpus=1, cache_dir='',
+                         include_store_skeleton=False):
     """Return the parca composite spec state dict (steps + wiring, unfired).
 
     Use with ``v2ecoli.pbg.save_pbg_doc(...)`` to serialize the parca
     pipeline structure to a ``.pbg`` JSON document without running. The
     configs that vary per-run (raw_data, cache directories) are
     placeholders here — ``save_pbg_doc`` strips them out anyway.
+
+    ``include_store_skeleton``: when True, prepend the empty store skeleton
+    (see ``_store_skeleton``) so the document renders as a navigable 9-step
+    graph in the dashboard explorer rather than collapsing to a single node.
+    Default False keeps the committed ``models/parca.pbg`` (and any other
+    steps-only consumer) unchanged.
     """
     _elong = dict(
         variable_elongation_transcription=True,
@@ -189,7 +220,13 @@ def build_parca_document(debug=False, cpus=1, cache_dir=''):
         raw_data=None, debug=debug, cpus=cpus,
         cache_dir=cache_dir, _elong=_elong,
     )
-    return {name: slots[name] for name in STEP_ORDER}
+    steps = {name: slots[name] for name in STEP_ORDER}
+    if include_store_skeleton:
+        # Store skeleton first (layout anchors), then the 9 step nodes. No key
+        # collisions: store roots ('process','mass','tick_*',…) are disjoint
+        # from step names ('initialize','final_adjustments',…).
+        return {**_store_skeleton(), **steps}
+    return steps
 
 
 def build_parca_composite(raw_data, debug=False, cpus=1,

--- a/workspace.yaml
+++ b/workspace.yaml
@@ -49,3 +49,16 @@ references_pdfs:
   sha256: 39b8c0eba221cd0d156180a66cb0747219a4a3464f9c2b7b40dac2be9bfe4b8e
 server:
   enabled: true
+dashboard:
+  # Registry tab: show ONLY this repo's own process/type classes. Without this
+  # the grid lists every installed pbg-* package's classes (pbg-cellpack, …)
+  # auto-registered by allocate_core(). Display-only allow-list by top-level
+  # package; discovery is unchanged.
+  registry:
+    include: [v2ecoli]
+  # Sources page: surface the ecoli-sources bundle (the ParCa/reconstruction
+  # input files) with links — inherited files link to the pinned ecoli-sources
+  # GitHub commit, local overrides to this repo. See v2ecoli/dashboard_sources.py.
+  data_sources:
+    provider: "v2ecoli.dashboard_sources:enumerate_sources"
+    label: "ecoli-sources"


### PR DESCRIPTION
Workspace side of three read-only-dashboard improvements from live review. Pairs with **vivarium-dashboard #227** (the SPA/publish changes: `url` rendering, committed composite-state, banner, base-path study links).

### Sources page — ecoli-sources with links
New `v2ecoli/dashboard_sources.py` provider surfaces all **135 ecoli-sources** (the ParCa/reconstruction input bundle) on the Sources page, each with a hyperlink — inherited files → the pinned `ecoli-sources` GitHub commit (`raw.githubusercontent.com`), the 3 local overrides → this repo. Wired via `workspace.yaml` `dashboard.data_sources`. Reuses the link logic from `reports/ecoli_sources_report.py`. (Links are the only access path that works in the static snapshot.)

### Registry tab — this repo only
`workspace.yaml` `dashboard.registry.include: [v2ecoli]` scopes the process grid to v2ecoli's own classes. Previously it listed every installed `pbg-*` package auto-registered by `allocate_core()` (pbg-cellpack, …). Verified: grid drops from a mixed set to **113 `v2ecoli` processes only**.

### Parca composite — navigable 9-step graph
The structural document emitted 9 steps but **no store nodes**, so bigraph-loom skipped process layout and collapsed all 9 steps onto the origin (the "one process + blob of port labels" bug). The generator now includes an empty **store skeleton** (`build_parca_document(include_store_skeleton=True)`) → the 9-step pipeline lays out as a connected graph (verified: 9 step-nodes + 34 store-roots). Default `build_parca_document()` is unchanged, so the committed `models/parca.pbg` and other steps-only consumers are untouched — all parca tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)