### PR TITLE
fix(allocator): survive over-draft instead of crashing the lineage

### DIFF
--- a/docs/allocator_overdraft_handling.md
+++ b/docs/allocator_overdraft_handling.md
@@ -1,0 +1,63 @@
+# Allocator over-draft handling (PROTON[c] `NegativeCountsError`)
+
+## Background
+
+Under metabolic-edge conditions a multi-generation run could die with:
+
+```
+v2ecoli.steps.allocator.NegativeCountsError: Negative value(s) in counts_unallocated:
+PROTON[c] (-916)
+```
+
+always preceded by `Warning: GLP_NOFEAS` (FBA infeasibility). Investigation
+(see the dnaa-replication handoff note) established two distinct baseline defects
+in `v2ecoli/steps/allocator.py`, fixed here.
+
+## Defect 1 — int64 overflow in `calculatePartition`
+
+The proportional split computed the excess fraction as
+
+```python
+requests * total_counts / total_requested
+```
+
+where `requests * total_counts` is an **int64** intermediate. For high-count
+molecules (PROTON[c]-scale pools `> ~3e9`, where `pool * request > 2^63`) this
+overflows and wraps to garbage, corrupting the partition (it could allocate
+negative or over-allocate). Fuzzing (220k cases) showed the split is otherwise
+correct at all normal magnitudes — overflow is the *only* arithmetic failure
+mode.
+
+**Fix:** cast to float before the multiply. For every non-overflowing magnitude
+the result is bit-identical to the prior int64 path (the division already
+produced float), verified at 0 mismatches / 20,000 random normal cases.
+
+## Defect 2 — hard crash on a pre-existing-negative pool
+
+The `-916` itself was *not* an allocator over-allocation. With the partition math
+proven correct at normal magnitudes, the only way to get a small, clean
+`counts_unallocated` deficit with all-positive allocations is that the pool was
+**already negative on entry** (no process even requested it that tick):
+`counts_unallocated = original(-916) - 0`. The allocator was merely *reporting* a
+pool driven negative upstream — the FBA `GLP_NOFEAS` infeasibility tick — and a
+single transient infeasibility was killing an entire lineage.
+
+**Fix:** the over-draft guard now degrades gracefully (`resolve_overdraft`):
+clamp any genuine over-allocation down to the available pool, leave an
+already-negative pool for the upstream to heal, and emit a **rate-limited
+warning** with an event counter instead of raising. Genuine corruption — a
+negative *request* or a negative *partition* — is still a hard `NegativeCountsError`.
+
+This is intentionally a robustness band-aid at the allocator layer. The true
+root cause (why FBA returns `GLP_NOFEAS` and lets PROTON[c] go negative) is a
+separate, harder metabolism fix and is **not** addressed here; it was also not
+reproducible on the current investigation branch (the autoregulation work has
+since been retuned toward homeostasis, removing the metabolic edge).
+
+## Tests
+
+`tests/test_allocator_robustness.py` covers both defects: overflow-magnitude
+splits stay within the pool; `resolve_overdraft` reports a pre-existing negative
+pool, clamps a positive-pool over-allocation, and is a no-op within budget;
+`Allocator.update` no longer raises on a negative pool but still raises on a
+negative request.

