### PR TITLE
deps: bump pbg-superpowers to the workspace-evaluator seam (activates report-card grading)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2619,12 +2619,13 @@ xarray = [
 [[package]]
 name = "pbg-superpowers"
 version = "0.14.0"
-source = { git = "https://github.com/vivarium-collective/pbg-superpowers.git?branch=main#37f6bcf25420d5fe9a78ae04601de94301b355bc" }
+source = { git = "https://github.com/vivarium-collective/pbg-superpowers.git?branch=main#9718c135f0a33e09f4703783f3bb8c80f3d5b70c" }
 dependencies = [
     { name = "bigraph-schema" },
     { name = "click" },
     { name = "jinja2" },
     { name = "jsonschema", extra = ["format-nongpl"] },
+    { name = "pbg-emitters" },
     { name = "process-bigraph" },
     { name = "pypdf" },
     { name = "pyyaml" },


### PR DESCRIPTION
Lockfile-only bump of `pbg-superpowers` (`37f6bcf → 9718c13`, current `main`) so the installed framework carries the **workspace-pluggable evaluator seam** merged in pbg-superpowers#143 (`load_workspace_evaluators` + the non-native-`measure.kind` dispatch).

## Why
`showcase-6-equivalence-large`'s five tests use `measure.kind: report_card_axis`, graded by `pbg_v2ecoli`'s registered evaluator. The previously-locked pbg-superpowers (`37f6bcf`) predates the seam, so those tests **degrade to `evaluated_by: agent`**. With this bump they grade live from the card's `report_card_verdict.json` → `computed_outcomes` → gate → acceptance criteria (physiology/composition/ribosomes PASS, exchange-fluxes & gene-expression FAIL → gate `failed` = partial equivalence).

`pyproject.toml` already pins `pbg-superpowers = { branch = "main" }`, so this is a `uv.lock`-only change. #143 is confirmed in the locked commit's ancestry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)