### PR TITLE
docs(readme): clarify dashboard + reports, separate the three output types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,10 @@
 # v2ecoli
 
-## 📊 Explore the [**v2ecoli Baseline Showcase**](https://vivarium-collective.github.io/v2ecoli/investigations/v2ecoli-baseline-showcase.html) — interactive investigation report
-
-> **[▶ Open the flagship report → vivarium-collective.github.io/v2ecoli/investigations/v2ecoli-baseline-showcase.html](https://vivarium-collective.github.io/v2ecoli/investigations/v2ecoli-baseline-showcase.html)**
->
-> A self-contained, interactive walk through the baseline whole-cell investigation:
-> **ParCa → baseline gallery → reviewer decisions**, with one-click feedback. This
-> is the best single starting point. Or browse the full
-> **[report gallery → vivarium-collective.github.io/v2ecoli/](https://vivarium-collective.github.io/v2ecoli/)**
-> (investigation reports, interactive model viewers, comparison benchmarks, and
-> technical docs).
+> **Explore in your browser — no install:**
+> &nbsp;🖥️ **[Interactive dashboard](https://vivarium-collective.github.io/v2ecoli/dashboard/)** (browse the whole workspace)
+> &nbsp;·&nbsp; 📊 **[Baseline Showcase report](https://vivarium-collective.github.io/v2ecoli/investigations/v2ecoli-baseline-showcase.html)** ⭐ (best starting point)
+> &nbsp;·&nbsp; 🗂️ **[Report gallery](https://vivarium-collective.github.io/v2ecoli/)**
+> — see **[Explore v2ecoli](#explore-v2ecoli)** for what each one is.
 
 **vEcoli, reimagined as a composable [process-bigraph](https://github.com/vivarium-collective/process-bigraph)
 model and a research workspace.** v2ecoli takes the Covert lab's whole-cell
@@ -24,143 +19,78 @@ Two things follow from that:
 
 - **Composition is a first-class operation.** Every process declares typed
   input/output ports, so building a model is wiring, not patching. A whole cell
-  is one `build_composite("baseline")` call; the `millard_fba_bridge_harness`
-  composite keeps that baseline FBA metabolism but pins its central-carbon flux to
-  the Millard 2017 kinetic ODE (the v2ecoli-pdmp investigation's kinetic-into-WCM
-  bridge); a colony embeds many cells through a
+  is one `build_composite("baseline")` call; a colony embeds many cells through a
   single bridge process; a kinetic-metabolism variant is a *different wiring of
-  the same parts*. Swapping a subsystem is a one-line change, not a fork.
+  the same parts* ([Architectures](#architectures)). Swapping a subsystem is a
+  one-line change, not a fork.
 - **The repository is a pbg research workspace.** Alongside the model code live
   **investigations** (a research question) and **studies** (the simulations that
   answer it) — browsable and runnable in the
   [vivarium-dashboard](https://github.com/vivarium-collective/vivarium-dashboard).
-  The current tree carries three investigations — `v2ecoli-baseline-showcase`,
-  `v2ecoli-pdmp`, and `colonies` — under `workspace/`, each publishing a
-  self-contained [investigation report](#all-investigation-reports--one-self-contained-report-per-research-question).
+  Investigations live under `workspace/investigations/` (baseline showcase,
+  PDMP, colonies, and more), each publishing a self-contained
+  [investigation report](#explore-v2ecoli).
   New science is added as a study, not a patch to a monolith.
 
-The biology stays faithful to upstream. v2ecoli reproduces vEcoli's cell-cycle
-trajectories from birth to division — across dry mass, mass composition
-(protein / RNA / DNA / water), bulk-molecule counts, and replication dynamics —
-not just a single endpoint. The
-[composite comparison](https://vivarium-collective.github.io/v2ecoli/composite_comparison.html)
-and [vEcoli-vs-v2ecoli](https://vivarium-collective.github.io/v2ecoli/v1_v2_comparison.html)
-reports lay the two engines side by side metric-by-metric. Through the full cell
-cycle the dry-mass trajectories track to within a fraction of a percent
-(707.2 fg vs 705.3 fg at division), with division timing of ~42 min in both.
+The biology stays faithful to upstream: v2ecoli reproduces vEcoli's cell-cycle
+trajectories from birth to division — dry mass, mass composition, bulk-molecule
+counts, and replication dynamics, not just a single endpoint — tracking dry mass
+to within a fraction of a percent through the full cell cycle, with ~42 min
+division timing in both ([Performance & validation](#performance--validation)).
+The ParCa is shipped **pre-computed**, so a fresh clone simulates end-to-end
+without the ~70 min knowledge-base rebuild.
 
-**Explore the model interactively:**
-[**🔬 the baseline whole-cell composite**](https://vivarium-collective.github.io/v2ecoli/baseline-viewer/)
-opens the full process/store wiring in an interactive
-[bigraph-loom](https://github.com/vivarium-collective/bigraph-loom) viewer — pan
-the bigraph, expand stores, and click any process for its formal `describe()`
-description (the mathematics it computes). Runs entirely in-browser from a static
-snapshot; no install.
-
-Under the hood, the biology is **17 biological process modules** plus 8
-listener/deriver steps (`v2ecoli/processes/`, `v2ecoli/steps/derivers/`); the
-partitioned baseline composite schedules these — after splitting some processes
-into requester/evolver halves and adding infrastructure steps — into ~45 steps
-per simulation tick. The Parameter Calculator (ParCa) is decomposed into nine
-process-bigraph Steps and ships pre-computed, so a fresh clone simulates
-end-to-end without the ~70 min knowledge-base rebuild.
-
-**New here?** Start with the [reports](#reports--interactive-viewers) just below —
-the flagship **[Baseline Showcase investigation report](https://vivarium-collective.github.io/v2ecoli/investigations/v2ecoli-baseline-showcase.html)**
-is the best single entry point. Then read in this order:
-[What v2ecoli is](#what-v2ecoli-is) → [Install](#install) →
+**New here?** Browse the published [dashboard and reports](#explore-v2ecoli)
+first, then read [What v2ecoli is](#what-v2ecoli-is) → [Install](#install) →
 [Quick start](#quick-start) →
-[The process-bigraph framework](#the-process-bigraph-framework) →
+[the framework](#the-process-bigraph-framework) →
 [Architectures](#architectures) →
-[running pipelines](#running-pipelines-multiseed--multigen--multivariant).
+[pipelines](#running-pipelines-multiseed--multigen--multivariant).
 
 ---
 
-## Reports & interactive viewers
+## Explore v2ecoli
 
-Everything v2ecoli produces is published as a self-contained HTML report, served
-from GitHub Pages root at
-**[vivarium-collective.github.io/v2ecoli](https://vivarium-collective.github.io/v2ecoli/)**.
-Start at the flagship investigation report; the model viewers, simulation
-results, and comparison benchmarks follow.
+Everything is published to GitHub Pages and runs in the browser — no install.
+There are **three** kinds of output, each from a different pipeline.
 
-### ⭐ Flagship — the Baseline Showcase investigation report
+### 🖥️ Interactive dashboard — *browse the whole workspace*
 
-> ## 📊 [**v2ecoli Baseline Showcase**](https://vivarium-collective.github.io/v2ecoli/investigations/v2ecoli-baseline-showcase.html) — interactive investigation report
->
-> **[▶ Open it → vivarium-collective.github.io/v2ecoli/investigations/v2ecoli-baseline-showcase.html](https://vivarium-collective.github.io/v2ecoli/investigations/v2ecoli-baseline-showcase.html)**
->
-> A self-contained, interactive walk through the baseline whole-cell
-> investigation: **ParCa → baseline gallery → reviewer decisions**, with
-> one-click feedback. The best single starting point for understanding what
-> v2ecoli is and what the cell does.
->
-> Browse every investigation, viewer, and benchmark from the
-> **[report gallery landing → vivarium-collective.github.io/v2ecoli/](https://vivarium-collective.github.io/v2ecoli/)**.
+**[→ vivarium-collective.github.io/v2ecoli/dashboard/](https://vivarium-collective.github.io/v2ecoli/dashboard/)**
 
-### All investigation reports — *one self-contained report per research question*
+A read-only snapshot of the v2ecoli workspace in the
+[vivarium-dashboard](https://github.com/vivarium-collective/vivarium-dashboard):
+investigations & studies, the process/type **registry**, navigable **composite**
+wiring graphs (`baseline`, `parca`), and the **sources** bundle. Auto-rebuilt
+from `main` on every push. For the full interactive version (authoring, running
+studies), clone and run `vivarium-dashboard serve` locally.
 
-Every investigation in `workspace/investigations/` publishes a self-contained,
-interactive report at `investigations/<slug>.html`. Each walks its research
-question end-to-end: overview → studies → figures → reviewer decisions.
+### 📊 Investigation reports — *one self-contained report per research question*
 
-| Investigation | Report | Research question |
-|---|---|---|
-| **Baseline Showcase** ⭐ | **[v2ecoli-baseline-showcase.html](https://vivarium-collective.github.io/v2ecoli/investigations/v2ecoli-baseline-showcase.html)** | Can v2ecoli rebuild the ParCa from raw ecoli-sources and reproduce the vEcoli baseline cell cycle? |
-| **PDMP reformulation** | **[v2ecoli-pdmp.html](https://vivarium-collective.github.io/v2ecoli/investigations/v2ecoli-pdmp.html)** | Can the hybrid whole-cell model be incrementally transformed into a piecewise-deterministic (PDMP) formulation — including the Millard kinetic-ODE → FBA flux bridge? |
-| **Colonies** | **[colonies.html](https://vivarium-collective.github.io/v2ecoli/investigations/colonies.html)** | How many whole-cell *E. coli* agents fit per HPC node, and at what per-cell wall-time? |
+Each investigation under `workspace/investigations/` auto-publishes a single,
+self-contained HTML report — overview → studies → figures → reviewer decisions —
+rebuilt from `main` on every push. **Start with the
+[Baseline Showcase ⭐](https://vivarium-collective.github.io/v2ecoli/investigations/v2ecoli-baseline-showcase.html)**,
+then browse the rest from the
+[report gallery](https://vivarium-collective.github.io/v2ecoli/) or interactively
+in the [dashboard](https://vivarium-collective.github.io/v2ecoli/dashboard/). Full
+list with research questions: **[docs/reports.md](docs/reports.md#2-investigation-reports-auto-generated)**.
 
-### Interactive model viewers — *explore the model in your browser*
+### 🔬 Model viewers & technical reports — *standalone HTML*
 
-The [**🔬 baseline whole-cell composite viewer**](https://vivarium-collective.github.io/v2ecoli/baseline-viewer/)
-opens the full process/store wiring in an interactive
-[bigraph-loom](https://github.com/vivarium-collective/bigraph-loom) viewer — pan
-the bigraph, expand stores, and click any process for its formal `describe()`
-description. Runs entirely in-browser; no install.
-
-| Report | Published | Generate locally |
-|---|---|---|
-| **[Baseline composite](https://vivarium-collective.github.io/v2ecoli/bigraph_baseline.html)** — processes, stores, wiring, port schemas (with units), and a formal equation for each process. Pan/zoom, expand store chips, toggle nodes. | `bigraph_baseline.html` | `scripts/viz_baseline_interactive.py` |
-| **[ParCa pipeline](https://vivarium-collective.github.io/v2ecoli/bigraph_parca.html)** — the nine-Step parameter calculator, same interactive viewer. | `bigraph_parca.html` | `scripts/viz_parca_interactive.py` |
-| **[ParCa network](https://vivarium-collective.github.io/v2ecoli/parca_network.html)** / **[Baseline network](https://vivarium-collective.github.io/v2ecoli/network_baseline.html)** — Cytoscape topology; click a process for ports, schema, docstring, math. | `parca_network.html`, `network_baseline.html` | `scripts/parca_network.py` |
-
-### Simulation result reports — *what the cell actually did*
-
-| Report | Published | Generate locally |
-|---|---|---|
-| **[Cell lifecycle](https://vivarium-collective.github.io/v2ecoli/workflow_report.html)** — one cell, mother → division → both daughters. | `workflow_report.html` | `reports/workflow_report.py` |
-| **[Multigeneration lineage](https://vivarium-collective.github.io/v2ecoli/multigeneration_report.html)** — N-generation single lineage, mass trajectories & fold-change. | `multigeneration_report.html` | `reports/multigeneration_report.py --generations 3` |
-| **[Colony](https://vivarium-collective.github.io/v2ecoli/colony_report.html)** — mixed colony with pymunk physics, growth & division, synced animations. | `colony_report.html` | `reports/colony_report.py --n-adder 9` |
-
-### Comparison & benchmark — *v2ecoli vs vEcoli*
-
-| Report | Published | Generate locally |
-|---|---|---|
-| **[v1 vs v2](https://vivarium-collective.github.io/v2ecoli/v1_v2_comparison.html)** — vEcoli 1.0 vs v2ecoli baseline: wall/sim time, dry mass, growth. | `v1_v2_comparison.html` | `reports/v1_v2_report.py` |
-| **[Composite comparison](https://vivarium-collective.github.io/v2ecoli/composite_comparison.html)** — any set of engines side-by-side (load/wall/sim, composition, sparklines). | `composite_comparison.html` | `reports/composite_comparison.py --engines baseline millard_pdmp_baseline` |
-| Benchmark — v2ecoli vs the vEcoli composite (local-only). | — | `reports/benchmark_report.py` |
-
-### Model structure & ParCa — *the math and the parameters*
-
-| Report | Published | Generate locally |
-|---|---|---|
-| **[Mathematical structure](https://vivarium-collective.github.io/v2ecoli/math_structure.html)** — every process's governing equations grouped by subsystem, the per-tick execution flow, and the partition→allocate→evolve contract. | `math_structure.html` | `reports/math_structure_report.py` |
-| **[ParCa workflow](https://vivarium-collective.github.io/v2ecoli/parca_workflow_report.html)** — the nine-Step run with per-step runtimes, port manifests, and raw-data stats. | `parca_workflow_report.html` | (ParCa pipeline) |
-
-> **Provenance banners.** PR-evidence reports (`scripts/pr_session_report.py`,
-> `scripts/sweep_report.py`) embed a self-describing header — ISO timestamp, git
-> SHA/branch, dirty-tree badge, last commit, host/OS/Python — so an HTML file
-> stays meaningful months later. Attach these to PRs that change biology; see
-> [AGENTS.md → Reports](AGENTS.md).
-
-Every report is generated by a script under `reports/` or `scripts/`; the
-published set is served from the gh-pages branch.
+Generated on demand by `reports/*.py` / `scripts/*.py` (committed under `docs/`):
+interactive [model-wiring viewers](https://vivarium-collective.github.io/v2ecoli/baseline-viewer/),
+[simulation-result reports](https://vivarium-collective.github.io/v2ecoli/workflow_report.html),
+[vEcoli comparisons](https://vivarium-collective.github.io/v2ecoli/v1_v2_comparison.html), and the
+[mathematical structure](https://vivarium-collective.github.io/v2ecoli/math_structure.html).
+Browse them from the **[report gallery](https://vivarium-collective.github.io/v2ecoli/)** —
+full list + how to regenerate each in **[docs/reports.md](docs/reports.md#3-standalone-html-reports)**.
 
 ---
 
 ## Contents
 
-- [Reports & interactive viewers](#reports--interactive-viewers)
+- [Explore v2ecoli](#explore-v2ecoli) — dashboard, investigation reports, HTML reports
 - [What v2ecoli is](#what-v2ecoli-is)
 - [Install](#install)
 - [Quick start](#quick-start)
@@ -200,9 +130,9 @@ What you get over upstream vEcoli:
   bigraph-schema JSON (no pickle in the save path).
 - **A research workspace.** The repo is a pbg workspace (`workspace.yaml`):
   biology sits next to **investigations** (a shared research question) and
-  **studies** (the runs that answer it), all browsable and runnable in the
-  vivarium-dashboard. The `colonies` and `v2ecoli-pdmp` investigations live in
-  `workspace/`. Manage them with the `pbg-investigation` / `pbg-study` skills.
+  **studies** (the runs that answer it) under `workspace/`, all browsable and
+  runnable in the vivarium-dashboard. Manage them with the `pbg-investigation` /
+  `pbg-study` skills.
 - **A decomposed ParCa.** The monolithic `fitSimData_1()` is broken into nine
   inspectable Steps, and the fitted `sim_data` is shipped pre-computed.
 - **Workflow pipelines.** Multiseed / multigeneration / multivariant sweeps are
@@ -473,19 +403,16 @@ Full path: `docs/generate_full_parca.md`.
 
 ## What changed since vEcoli
 
-**Engine & architecture**
+Beyond the headline changes in [What v2ecoli is](#what-v2ecoli-is) (no
+`vivarium-core`, composition over configuration, typed/serializable state, a
+decomposed pre-computed ParCa), the architecture-level specifics are:
 
-- **No `vivarium-core`.** The model is a process-bigraph state document run by
-  the process-bigraph engine.
 - **Partitioned scheduling** (`v2ecoli/steps/partition.py`, `allocator.py`):
   contended processes split into a *requester* (declares demand) and an
   *evolver* (acts on the allocation), coordinated by an allocator — the
   vEcoli-parity execution order, made explicit in the composite.
 - **`EcoliWCM` bridge** (`v2ecoli/bridge.py`) wraps a whole cell as a single
-  process so many cells compose into a colony.
-- **ParCa decomposed** into nine inspectable Steps and shipped pre-computed.
-- **Typed, serializable state** — bigraph-schema types with units; save states
-  round-trip through JSON (no pickle outside the ParCa cache).
+  process so many cells compose into a colony ([Architectures](#architectures)).
 
 **Biology — process inventory (ground truth)**
 
@@ -511,11 +438,8 @@ restructuring: polypeptide elongation's old strategy-pattern variants
   (DnaA-box catalog at `v2ecoli/data/dnaa_box_catalog.py`), on an investigation
   branch, not yet on `main`.
 
-**Parity.** At 60 s, v2ecoli's dry mass is 384.6 fg vs vEcoli's 384.5 fg
-(0.0 % drift), and time-to-division matches at ~42 min — see the
-[v1 vs v2](https://vivarium-collective.github.io/v2ecoli/v1_v2_comparison.html)
-and [composite comparison](https://vivarium-collective.github.io/v2ecoli/composite_comparison.html)
-reports.
+**Parity.** v2ecoli matches vEcoli observable-by-observable through the full
+cell cycle — see [Performance & validation](#performance--validation).
 
 ---
 

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -1,0 +1,117 @@
+# Published outputs: dashboard, investigation reports, and HTML reports
+
+Everything v2ecoli publishes is served from GitHub Pages at
+**[vivarium-collective.github.io/v2ecoli](https://vivarium-collective.github.io/v2ecoli/)**
+and runs in the browser with no install. There are **three** kinds of output,
+each produced by a different pipeline.
+
+| Output | Where it's served | How it's published |
+|---|---|---|
+| **[Interactive dashboard](#1-the-interactive-dashboard)** | `/dashboard/` | Static snapshot of the workspace SPA, auto-rebuilt from `main` (`.github/workflows/publish-dashboard.yml`) |
+| **[Investigation reports](#2-investigation-reports-auto-generated)** | `/investigations/<slug>.html` (one per investigation) | Auto-rebuilt from `main` (`.github/workflows/publish-reports.yml`) |
+| **[Standalone HTML reports](#3-standalone-html-reports)** | gallery root — `/<name>.html` | Generated on demand by `reports/*.py` / `scripts/*.py`, committed under `docs/` |
+
+The [report gallery landing page](https://vivarium-collective.github.io/v2ecoli/)
+links into all three.
+
+---
+
+## 1. The interactive dashboard
+
+**[→ vivarium-collective.github.io/v2ecoli/dashboard/](https://vivarium-collective.github.io/v2ecoli/dashboard/)**
+
+A **read-only** snapshot of the v2ecoli workspace rendered by the
+[vivarium-dashboard](https://github.com/vivarium-collective/vivarium-dashboard)
+SPA. Browse:
+
+- **Investigations & studies** — the research questions and the runs that answer
+  them, with verdicts and figures.
+- **Registry** — the Processes, Steps, Emitters, and Types this workspace
+  registers (scoped to v2ecoli + its installed modules).
+- **Composites** — navigable process/store wiring graphs (e.g. `baseline`,
+  `parca`) via the embedded [bigraph-loom](https://github.com/vivarium-collective/bigraph-loom) viewer.
+- **Sources** — the ecoli-sources input bundle, each with a link.
+
+**How it's built.** `vivarium-dashboard-publish` exports the workspace into a
+self-contained static bundle (per-resource JSON + page shells + assets) that any
+static server can host. The `publish-dashboard.yml` workflow rebuilds it from
+`main` and publishes it to `gh-pages:dashboard/`.
+
+> The hosted version is **view-only**. For the full interactive dashboard —
+> authoring investigations, running studies, editing wiring — clone the repo and
+> run `vivarium-dashboard serve` locally (see the
+> [vivarium-dashboard README](https://github.com/vivarium-collective/vivarium-dashboard#readme)).
+
+---
+
+## 2. Investigation reports (auto-generated)
+
+Each investigation under `workspace/investigations/<slug>/` (any with an
+`investigation.yaml`) publishes a single, **self-contained** interactive HTML
+report — overview → studies → figures → reviewer decisions — at
+`investigations/<slug>.html`.
+
+**How it's built.** The report is rendered **client-side** by the dashboard SPA
+(`_generateInvestigationReport`), embedding each study's figures inline. The
+`publish-reports.yml` workflow drives that generator headlessly (Playwright) and
+publishes the result to `gh-pages:investigations/` on every push to `main`.
+
+| Investigation | Report | Research question |
+|---|---|---|
+| **Baseline Showcase** ⭐ | [v2ecoli-baseline-showcase.html](https://vivarium-collective.github.io/v2ecoli/investigations/v2ecoli-baseline-showcase.html) | Can v2ecoli rebuild the ParCa from raw ecoli-sources and reproduce the vEcoli baseline cell cycle? |
+| **PDMP reformulation** | [v2ecoli-pdmp.html](https://vivarium-collective.github.io/v2ecoli/investigations/v2ecoli-pdmp.html) | Can the hybrid WCM be incrementally transformed into a piecewise-deterministic (PDMP) formulation, incl. the Millard kinetic-ODE → FBA flux bridge? |
+| **Colonies** | [colonies.html](https://vivarium-collective.github.io/v2ecoli/investigations/colonies.html) | How many whole-cell *E. coli* agents fit per HPC node, and at what per-cell wall-time? |
+| **KETCHUP baseline comparison** | [ketchup-baseline-comparison.html](https://vivarium-collective.github.io/v2ecoli/investigations/ketchup-baseline-comparison.html) | Does the baseline central-carbon exchange match the KETCHUP core-metabolism kinetic models? |
+| **Parameter UQ** | [parameter-uq.html](https://vivarium-collective.github.io/v2ecoli/investigations/parameter-uq.html) | Forward uncertainty quantification — which parameters drive growth-rate variance? |
+| **Units Atlas** | [units-atlas.html](https://vivarium-collective.github.io/v2ecoli/investigations/units-atlas.html) | A units-aware readout inventory across the model's ports. |
+
+---
+
+## 3. Standalone HTML reports
+
+Generated on demand by a script under `reports/` or `scripts/`, committed under
+`docs/`, and served at the gallery root. Each writes a self-contained HTML file.
+
+### Interactive model viewers — *explore the model in your browser*
+
+The [**baseline whole-cell composite viewer**](https://vivarium-collective.github.io/v2ecoli/baseline-viewer/)
+opens the full process/store wiring in an interactive
+[bigraph-loom](https://github.com/vivarium-collective/bigraph-loom) viewer — pan
+the bigraph, expand stores, click any process for its formal `describe()`
+description. Runs entirely in-browser.
+
+| Report | Published | Generate locally |
+|---|---|---|
+| [Baseline composite](https://vivarium-collective.github.io/v2ecoli/bigraph_baseline.html) — processes, stores, wiring, port schemas (with units), per-process equations | `bigraph_baseline.html` | `scripts/viz_baseline_interactive.py` |
+| [ParCa pipeline](https://vivarium-collective.github.io/v2ecoli/bigraph_parca.html) — the nine-Step parameter calculator, same viewer | `bigraph_parca.html` | `scripts/viz_parca_interactive.py` |
+| [ParCa network](https://vivarium-collective.github.io/v2ecoli/parca_network.html) / [Baseline network](https://vivarium-collective.github.io/v2ecoli/network_baseline.html) — Cytoscape topology; click a process for ports/schema/docstring/math | `parca_network.html`, `network_baseline.html` | `scripts/parca_network.py` |
+
+### Simulation result reports — *what the cell actually did*
+
+| Report | Published | Generate locally |
+|---|---|---|
+| [Cell lifecycle](https://vivarium-collective.github.io/v2ecoli/workflow_report.html) — one cell, mother → division → both daughters | `workflow_report.html` | `reports/workflow_report.py` |
+| [Multigeneration lineage](https://vivarium-collective.github.io/v2ecoli/multigeneration_report.html) — N-generation single lineage, mass trajectories & fold-change | `multigeneration_report.html` | `reports/multigeneration_report.py --generations 3` |
+| [Colony](https://vivarium-collective.github.io/v2ecoli/colony_report.html) — mixed colony with pymunk physics, growth & division, synced animations | `colony_report.html` | `reports/colony_report.py --n-adder 9` |
+
+### Comparison & benchmark — *v2ecoli vs vEcoli*
+
+| Report | Published | Generate locally |
+|---|---|---|
+| [v1 vs v2](https://vivarium-collective.github.io/v2ecoli/v1_v2_comparison.html) — vEcoli 1.0 vs v2ecoli baseline: wall/sim time, dry mass, growth | `v1_v2_comparison.html` | `reports/v1_v2_report.py` |
+| [Composite comparison](https://vivarium-collective.github.io/v2ecoli/composite_comparison.html) — any set of engines side-by-side (load/wall/sim, composition, sparklines) | `composite_comparison.html` | `reports/composite_comparison.py --engines baseline millard_pdmp_baseline` |
+| Benchmark — v2ecoli vs the vEcoli composite (local-only) | — | `reports/benchmark_report.py` |
+
+### Model structure, ParCa & sources — *the math, the parameters, the inputs*
+
+| Report | Published | Generate locally |
+|---|---|---|
+| [Mathematical structure](https://vivarium-collective.github.io/v2ecoli/math_structure.html) — every process's governing equations by subsystem, per-tick execution flow, partition→allocate→evolve contract | `math_structure.html` | `reports/math_structure_report.py` |
+| [ParCa workflow](https://vivarium-collective.github.io/v2ecoli/parca_workflow_report.html) — the nine-Step run with per-step runtimes, port manifests, raw-data stats | `parca_workflow_report.html` | (ParCa pipeline) |
+| [ecoli-sources](https://vivarium-collective.github.io/v2ecoli/ecoli_sources_report.html) — the ParCa input bundle (inherited + v2ecoli overrides), each with a download link | `ecoli_sources_report.html` | `reports/ecoli_sources_report.py` |
+
+> **Provenance banners.** PR-evidence reports (`scripts/pr_session_report.py`,
+> `scripts/sweep_report.py`) embed a self-describing header — ISO timestamp, git
+> SHA/branch, dirty-tree badge, last commit, host/OS/Python — so an HTML file
+> stays meaningful months later. Attach these to PRs that change biology; see
+> [AGENTS.md → Reports](../AGENTS.md).


### PR DESCRIPTION
Cleans up the README's reports/links section per review.

## What changed
**Compact new `## Explore v2ecoli` section** replaces the long "Reports & interactive viewers" block, cleanly separating the **three** published outputs — each with a one-line *how it's built*:

1. **🖥️ Interactive dashboard** — the read-only SPA snapshot at `/dashboard/` (auto-rebuilt from main). **Was not mentioned in the README at all** before.
2. **📊 Investigation reports** — one self-contained HTML per investigation (publish-reports.yml). Fixed the stale list: **3 → the 6 now published** (added KETCHUP, parameter-uq, units-atlas).
3. **🔬 Standalone HTML reports** — model viewers, sim results, comparisons, math.

**New complementary doc `docs/reports.md`** holds the detailed standalone-report catalog (per-report links + "generate locally" commands) and documents how each of the three publishing pipelines works — keeping the README compact.

**Also:** consolidated the duplicated flagship banner at the top into one compact entry-point block (dashboard · flagship report · gallery), and fixed the internal anchors.

README: **607 → 565 lines**. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)