--- a/tests/test_allocator_robustness.py
+++ b/tests/test_allocator_robustness.py
@@ -1,0 +1,169 @@
+"""Robustness tests for the molecule Allocator.
+
+Covers two baseline defects (see docs/proton_allocator_negativecounts_crash.md):
+
+1. ``calculatePartition`` over-allocated when the int64 intermediate
+   ``requests * total_counts`` overflowed (PROTON[c]-scale pools), corrupting the
+   partition. The fractional split must use float arithmetic so it never
+   overflows, and must never hand out more than ``total_counts``.
+
+2. The over-draft guard hard-raised ``NegativeCountsError`` and killed the whole
+   lineage when a molecule pool was already negative on entry (a transient FBA
+   infeasibility upstream, e.g. PROTON[c] after GLP_NOFEAS). A single infeasible
+   tick must degrade gracefully (clamp + report) instead of crashing.
+"""
+
+import numpy as np
+import pytest
+
+from v2ecoli.steps.allocator import (
+    Allocator,
+    NegativeCountsError,
+    calculatePartition,
+    resolve_overdraft,
+)
+
+
+# ---------------------------------------------------------------------------
+# calculatePartition: never over-allocate, even at int64-overflow magnitudes
+# ---------------------------------------------------------------------------
+
+def _max_overdraft(partitioned, total_counts):
+    """Largest amount by which any molecule's allocation exceeds its pool."""
+    return int(np.max(partitioned.sum(axis=1) - total_counts))
+
+
+def test_partition_no_overdraft_at_overflow_magnitudes():
+    """PROTON-scale pools (>3e9) made `requests * total_counts` overflow int64,
+    producing a corrupt (over- or under-allocating) partition. The split must
+    stay within the pool."""
+    rng = np.random.RandomState(0)
+    # two processes each requesting ~the full pool -> excess branch; pool large
+    # enough that req*pool > int64 max (9.2e18).
+    for tot in [3_100_000_000, 4_000_000_000, 4_900_000_000]:
+        total_counts = np.array([tot], dtype=np.int64)
+        requests = np.array([[tot, tot]], dtype=np.int64)  # total 2*tot > pool
+        priorities = np.zeros(2)
+        part = calculatePartition(priorities, requests, total_counts.copy(), rng)
+        assert np.all(part >= 0), f"negative allocation at tot={tot}: {part}"
+        assert _max_overdraft(part, total_counts) <= 0, (
+            f"over-draft at tot={tot}: allocated {part.sum()} of {tot}")
+        # an excess single-priority split should hand out the whole pool
+        assert part.sum() == tot, f"under-allocated at tot={tot}: {part.sum()}/{tot}"
+
+
+def test_partition_normal_regime_unchanged():
+    """Regression guard: in the normal regime the split is fully-allocating and
+    bounded (the property the parity baseline depends on)."""
+    rng = np.random.RandomState(1)
+    for _ in range(2000):
+        n_proc = rng.randint(1, 8)
+        tot = rng.randint(0, 200, size=3)
+        req = rng.randint(0, 80, size=(3, n_proc))
+        prio = rng.randint(0, 3, size=n_proc).astype(float)
+        part = calculatePartition(prio, req.copy(), tot.copy(), rng)
+        assert np.all(part >= 0)
+        assert _max_overdraft(part, tot) <= 0
+
+
+# ---------------------------------------------------------------------------
+# resolve_overdraft: graceful clamp instead of hard crash
+# ---------------------------------------------------------------------------
+
+def test_resolve_overdraft_reports_preexisting_negative_pool():
+    """Pool already negative on entry, nothing allocated (no process requested
+    it): report the deficit, leave the (zero) allocation untouched, don't raise."""
+    partitioned = np.array([[0, 0], [5, 3]], dtype=np.int64)   # mol0 unallocated
+    original = np.array([-916, 100], dtype=np.int64)           # mol0 pre-negative
+    clamped, overdrafts = resolve_overdraft(partitioned, original)
+    assert [m for m, _ in overdrafts] == [0]
+    assert dict(overdrafts)[0] == -916          # reported deficit
+    assert np.array_equal(clamped[0], [0, 0])   # nothing to claw back
+    assert np.array_equal(clamped[1], [5, 3])   # healthy molecule untouched
+
+
+def test_resolve_overdraft_clamps_positive_pool_overallocation():
+    """If a positive pool is over-allocated, scale the allocation down so the sum
+    never exceeds the pool (defense-in-depth)."""
+    partitioned = np.array([[60, 60]], dtype=np.int64)  # sums to 120
+    original = np.array([100], dtype=np.int64)          # only 100 available
+    clamped, overdrafts = resolve_overdraft(partitioned, original)
+    assert [m for m, _ in overdrafts] == [0]
+    assert clamped.sum() == 100                 # clamped to the pool exactly
+    assert np.all(clamped >= 0)
+
+
+def test_resolve_overdraft_noop_when_within_pool():
+    """No over-draft -> returns the partition unchanged and reports nothing."""
+    partitioned = np.array([[10, 20], [0, 5]], dtype=np.int64)
+    original = np.array([100, 100], dtype=np.int64)
+    clamped, overdrafts = resolve_overdraft(partitioned, original)
+    assert overdrafts == []
+    assert np.array_equal(clamped, partitioned)
+
+
+# ---------------------------------------------------------------------------
+# Allocator.update: a transient infeasible tick must not kill the run
+# ---------------------------------------------------------------------------
+
+def _make_allocator(molecule_names, process_names):
+    return Allocator(parameters={
+        "molecule_names": molecule_names,
+        "process_names": process_names,
+        "custom_priorities": {},
+        "seed": 0,
+    })
+
+
+def _bulk(ids, counts):
+    arr = np.zeros(len(ids), dtype=[("id", "U20"), ("count", "i8")])
+    arr["id"] = ids
+    arr["count"] = counts
+    return arr
+
+
+def test_update_does_not_raise_on_preexisting_negative_pool():
+    """The reported crash: PROTON[c] negative on entry, no process requesting it.
+    The allocator must report + continue, not raise NegativeCountsError."""
+    mols = ["PROTON[c]", "ATP[c]"]
+    procs = ["procA", "procB"]
+    alloc = _make_allocator(mols, procs)
+    states = {
+        "bulk": _bulk(["PROTON[c]", "ATP[c]"], [-916, 1000]),
+        "request": {
+            # only ATP[c] (local idx 1) is requested; PROTON[c] is not
+            "procA": {"bulk": [(1, 100)]},
+            "procB": {"bulk": [(1, 100)]},
+        },
+        "allocator_rng": np.random.RandomState(0),
+        "listeners": {"atp": {
+            "atp_requested": np.zeros(len(procs), dtype=int),
+            "atp_allocated_initial": np.zeros(len(procs), dtype=int),
+        }},
+    }
+    update = alloc.update(states)  # must not raise
+    # ATP allocated fully (within pool); PROTON allocations are zero/non-negative
+    alloc_a = update["allocate"]["procA"]["bulk"]
+    alloc_b = update["allocate"]["procB"]["bulk"]
+    assert alloc_a[1] + alloc_b[1] <= 1000          # ATP within pool
+    assert alloc_a[0] == 0 and alloc_b[0] == 0       # no PROTON handed out
+    assert getattr(alloc, "_overdraft_events", 0) >= 1
+
+
+def test_update_still_raises_on_negative_request():
+    """A negative *request* is genuine corruption, not a transient pool dip — it
+    must stay a hard error."""
+    mols = ["PROTON[c]", "ATP[c]"]
+    procs = ["procA"]
+    alloc = _make_allocator(mols, procs)
+    states = {
+        "bulk": _bulk(["PROTON[c]", "ATP[c]"], [100, 1000]),
+        "request": {"procA": {"bulk": [(1, -5)]}},
+        "allocator_rng": np.random.RandomState(0),
+        "listeners": {"atp": {
+            "atp_requested": np.zeros(1, dtype=int),
+            "atp_allocated_initial": np.zeros(1, dtype=int),
+        }},
+    }
+    with pytest.raises(NegativeCountsError):
+        alloc.update(states)

--- a/v2ecoli/steps/allocator.py
+++ b/v2ecoli/steps/allocator.py
@@ -106,6 +106,11 @@ class Allocator(Step):
         # Helper indices for Numpy indexing
         self.molecule_idx = None
 
+        # Count of ticks on which an over-draft had to be clamped (a transient
+        # infeasibility upstream). Surfaced via a rate-limited warning so a
+        # persistent problem stays visible without flooding the log.
+        self._overdraft_events = 0
+
     def update(self, states, interval=None):
         if self.molecule_idx is None:
             self.molecule_idx = bulk_name_to_idx(
@@ -160,19 +165,33 @@ class Allocator(Step):
                 )
             )
 
-        # Ensure we are not overdrafting any molecules
-        counts_unallocated = original_totals - np.sum(partitioned_counts, axis=-1)
-
-        if ASSERT_POSITIVE_COUNTS and np.any(counts_unallocated < 0):
-            raise NegativeCountsError(
-                "Negative value(s) in counts_unallocated:\n"
-                + "\n".join(
-                    "{} ({})".format(
-                        self.mol_idx_to_name[molIndex], counts_unallocated[molIndex]
-                    )
-                    for molIndex in np.where(counts_unallocated < 0)[0]
+        # Resolve any over-draft gracefully instead of crashing the lineage. An
+        # over-draft here is almost always a molecule pool already driven
+        # negative upstream (e.g. PROTON[c] after an FBA GLP_NOFEAS tick), which
+        # the allocator merely observes — a single infeasible tick must not kill
+        # a multi-generation run. Genuine corruption (negative requests / negative
+        # allocations) is still a hard error in the checks above.
+        partitioned_counts, overdrafts = resolve_overdraft(
+            partitioned_counts, original_totals
+        )
+        if overdrafts:
+            self._overdraft_events += 1
+            if self._overdraft_events <= 5 or self._overdraft_events % 100 == 0:
+                detail = ", ".join(
+                    "{} ({})".format(self.mol_idx_to_name[m], d)
+                    for m, d in overdrafts
                 )
-            )
+                print(
+                    "Warning: allocator '{}' clamped over-draft "
+                    "(event #{}): {} — pool driven negative upstream "
+                    "(e.g. FBA infeasibility); clamping to available and "
+                    "continuing".format(
+                        getattr(self, "name", "allocator"),
+                        self._overdraft_events,
+                        detail,
+                    ),
+                    flush=True,
+                )
 
         # Only update listener ATP counts for processes in
         # current partitioning layer
@@ -201,6 +220,53 @@ class Allocator(Step):
         return update
 
 
+def resolve_overdraft(partitioned_counts, original_totals):
+    """Clamp allocations so no molecule is handed out beyond its available pool,
+    and report any over-draft.
+
+    Returns ``(clamped_counts, overdrafts)`` where ``overdrafts`` is a list of
+    ``(molecule_index, deficit)`` pairs and ``deficit < 0`` is the amount by
+    which the pool was exceeded.
+
+    Two cases produce an over-draft:
+
+    - The pool was already negative on entry (a transient infeasibility upstream
+      — e.g. PROTON[c] driven negative by an FBA ``GLP_NOFEAS`` tick). Nothing
+      was allocated to claw back, so the deficit is reported and the (zero)
+      allocation is left untouched; the negative pool is the upstream's to heal.
+    - A positive pool was genuinely over-allocated. The offending molecule's
+      allocations are scaled down proportionally so their sum equals the pool
+      (defense-in-depth; the float partition above should already prevent this).
+    """
+    counts_unallocated = original_totals - partitioned_counts.sum(axis=1)
+    over_idx = np.where(counts_unallocated < 0)[0]
+    if len(over_idx) == 0:
+        return partitioned_counts, []
+
+    clamped = partitioned_counts.copy()
+    overdrafts = []
+    for mol in over_idx:
+        overdrafts.append((int(mol), int(counts_unallocated[mol])))
+        avail = max(int(original_totals[mol]), 0)
+        row = clamped[mol, :]
+        row_sum = int(row.sum())
+        if row_sum <= avail:
+            continue  # pool already negative; nothing allocated to claw back
+        if avail == 0:
+            clamped[mol, :] = 0
+            continue
+        # Proportional integer scale-down to the available pool, distributing the
+        # rounding remainder to the largest fractional parts (full allocation).
+        scaled = row.astype(np.float64) * avail / row_sum
+        floored = np.floor(scaled).astype(clamped.dtype)
+        deficit = avail - int(floored.sum())
+        if deficit > 0:
+            order = np.argsort(scaled - floored)[::-1][:deficit]
+            floored[order] += 1
+        clamped[mol, :] = floored
+    return clamped, overdrafts
+
+
 def calculatePartition(
     process_priorities, counts_requested, total_counts, random_state
 ):
@@ -218,8 +284,13 @@ def calculatePartition(
 
         # Get fractional request for molecules that have excess request
         # compared to available counts
+        # Cast to float before multiplying: `requests * total_counts` is an int64
+        # intermediate that overflows for high-count molecules (e.g. PROTON[c],
+        # pools > ~3e9), wrapping to garbage and corrupting the partition. The
+        # division already yields float, so for all non-overflowing magnitudes
+        # this is bit-identical to the prior int64 path.
         fractional_requests = (
-            requests[excess_request_mask, :]
+            requests[excess_request_mask, :].astype(np.float64)
             * total_counts[excess_request_mask, np.newaxis]
             / total_requested[excess_request_mask, np.newaxis]
         )


### PR DESCRIPTION
## Summary

Fixes two baseline robustness defects in `v2ecoli/steps/allocator.py` that surfaced as a `PROTON[c]` `NegativeCountsError` killing multi-generation runs (always preceded by an FBA `GLP_NOFEAS` infeasibility tick).

### 1. int64 overflow in `calculatePartition`
The excess split computed `requests * total_counts / total_requested` with an **int64** intermediate that overflows for high-count molecules (pools `> ~3e9`, PROTON[c]-scale, where `pool * request > 2^63`), wrapping to garbage and corrupting the partition. **Fix:** cast to `float64` before the multiply — bit-identical to the prior path for every non-overflowing magnitude (verified **0 mismatches / 20,000** random normal cases), correct above the int64 boundary.

### 2. Hard crash on a pre-existing-negative pool
The reported `−916` was **not** an allocator over-allocation. A 220k-case fuzz shows the partition math never over-drafts at normal magnitudes; the only way to get a small clean deficit with all-positive allocations is a pool **already negative on entry** (`counts_unallocated = original(−916) − 0`). The allocator was merely *reporting* a pool driven negative upstream by FBA infeasibility, and a single transient tick was killing the whole lineage. **Fix:** new `resolve_overdraft()` clamps any genuine over-allocation down to the available pool, leaves an already-negative pool for the upstream to heal, and emits a **rate-limited warning + event counter** instead of raising. Negative *requests* / negative *partitions* remain hard `NegativeCountsError`.

The true root (why FBA returns `GLP_NOFEAS`) is a separate metabolism fix — **not** addressed here and not currently reproducible (the dnaa-4 investigation branch was retuned toward homeostasis, removing the metabolic edge). See `docs/allocator_overdraft_handling.md`.

## Verification
- New `tests/test_allocator_robustness.py` — **7 passed** (overflow stays within pool; `resolve_overdraft` reports a negative pool, clamps a positive-pool over-allocation, no-ops within budget; `update` no longer raises on a negative pool but still raises on a negative request).
- Fast suite (`-m "not sim"`): **505 passed**, 36 skipped.
- Behavior test `test_daughters_build_and_grow`: **passed**.
- **Parity: behavior-neutral.** Control run (clean `origin/main` allocator + same cache) produces a **byte-identical** signature to this fix. The committed parity golden is stale vs the current `parca_state.pkl.gz` fixture (`inputs_hash` 2fbf920b vs golden 389784f7) — a pre-existing main condition, independent of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)