### PR TITLE
feat: biologically-organized composite (Phase 1, bit-identical to baseline)

### DIFF
--- a/docs/superpowers/plans/2026-06-13-biological-composite-phase1.md
+++ b/docs/superpowers/plans/2026-06-13-biological-composite-phase1.md
@@ -1,0 +1,761 @@
+# Biological Composite — Phase 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a `biological()` composite for v2ecoli whose store hierarchy is organized by cellular compartment → molecular class, by post-processing the finished baseline document through a pure path-remap, and prove its trajectory is **bit-identical** to the baseline.
+
+**Architecture:** `baseline()` already returns a complete process-bigraph document whose cell state lives at `state.agents.0`, with every process wired via `make_edge` topology tuples and all build-time seeding done on the original layout. Phase 1 adds (a) a reusable path-remap module that relocates data subtrees and rewrites edge wires, and (b) a `biological()` generator that calls `baseline()` then applies the remap. No process internals change, so the simulation is provably identical. A pytest gate runs both composites N steps and asserts every data leaf is `np.array_equal`.
+
+**Tech Stack:** Python, numpy, process-bigraph (`Composite`), pbg-superpowers `@composite_generator`, pytest. Reuses `tests/_state_equal.py:deep_equal`.
+
+---
+
+## Execution environment
+
+The worktree `/Users/eranagmon/code/v2e-biological` has **no `.venv`**. Run everything with the main checkout's interpreter and PYTHONPATH-shadow the worktree source:
+
+```bash
+export V2E_PY=/Users/eranagmon/code/v2ecoli/.venv/bin/python
+export PYTHONPATH=/Users/eranagmon/code/v2e-biological
+cd /Users/eranagmon/code/v2e-biological
+```
+
+- Tasks 1–2 are pure unit tests — **no ParCa cache needed.**
+- Tasks 4–6 build the full composite — they need a built cache. Point at the main checkout's cache:
+  ```bash
+  export V2ECOLI_CACHE_DIR=/Users/eranagmon/code/v2ecoli/out/cache
+  ```
+  Confirm it exists first: `ls "$V2ECOLI_CACHE_DIR"/sim_data_cache.dill`. If absent, build with `$V2E_PY scripts/build_cache.py --mode full` (per memory: ~2.5 min on the mini; use `--mode full`, never `fast`, for simulation).
+
+All pytest invocations below assume the three exports above are set.
+
+---
+
+## File structure
+
+- Create `v2ecoli/composites/_remap.py` — the remap tables + transform (Tasks 1–2).
+- Create `v2ecoli/composites/biological.py` — the `biological()` generator (Tasks 3–4).
+- Create `tests/test_remap.py` — unit tests for the remap (Tasks 1–2).
+- Create `tests/test_biological_equivalence.py` — the bit-identical gate (Task 5).
+- Create `scripts/compare_biological.py` — biological-marker comparison + HTML (Task 6).
+
+---
+
+### Task 1: Remap tables + `remap_path`
+
+**Files:**
+- Create: `v2ecoli/composites/_remap.py`
+- Test: `tests/test_remap.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_remap.py
+from v2ecoli.composites._remap import remap_path
+
+
+def test_bulk_relocates_to_cell_molecules():
+    assert remap_path(['bulk']) == ['cell', 'molecules']
+
+def test_bulk_subpath_preserves_tail():
+    assert remap_path(['bulk', 'count']) == ['cell', 'molecules', 'count']
+
+def test_unique_rnap_relocates_and_renames():
+    assert remap_path(['unique', 'active_RNAP']) == ['cell', 'transcription', 'rna_polymerases']
+
+def test_unique_chromosome_groups_under_chromosome():
+    assert remap_path(['unique', 'full_chromosome']) == ['cell', 'chromosome', 'full_chromosome']
+
+def test_listeners_subleaf_relocates():
+    assert remap_path(['listeners', 'mass']) == ['cell', 'observables', 'mass']
+
+def test_global_time_relocates_to_clock():
+    assert remap_path(['global_time']) == ['clock', 'global_time']
+
+def test_coordination_store_relocates_to_machinery():
+    assert remap_path(['process_state', 'polypeptide_elongation']) == \
+        ['machinery', 'process_state', 'polypeptide_elongation']
+
+def test_flow_token_is_left_untouched():
+    assert remap_path(['_layer_token_3']) == ['_layer_token_3']
+
+def test_unknown_head_is_left_untouched():
+    assert remap_path(['agents', '0']) == ['agents', '0']
+
+def test_empty_path_is_noop():
+    assert remap_path([]) == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `$V2E_PY -m pytest tests/test_remap.py -q`
+Expected: FAIL with `ModuleNotFoundError: No module named 'v2ecoli.composites._remap'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# v2ecoli/composites/_remap.py
+"""Pure path-remap: relabel the baseline store hierarchy into a biological
+(compartment -> molecular class) one. See
+docs/superpowers/specs/2026-06-13-biological-composite-design.md.
+
+The transform is a relabel only — no store internals are split and no update
+math changes — so a composite built through it is bit-identical to baseline.
+"""
+from __future__ import annotations
+
+# Top-level data store -> new biological path. Coordination/clock stores move
+# under machinery/ and clock/ so the cell/ subtree reads as biology, not plumbing.
+REMAP: dict[str, tuple[str, ...]] = {
+    'bulk':               ('cell', 'molecules'),
+    'listeners':          ('cell', 'observables'),
+    'ppgpp_state':        ('cell', 'regulation', 'ppgpp_state'),
+    'attenuation_config': ('cell', 'regulation', 'attenuation_config'),
+    'boundary':           ('environment', 'boundary'),
+    'environment':        ('environment', 'media'),
+    'exchange':           ('environment', 'exchange'),
+    'process':            ('machinery', 'process'),
+    'allocator_rng':      ('machinery', 'allocator_rng'),
+    'process_state':      ('machinery', 'process_state'),
+    'next_update_time':   ('machinery', 'next_update_time'),
+    'request':            ('machinery', 'request'),
+    'allocate':           ('machinery', 'allocate'),
+    'global_time':        ('clock', 'global_time'),
+    'timestep':           ('clock', 'timestep'),
+    'divide':             ('clock', 'divide'),
+    'division_threshold': ('clock', 'division_threshold'),
+}
+
+# Each unique-molecule leaf -> its biological compartment/subsystem path.
+UNIQUE_REMAP: dict[str, tuple[str, ...]] = {
+    'full_chromosome':     ('cell', 'chromosome', 'full_chromosome'),
+    'chromosome_domain':   ('cell', 'chromosome', 'chromosome_domain'),
+    'oriC':                ('cell', 'chromosome', 'oriC'),
+    'DnaA_box':            ('cell', 'chromosome', 'DnaA_box'),
+    'chromosomal_segment': ('cell', 'chromosome', 'chromosomal_segment'),
+    'gene':                ('cell', 'chromosome', 'gene'),
+    'active_replisome':    ('cell', 'chromosome', 'active_replisome'),
+    'active_RNAP':         ('cell', 'transcription', 'rna_polymerases'),
+    'RNA':                 ('cell', 'transcription', 'transcripts'),
+    'promoter':            ('cell', 'transcription', 'promoters'),
+    'active_ribosome':     ('cell', 'translation', 'ribosomes'),
+}
+
+
+def remap_path(path: list) -> list:
+    """Rewrite one wire path (list of segments) into its biological location.
+
+    Leading segment(s) are rewritten through UNIQUE_REMAP (for 'unique/<x>')
+    or REMAP; the tail is preserved. Unknown heads (flow tokens, 'agents', …)
+    pass through unchanged.
+    """
+    if not path:
+        return list(path)
+    head = path[0]
+    if head == 'unique' and len(path) >= 2 and path[1] in UNIQUE_REMAP:
+        return list(UNIQUE_REMAP[path[1]]) + list(path[2:])
+    if head in REMAP:
+        return list(REMAP[head]) + list(path[1:])
+    return list(path)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `$V2E_PY -m pytest tests/test_remap.py -q`
+Expected: PASS (10 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add v2ecoli/composites/_remap.py tests/test_remap.py
+git commit -m "feat(remap): biological path-remap tables + remap_path
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Relocate data stores + rewrite edge wires (`remap_cell_state`)
+
+**Files:**
+- Modify: `v2ecoli/composites/_remap.py`
+- Test: `tests/test_remap.py`
+
+This is the structural transform applied to a finished `agents.0` cell state: data subtrees move to their biological paths; edges (`_type` in step/process) stay at the root but have every wire path rewritten.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tests/test_remap.py
+import numpy as np
+from v2ecoli.composites._remap import remap_cell_state
+
+
+def _fake_edge():
+    # Mimics make_edge output: wires are {port: [path, segments]} lists.
+    return {
+        '_type': 'step',
+        'priority': 1.0,
+        'instance': object(),
+        '_inputs': {}, '_outputs': {},
+        'inputs': {
+            'bulk': ['bulk'],
+            'active_RNAP': ['unique', 'active_RNAP'],
+            'mass': ['listeners', 'mass'],
+            'global_time': ['global_time'],
+            '_layer_in_1': ['_layer_token_0'],
+        },
+        'outputs': {
+            'bulk': ['bulk'],
+            'next': ['next_update_time', 'metabolism'],
+        },
+    }
+
+
+def _fake_cell_state():
+    return {
+        'bulk': np.array([1, 2, 3]),
+        'unique': {'active_RNAP': np.array([10, 11]),
+                   'full_chromosome': np.array([7])},
+        'listeners': {'mass': {'cell_mass': 4.0}},
+        'global_time': 0.0,
+        'process_state': {'polypeptide_elongation': {'gtp_to_hydrolyze': 0}},
+        'ecoli-metabolism': _fake_edge(),
+    }
+
+
+def test_data_stores_move_to_biological_paths():
+    out = remap_cell_state(_fake_cell_state())
+    assert np.array_equal(out['cell']['molecules'], np.array([1, 2, 3]))
+    assert np.array_equal(out['cell']['transcription']['rna_polymerases'], np.array([10, 11]))
+    assert np.array_equal(out['cell']['chromosome']['full_chromosome'], np.array([7]))
+    assert out['cell']['observables']['mass'] == {'cell_mass': 4.0}
+    assert out['clock']['global_time'] == 0.0
+    assert out['machinery']['process_state'] == {'polypeptide_elongation': {'gtp_to_hydrolyze': 0}}
+
+
+def test_old_top_level_keys_are_gone():
+    out = remap_cell_state(_fake_cell_state())
+    for old in ('bulk', 'unique', 'listeners', 'global_time', 'process_state'):
+        assert old not in out
+
+
+def test_edge_stays_at_root_and_wires_rewritten():
+    out = remap_cell_state(_fake_cell_state())
+    edge = out['ecoli-metabolism']
+    assert edge['_type'] == 'step'
+    assert edge['inputs']['bulk'] == ['cell', 'molecules']
+    assert edge['inputs']['active_RNAP'] == ['cell', 'transcription', 'rna_polymerases']
+    assert edge['inputs']['mass'] == ['cell', 'observables', 'mass']
+    assert edge['inputs']['global_time'] == ['clock', 'global_time']
+    assert edge['inputs']['_layer_in_1'] == ['_layer_token_0']      # untouched
+    assert edge['outputs']['next'] == ['machinery', 'next_update_time', 'metabolism']
+
+
+def test_input_is_not_mutated():
+    src = _fake_cell_state()
+    remap_cell_state(src)
+    assert 'bulk' in src and 'cell' not in src    # original untouched
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `$V2E_PY -m pytest tests/test_remap.py -q`
+Expected: FAIL with `ImportError: cannot import name 'remap_cell_state'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# append to v2ecoli/composites/_remap.py
+import copy
+
+_EDGE_TYPES = ('step', 'process')
+
+
+def _is_edge(value) -> bool:
+    return isinstance(value, dict) and value.get('_type') in _EDGE_TYPES
+
+
+def _set_path(tree: dict, path: tuple, value) -> None:
+    """Place value at nested path, creating intermediate dicts."""
+    node = tree
+    for seg in path[:-1]:
+        node = node.setdefault(seg, {})
+    node[path[-1]] = value
+
+
+def _rewrite_wires(wires):
+    """Rewrite a wire structure (dict of port -> path-list, possibly nested)."""
+    if isinstance(wires, list):
+        return remap_path(wires)
+    if isinstance(wires, dict):
+        return {k: _rewrite_wires(v) for k, v in wires.items()}
+    return wires
+
+
+def remap_cell_state(cell_state: dict) -> dict:
+    """Return a new cell-state tree with data stores relocated to biological
+    paths and every edge's wires rewritten. Edges stay at the root. The input
+    is not mutated.
+
+    Unknown non-edge keys (not in REMAP, not 'unique') are carried over at the
+    root unchanged so nothing is silently dropped.
+    """
+    out: dict = {}
+    for key, value in cell_state.items():
+        if _is_edge(value):
+            edge = copy.deepcopy(value)
+            if 'inputs' in edge:
+                edge['inputs'] = _rewrite_wires(edge['inputs'])
+            if 'outputs' in edge:
+                edge['outputs'] = _rewrite_wires(edge['outputs'])
+            out[key] = edge
+        elif key == 'unique':
+            for uname, uval in value.items():
+                target = UNIQUE_REMAP.get(uname)
+                if target is None:
+                    # Unmapped unique molecule: keep under cell/<name> rather
+                    # than drop it, and make the omission visible.
+                    target = ('cell', uname)
+                _set_path(out, target, uval)
+        elif key in REMAP:
+            _set_path(out, REMAP[key], value)
+        else:
+            out[key] = value
+    return out
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `$V2E_PY -m pytest tests/test_remap.py -q`
+Expected: PASS (14 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add v2ecoli/composites/_remap.py tests/test_remap.py
+git commit -m "feat(remap): relocate data stores + rewrite edge wires
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: `biological()` generator (structural)
+
+**Files:**
+- Create: `v2ecoli/composites/biological.py`
+- Test: `tests/test_remap.py` (structural assertion; no cache needed because we
+  monkeypatch `baseline` with a tiny stub here)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tests/test_remap.py
+def test_biological_wraps_baseline_and_remaps(monkeypatch):
+    import v2ecoli.composites.biological as biomod
+
+    def fake_baseline(**kwargs):
+        return {
+            'state': {
+                'agents': {'0': {
+                    'bulk': [1],
+                    'unique': {'active_RNAP': [2]},
+                    'listeners': {'mass': {}},
+                    'global_time': 0.0,
+                    'emitter': {'_type': 'step', 'inputs': {'b': ['bulk']},
+                                'outputs': {}},
+                }},
+                'global_time': 0.0,
+            },
+            'skip_initial_steps': True,
+            'sequential_steps': False,
+            'flow_order': ['emitter'],
+        }
+
+    monkeypatch.setattr(biomod, 'baseline', fake_baseline)
+    doc = biomod.biological(seed=0)
+    agent = doc['state']['agents']['0']
+    assert set(agent) >= {'cell', 'clock', 'emitter'}
+    assert 'bulk' not in agent and 'unique' not in agent and 'listeners' not in agent
+    assert agent['emitter']['inputs']['b'] == ['cell', 'molecules']
+    # The outer document scaffolding is preserved verbatim.
+    assert doc['skip_initial_steps'] is True
+    assert doc['flow_order'] == ['emitter']
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `$V2E_PY -m pytest tests/test_remap.py::test_biological_wraps_baseline_and_remaps -q`
+Expected: FAIL with `ModuleNotFoundError: No module named 'v2ecoli.composites.biological'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# v2ecoli/composites/biological.py
+"""Biologically-organized E. coli whole-cell composite.
+
+Identical simulation to ``baseline()`` — same processes, same update math —
+but the store hierarchy is relabeled into cellular compartments / molecular
+classes via a pure path-remap (see _remap.py and
+docs/superpowers/specs/2026-06-13-biological-composite-design.md).
+
+Phase 1: relabel only -> bit-identical to baseline (see
+tests/test_biological_equivalence.py). Phase 2 (not built here) splits the
+monolithic pools and adds unit-bearing schemas.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from pbg_superpowers.composite_generator import composite_generator
+
+from v2ecoli.composites.baseline import baseline
+from v2ecoli.composites._remap import remap_cell_state
+
+
+@composite_generator(
+    emitters=[
+        {
+            "address": "local:ParquetEmitter",
+            "config": {},
+            # Remapped emit paths (baseline used global_time/bulk/listeners).
+            "paths": ["clock/global_time", "cell/molecules", "cell/observables"],
+        },
+    ],
+)
+def biological(core: Any = None, **kwargs) -> dict:
+    """Build the biological composite document.
+
+    All keyword arguments are forwarded verbatim to :func:`baseline`
+    (seed, cache_dir, emitter, feature toggles, bundle, …). The finished
+    baseline document is then relabeled in place at ``state.agents.0``.
+    """
+    doc = baseline(core=core, **kwargs)
+    agents = doc['state']['agents']
+    for agent_id, cell_state in list(agents.items()):
+        agents[agent_id] = remap_cell_state(cell_state)
+    return doc
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `$V2E_PY -m pytest tests/test_remap.py::test_biological_wraps_baseline_and_remaps -q`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add v2ecoli/composites/biological.py tests/test_remap.py
+git commit -m "feat(biological): biological() generator wrapping baseline + remap
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Build-and-run smoke test (real cache)
+
+Proves the remapped document actually constructs and ticks under the real
+process-bigraph engine (catches path-resolution errors the unit stubs can't).
+
+**Files:**
+- Test: `tests/test_biological_equivalence.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_biological_equivalence.py
+"""Phase-1 equivalence gate: the biological composite is bit-identical to
+baseline. See docs/superpowers/specs/2026-06-13-biological-composite-design.md.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+import v2ecoli.library.unit_bridge  # noqa: F401  (registers pint units pre-cache)
+
+pytestmark = [
+    pytest.mark.sim,
+    pytest.mark.skipif(
+        not os.path.isdir(os.environ.get('V2ECOLI_CACHE_DIR', 'out/cache')),
+        reason="ParCa cache not present; set V2ECOLI_CACHE_DIR or build it.",
+    ),
+]
+
+CACHE = os.environ.get('V2ECOLI_CACHE_DIR', 'out/cache')
+
+
+def test_biological_builds_and_runs_one_step():
+    from process_bigraph import Composite
+    from v2ecoli.core import build_core
+    from v2ecoli.composites.biological import biological
+
+    core = build_core()
+    doc = biological(core=core, seed=0, cache_dir=CACHE, emitter='null')
+    composite = Composite(doc, core=core)
+    composite.run(1)  # must not raise
+
+    agent = composite.state['agents']['0']
+    assert 'cell' in agent and 'molecules' in agent['cell']
+    assert 'bulk' not in agent
+```
+
+- [ ] **Step 2: Run test to verify it fails (or errors meaningfully)**
+
+Run: `$V2E_PY -m pytest tests/test_biological_equivalence.py::test_biological_builds_and_runs_one_step -q`
+Expected: At this point the code from Tasks 1–3 exists, so this should PASS once
+the cache is available. If it FAILS, the failure localizes a real wiring bug
+(e.g. an edge whose wires were not rewritten, or a hard-coded path consumer).
+Fix the remap until it passes — do **not** weaken the assertions.
+
+- [ ] **Step 3: (only if Step 2 failed) diagnose & fix**
+
+Likely culprits and fixes:
+- A process reads a store by hard-coded absolute path bypassing `make_edge`.
+  Grep for it: `grep -rn "'bulk'\|\"bulk\"\|'listeners'" v2ecoli/processes v2ecoli/steps | grep -i "state\[\|\.get("`. If found, that path must be added to the remap's awareness or the consumer left on the original key. Document the finding in the spec's "Open questions" section.
+- An edge type not in `_EDGE_TYPES`. Inspect `composite.state['agents']['0']` keys for dict values with a `_type` not in `('step','process')` and extend `_EDGE_TYPES`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `$V2E_PY -m pytest tests/test_biological_equivalence.py::test_biological_builds_and_runs_one_step -q`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_biological_equivalence.py
+git commit -m "test(biological): smoke build+run of the biological composite
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Bit-identical equivalence gate (the core proof)
+
+**Files:**
+- Modify: `tests/test_biological_equivalence.py`
+
+Run baseline and biological from the **same cache bundle and seed**, step both
+the same number of times with the null emitter, and assert every data leaf
+matches after projecting biological paths back through the remap. Uses the
+existing `tests/_state_equal.py:deep_equal`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tests/test_biological_equivalence.py
+N_STEPS = 50  # enough to exercise transcription/translation/metabolism/replication
+
+
+def _data_pairs(baseline_agent, bio_agent):
+    """Yield (label, baseline_value, biological_value) for every data store we
+    assert on: the bulk pool, all unique molecules, and the listeners tree."""
+    from v2ecoli.composites._remap import REMAP, UNIQUE_REMAP
+
+    def _dig(tree, path):
+        node = tree
+        for seg in path:
+            node = node[seg]
+        return node
+
+    # bulk + listeners (relocated whole)
+    for old_key in ('bulk', 'listeners'):
+        yield (old_key, baseline_agent[old_key], _dig(bio_agent, REMAP[old_key]))
+    # every unique molecule present in baseline
+    for uname, val in baseline_agent['unique'].items():
+        target = UNIQUE_REMAP.get(uname, ('cell', uname))
+        yield (f'unique/{uname}', val, _dig(bio_agent, target))
+
+
+def test_biological_is_bit_identical_to_baseline():
+    from process_bigraph import Composite
+    from v2ecoli.core import build_core
+    from v2ecoli.composites.baseline import baseline, load_cache_bundle
+    from v2ecoli.composites.biological import biological
+    from tests._state_equal import deep_equal
+
+    bundle = load_cache_bundle(CACHE)  # one load -> identical initial state
+
+    core_b = build_core()
+    base = Composite(baseline(core=core_b, seed=0, bundle=bundle, emitter='null'),
+                     core=core_b)
+    core_x = build_core()
+    bio = Composite(biological(core=core_x, seed=0, bundle=bundle, emitter='null'),
+                    core=core_x)
+
+    for step in range(N_STEPS):
+        base.run(1)
+        bio.run(1)
+        ba = base.state['agents']['0']
+        xa = bio.state['agents']['0']
+        for label, bval, xval in _data_pairs(ba, xa):
+            ok, reason = deep_equal(bval, xval, path=label)
+            assert ok, f"divergence at step {step+1}, store {label}: {reason}"
+```
+
+- [ ] **Step 2: Run test to verify it fails (or passes — this is the gate)**
+
+Run: `$V2E_PY -m pytest tests/test_biological_equivalence.py::test_biological_is_bit_identical_to_baseline -q`
+Expected: PASS if the remap is faithful. A FAIL prints the exact step + store +
+dotted leaf path that diverged — investigate with systematic-debugging; the
+cause is always either an unrewritten wire or a hard-coded path consumer (see
+Task 4 Step 3). Do not relax `deep_equal` or shrink `N_STEPS` to make it pass.
+
+- [ ] **Step 3: (if needed) fix the remap, re-run until green**
+
+- [ ] **Step 4: Run the full remap + equivalence suite**
+
+Run: `$V2E_PY -m pytest tests/test_remap.py tests/test_biological_equivalence.py -q`
+Expected: PASS (all)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_biological_equivalence.py
+git commit -m "test(biological): bit-identical equivalence gate vs baseline (50 steps)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Biological-marker comparison report
+
+A side-by-side baseline-vs-biological run that also reports the biological
+markers from the spec (growth rate, division-relevant mass, dry-mass fractions),
+emitting a small self-contained HTML. For Phase 1 these markers are *identical*
+(it's the same simulation); the script exists so Phase 2's tolerant comparison
+has a home and so the equivalence is visible, not just asserted in CI.
+
+**Files:**
+- Create: `scripts/compare_biological.py`
+
+- [ ] **Step 1: Write the script**
+
+```python
+# scripts/compare_biological.py
+"""Run baseline vs biological for N steps and emit an HTML comparison of mass /
+growth markers. Phase 1: the two are identical by construction; this makes that
+visible and is the Phase-2 (tolerant) comparison's entry point.
+
+Usage:
+    python scripts/compare_biological.py --steps 100 \
+        --cache "$V2ECOLI_CACHE_DIR" --out out/biological_comparison.html
+"""
+from __future__ import annotations
+
+import argparse
+import os
+
+import v2ecoli.library.unit_bridge  # noqa: F401
+
+
+def _mass(agent_listeners) -> dict:
+    m = agent_listeners.get('mass', {})
+    def _f(x):
+        return float(getattr(x, 'magnitude', x))
+    return {k: _f(m[k]) for k in ('cell_mass', 'dry_mass') if k in m}
+
+
+def run(steps: int, cache: str):
+    from process_bigraph import Composite
+    from v2ecoli.core import build_core
+    from v2ecoli.composites.baseline import baseline, load_cache_bundle
+    from v2ecoli.composites.biological import biological
+
+    bundle = load_cache_bundle(cache)
+    cb = build_core()
+    base = Composite(baseline(core=cb, seed=0, bundle=bundle, emitter='null'), core=cb)
+    cx = build_core()
+    bio = Composite(biological(core=cx, seed=0, bundle=bundle, emitter='null'), core=cx)
+
+    rows = []
+    for i in range(steps):
+        base.run(1); bio.run(1)
+        bm = _mass(base.state['agents']['0']['listeners'])
+        xm = _mass(bio.state['agents']['0']['cell']['observables'])
+        rows.append((i + 1, bm, xm))
+    return rows
+
+
+def to_html(rows) -> str:
+    head = ("<tr><th>step</th><th>baseline cell_mass</th>"
+            "<th>biological cell_mass</th><th>Δ</th></tr>")
+    body = []
+    for step, bm, xm in rows:
+        b = bm.get('cell_mass', float('nan'))
+        x = xm.get('cell_mass', float('nan'))
+        body.append(f"<tr><td>{step}</td><td>{b:.6g}</td>"
+                    f"<td>{x:.6g}</td><td>{abs(b - x):.3g}</td></tr>")
+    return ("<html><head><meta charset='utf-8'><title>baseline vs biological</title>"
+            "<style>table{border-collapse:collapse}td,th{border:1px solid #ccc;"
+            "padding:4px 8px;font-family:monospace}</style></head><body>"
+            "<h1>Baseline vs Biological — mass markers</h1>"
+            "<p>Phase 1 is a pure relabel; Δ should be 0 at every step.</p>"
+            f"<table>{head}{''.join(body)}</table></body></html>")
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser()
+    p.add_argument('--steps', type=int, default=100)
+    p.add_argument('--cache', default=os.environ.get('V2ECOLI_CACHE_DIR', 'out/cache'))
+    p.add_argument('--out', default='out/biological_comparison.html')
+    args = p.parse_args(argv)
+
+    rows = run(args.steps, args.cache)
+    max_delta = max((abs(bm.get('cell_mass', 0) - xm.get('cell_mass', 0))
+                     for _, bm, xm in rows), default=0.0)
+    os.makedirs(os.path.dirname(args.out) or '.', exist_ok=True)
+    with open(args.out, 'w') as f:
+        f.write(to_html(rows))
+    print(f"wrote {args.out}; max cell_mass Δ over {args.steps} steps = {max_delta:.3g}")
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())
+```
+
+- [ ] **Step 2: Run the script**
+
+Run: `$V2E_PY scripts/compare_biological.py --steps 50 --out out/biological_comparison.html`
+Expected: prints `max cell_mass Δ over 50 steps = 0` (or `0.0`), and writes the HTML.
+
+- [ ] **Step 3: Verify the delta is zero**
+
+The printed `max cell_mass Δ` must be `0` — that's the visible confirmation of
+bit-identity. A non-zero delta means Task 5 should have caught a divergence;
+go back to Task 5 rather than shipping the script.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/compare_biological.py
+git commit -m "feat(biological): baseline-vs-biological mass comparison report
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Definition of done (Phase 1)
+
+- `tests/test_remap.py` and `tests/test_biological_equivalence.py` pass.
+- `test_biological_is_bit_identical_to_baseline` is green for ≥50 steps with
+  `deep_equal` (no tolerance).
+- `scripts/compare_biological.py` reports `max cell_mass Δ == 0`.
+- No process implementation was modified — `git diff --stat origin/main` touches
+  only `composites/_remap.py`, `composites/biological.py`, the two test files,
+  the script, and docs.
+
+## Out of scope (deferred to Phase 2)
+
+- Splitting `cell/molecules` into per-class sub-pools (needs an index-remap shim).
+- Unit-bearing / `describe()`-backed leaf schemas.
+- Distributing `cell/observables` into subsystem homes.
+- Cross-generation / daughter-carry and the `EcoliWCM` bridge under the new layout.
+- Remapping the dashboard catalog registration / explorer view.

--- a/docs/superpowers/specs/2026-06-13-biological-composite-design.md
+++ b/docs/superpowers/specs/2026-06-13-biological-composite-design.md
@@ -1,0 +1,180 @@
+# Biological Composite — design
+
+**Date:** 2026-06-13
+**Branch:** `feat/biological-composite`
+**Status:** approved design, Phase 1 to be implemented
+
+## Goal
+
+Build a new E. coli whole-cell composite for v2ecoli whose **store hierarchy is
+organized by biology** (cellular compartments → molecular classes) rather than by
+*representation* (`bulk` / `unique` / `listeners`). Reuse the existing process
+implementations wherever possible, make the wiring cleaner and the state tree
+interpretable, and **prove equivalence against the baseline composite**.
+
+A second axis — hardening units and schemas so the model is more biological,
+interpretable, and compositional — is sequenced as Phase 2, after Phase 1's
+re-wiring is proven equivalent.
+
+## Core insight
+
+Today's top-level stores (`bulk`, `unique`, `listeners`, plus coordination stores)
+are organized by *how state is represented and applied*, not by *what it is
+biologically*. process-bigraph cleanly separates **process update math** from
+**store routing**: every process declares ports and a module-level `TOPOLOGY`
+(port → store-path), and the baseline builder funnels all wiring through a single
+choke point (`make_edge`).
+
+Therefore the reorganization can be a **pure relabel of store paths**, not a
+rewrite of any process. If no store's internals are split and no update math
+changes, the simulated trajectory is **provably bit-identical** to the baseline.
+This is what makes a strong equivalence claim possible and is the backbone of
+Phase 1.
+
+## Two-phase plan
+
+- **Phase 1 — re-wire (bit-identical).** Reorganize store *paths* into a biological
+  hierarchy using a uniform path-remap. Leaf types are unchanged. Target: trajectories
+  numerically identical to baseline. **This is what we plan and build now.**
+- **Phase 2 — harden units & schemas (statistical equivalence).** Split the
+  monolithic pools into biological sub-pools, add unit-bearing / self-documenting
+  schemas, distribute observables into their subsystems. Target: biological markers
+  within tolerance of baseline. **Documented as a sketch; gated behind Phase 1.**
+
+Phasing isolates "did the reorganization change anything" (Phase 1, exact) from
+"did units hardening change anything" (Phase 2, tolerant) — each is independently
+debuggable.
+
+## Architecture
+
+### Phase 1 mechanism — the path-remap layer
+
+A new builder `biological()` reuses baseline's exact process *instances* and applies
+one `REMAP` (old store-path → new biological path) uniformly to three things:
+
+1. the pre-created store tree,
+2. the seeded initial state (from the ParCa cache bundle),
+3. every edge's input/output topology (the port → store-path mappings).
+
+Because process instances and update math are untouched and only routing labels
+change, the trajectory is identical to baseline.
+
+### Re-pathing granularity (an honest constraint)
+
+What is safely re-pathable in Phase 1 depends on how each store is structured:
+
+- **`unique.*`** — already per-type leaf arrays (`unique/active_RNAP`, …); processes
+  target those leaf paths. These get the **full biological treatment**: split across
+  `chromosome` / `transcription` / `translation`. Bit-identical-safe.
+- **`bulk`** — a single performance-critical monolithic structured array; every
+  process does global index lookups against it through one port. It **stays one
+  physical store** in Phase 1 (relocated whole), plus a biological *manifest*
+  (metadata grouping molecule names → metabolites / proteins / energy / bulk-RNA)
+  for interpretability. Physically splitting it is **Phase 2** (needs an index-remap
+  shim).
+- **`listeners`** — a single deep-merge (`DerivedProperties`) store; processes mostly
+  target it whole or via leaf sub-paths. **Relocated whole** in Phase 1; distributed
+  into subsystems in Phase 2.
+- **coordination stores** (`process`, `allocator_rng`, `process_state`,
+  `next_update_time`, `request`, `allocate`) and **clock stores** (`global_time`,
+  `timestep`, `divide`, `division_threshold`) — relocated whole under `machinery/`
+  and `clock/` so the biological view is not cluttered by plumbing.
+
+### Target hierarchy (Phase 1)
+
+```
+cell/
+  chromosome/          ← unique: full_chromosome, chromosome_domain, oriC,
+                              DnaA_box, chromosomal_segment, gene, active_replisome
+  transcription/       ← unique: active_RNAP→rna_polymerases, RNA→transcripts,
+                              promoter→promoters
+  translation/         ← unique: active_ribosome→ribosomes
+  molecules/           ← bulk (whole monolith) + biological name-manifest   [split in Phase 2]
+  observables/         ← listeners (whole)                                  [distributed in Phase 2]
+  regulation/          ← ppgpp_state, attenuation_config
+membrane/              ← placeholder seam (baseline has little; ties into the
+                              autopoiesis membrane v2ecoli lacks)
+environment/           ← boundary/external, environment metadata, exchange
+machinery/             ← process, allocator_rng, process_state, next_update_time,
+                              request, allocate
+clock/                 ← global_time, timestep, divide, division_threshold
+```
+
+`machinery/` and `clock/` deliberately pull bookkeeping out of `cell/` so the
+biological subtree reads as biology, not plumbing. `membrane/` is an intentional
+seam for the autopoiesis-style self-produced membrane.
+
+## Equivalence harness
+
+### Phase 1 — bit-identical assertion
+
+A `REMAP`-aware diff runs `baseline()` and `biological()` from the same seed and
+cache bundle and asserts the trajectories are identical after translating the
+biological state back through `REMAP⁻¹`:
+
+- **Structural:** the remapped biological state tree, projected back through
+  `REMAP⁻¹`, is key-for-key equal to baseline's tree (catches any wiring miss).
+- **Numerical:** per-step, every leaf array (`bulk` counts, each `unique` array,
+  every listener leaf) is `np.array_equal` to baseline. A single mismatch fails
+  loudly with the offending path.
+
+This runs as a pytest gate and reuses `scripts/compare_harness.py` plumbing, with
+the bar tightened from "within tolerance" to "identical."
+
+### Phase 2 — biological-marker equivalence
+
+Once units/schemas change, exact equality no longer holds, so the bar drops to
+statistical bands on biological observables: growth-rate curve, division time,
+dry-mass fractions (protein / RNA / DNA / water), replication-initiation timing,
+final molecule composition. Reported side-by-side (baseline vs biological) in an
+HTML comparison, in the style of the existing 3-way composite report.
+
+## Phase 2 — units & schema hardening (sketch only)
+
+Layered on the now-biological hierarchy:
+
+- **Split `cell/molecules`** into `cell/metabolism/metabolites`,
+  `cell/proteins/monomers`, `cell/proteins/complexes`, `cell/transcription/bulk_rna`,
+  `cell/metabolism/energy`, via an index-remap shim so existing processes still see
+  one logical pool. This change forces the statistical bar.
+- **Unit-bearing leaf schemas** (`quantity[float, fg]`, `count`, `mM`, …) so plot
+  axes auto-label and dimensional mismatches are catchable — building on the existing
+  units-propagation work.
+- **`describe()`-backed schemas** so each store is self-documenting.
+- **Distribute `observables`** into subsystem homes (`fba_results`→metabolism,
+  `rnap_data`→transcription, `ribosome_data`→translation,
+  `replication_data`→chromosome, etc.).
+
+Phase 2 stays a sketch here; scope is revisited only after Phase 1 passes.
+
+## Deliverables (Phase 1)
+
+- **Worktree + branch:** `feat/biological-composite` (isolated checkout).
+- `v2ecoli/composites/biological.py` — `biological()` `@composite_generator` + the
+  `REMAP` table.
+- `v2ecoli/composites/_remap.py` — the reusable path-remap transform (store tree,
+  initial state, topology) and its inverse `REMAP⁻¹`.
+- `tests/test_biological_equivalence.py` — the bit-identical pytest gate.
+- `scripts/compare_biological.py` — biological-marker comparison + HTML report
+  (Phase 2-ready).
+- This spec.
+
+## Scope discipline
+
+- Phase 1 only (re-wire + bit-identical proof) is planned and built now.
+- Phase 2 (pool splitting + units) is documented but gated behind Phase 1 success.
+- No process *internals* are modified in Phase 1 — only routing/topology and the
+  store tree shape. Any change that would touch a process's update math belongs to
+  Phase 2.
+
+## Open questions / risks
+
+- **`make_edge` choke point:** the remap assumes topology application is centralized
+  through `make_edge` in `composites/baseline.py` / `composites/_helpers.py`. Confirm
+  during planning that no process bypasses it with hard-coded absolute paths.
+- **Listener leaf-targeting processes:** confirm processes that read listener
+  sub-paths (e.g. metabolism reads `listeners/mass`) are remapped consistently when
+  `listeners` relocates whole.
+- **Type resolution dispatches:** the `_resolve_*` functions in `types/__init__.py`
+  key on store semantics, not paths, so relocation should be transparent — verify no
+  dispatch is path-sensitive.

--- a/docs/superpowers/specs/2026-06-13-biological-composite-design.md
+++ b/docs/superpowers/specs/2026-06-13-biological-composite-design.md
@@ -63,9 +63,17 @@ change, the trajectory is identical to baseline.
 
 What is safely re-pathable in Phase 1 depends on how each store is structured:
 
-- **`unique.*`** — already per-type leaf arrays (`unique/active_RNAP`, …); processes
-  target those leaf paths. These get the **full biological treatment**: split across
-  `chromosome` / `transcription` / `translation`. Bit-identical-safe.
+- **`unique.*`** — although these are per-type leaf arrays (`unique/active_RNAP`, …),
+  **they cannot be split in Phase 1.** Implementation discovered three consumers
+  (`division` and the two mass listeners) wire the *whole* `unique` map through a
+  single `InPlaceDict` / `map[node]` port and index molecules internally
+  (`division.py` reads `states['unique']` wholesale). Relocating any molecule out of
+  a shared `unique` store hands those consumers a partial map → divergence. So
+  `unique` **stays one store, relocated whole** to `cell/unique_molecules` in Phase 1
+  — exactly the constraint that applies to `bulk`. The per-molecule split across
+  `chromosome` / `transcription` / `translation` (the rename targets are kept in
+  `UNIQUE_REMAP_PHASE2`) is **Phase 2**, gated behind the same aggregator-view shim
+  as the `bulk` split.
 - **`bulk`** — a single performance-critical monolithic structured array; every
   process does global index lookups against it through one port. It **stays one
   physical store** in Phase 1 (relocated whole), plus a biological *manifest*
@@ -82,6 +90,28 @@ What is safely re-pathable in Phase 1 depends on how each store is structured:
 
 ### Target hierarchy (Phase 1)
 
+As-built Phase 1 (bit-identical to baseline):
+
+```
+cell/
+  molecules/           ← bulk (whole monolith)                              [split in Phase 2]
+  unique_molecules/    ← unique (whole — all 11 molecule types together)    [split in Phase 2]
+  observables/         ← listeners (whole)                                  [distributed in Phase 2]
+  regulation/          ← ppgpp_state, attenuation_config
+environment/           ← boundary/external, media metadata, exchange
+machinery/             ← process, allocator_rng, process_state, next_update_time,
+                              request, allocate
+clock/                 ← global_time, timestep, divide, division_threshold
+```
+
+`machinery/` and `clock/` deliberately pull bookkeeping out of `cell/` so the
+biological subtree reads as biology, not plumbing.
+
+The richer compartment layout below is the **Phase-2 target** — it requires the
+aggregator-view shim (so whole-map consumers still see all of `unique` / `bulk`
+while readers see split compartments), which trades bit-identity for statistical
+equivalence:
+
 ```
 cell/
   chromosome/          ← unique: full_chromosome, chromosome_domain, oriC,
@@ -89,20 +119,13 @@ cell/
   transcription/       ← unique: active_RNAP→rna_polymerases, RNA→transcripts,
                               promoter→promoters
   translation/         ← unique: active_ribosome→ribosomes
-  molecules/           ← bulk (whole monolith) + biological name-manifest   [split in Phase 2]
-  observables/         ← listeners (whole)                                  [distributed in Phase 2]
-  regulation/          ← ppgpp_state, attenuation_config
-membrane/              ← placeholder seam (baseline has little; ties into the
-                              autopoiesis membrane v2ecoli lacks)
-environment/           ← boundary/external, environment metadata, exchange
-machinery/             ← process, allocator_rng, process_state, next_update_time,
-                              request, allocate
-clock/                 ← global_time, timestep, divide, division_threshold
+  metabolism/          ← bulk: metabolites, energy carriers
+  proteins/            ← bulk: monomers, complexes
+membrane/              ← placeholder seam (ties into the autopoiesis membrane v2ecoli lacks)
 ```
 
-`machinery/` and `clock/` deliberately pull bookkeeping out of `cell/` so the
-biological subtree reads as biology, not plumbing. `membrane/` is an intentional
-seam for the autopoiesis-style self-produced membrane.
+`membrane/` is an intentional Phase-2 seam for the autopoiesis-style self-produced
+membrane.
 
 ## Equivalence harness
 

--- a/scripts/compare_biological.py
+++ b/scripts/compare_biological.py
@@ -1,0 +1,81 @@
+# scripts/compare_biological.py
+"""Run baseline vs biological for N steps and emit an HTML comparison of mass /
+growth markers. Phase 1: the two are identical by construction; this makes that
+visible and is the Phase-2 (tolerant) comparison's entry point.
+
+Usage:
+    python scripts/compare_biological.py --steps 100 \
+        --cache "$V2ECOLI_CACHE_DIR" --out out/biological_comparison.html
+"""
+from __future__ import annotations
+
+import argparse
+import os
+
+import v2ecoli.library.unit_bridge  # noqa: F401
+
+
+def _mass(agent_listeners) -> dict:
+    m = agent_listeners.get('mass', {})
+    def _f(x):
+        return float(getattr(x, 'magnitude', x))
+    return {k: _f(m[k]) for k in ('cell_mass', 'dry_mass') if k in m}
+
+
+def run(steps: int, cache: str):
+    from process_bigraph import Composite
+    from v2ecoli.core import build_core
+    from v2ecoli.composites.baseline import baseline, load_cache_bundle
+    from v2ecoli.composites.biological import biological
+
+    bundle = load_cache_bundle(cache)
+    cb = build_core()
+    base = Composite(baseline(core=cb, seed=0, bundle=bundle, emitter='null'), core=cb)
+    cx = build_core()
+    bio = Composite(biological(core=cx, seed=0, bundle=bundle, emitter='null'), core=cx)
+
+    rows = []
+    for i in range(steps):
+        base.run(1); bio.run(1)
+        bm = _mass(base.state['agents']['0']['listeners'])
+        xm = _mass(bio.state['agents']['0']['cell']['observables'])
+        rows.append((i + 1, bm, xm))
+    return rows
+
+
+def to_html(rows) -> str:
+    head = ("<tr><th>step</th><th>baseline cell_mass</th>"
+            "<th>biological cell_mass</th><th>Δ</th></tr>")
+    body = []
+    for step, bm, xm in rows:
+        b = bm.get('cell_mass', float('nan'))
+        x = xm.get('cell_mass', float('nan'))
+        body.append(f"<tr><td>{step}</td><td>{b:.6g}</td>"
+                    f"<td>{x:.6g}</td><td>{abs(b - x):.3g}</td></tr>")
+    return ("<html><head><meta charset='utf-8'><title>baseline vs biological</title>"
+            "<style>table{border-collapse:collapse}td,th{border:1px solid #ccc;"
+            "padding:4px 8px;font-family:monospace}</style></head><body>"
+            "<h1>Baseline vs Biological — mass markers</h1>"
+            "<p>Phase 1 is a pure relabel; Δ should be 0 at every step.</p>"
+            f"<table>{head}{''.join(body)}</table></body></html>")
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser()
+    p.add_argument('--steps', type=int, default=100)
+    p.add_argument('--cache', default=os.environ.get('V2ECOLI_CACHE_DIR', 'out/cache'))
+    p.add_argument('--out', default='out/biological_comparison.html')
+    args = p.parse_args(argv)
+
+    rows = run(args.steps, args.cache)
+    max_delta = max((abs(bm.get('cell_mass', 0) - xm.get('cell_mass', 0))
+                     for _, bm, xm in rows), default=0.0)
+    os.makedirs(os.path.dirname(args.out) or '.', exist_ok=True)
+    with open(args.out, 'w', encoding='utf-8') as f:
+        f.write(to_html(rows))
+    print(f"wrote {args.out}; max cell_mass Δ over {args.steps} steps = {max_delta:.3g}")
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tests/test_biological_equivalence.py
+++ b/tests/test_biological_equivalence.py
@@ -1,0 +1,35 @@
+"""Phase-1 equivalence gate: the biological composite is bit-identical to
+baseline. See docs/superpowers/specs/2026-06-13-biological-composite-design.md.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+import v2ecoli.library.unit_bridge  # noqa: F401  (registers pint units pre-cache)
+
+pytestmark = [
+    pytest.mark.sim,
+    pytest.mark.skipif(
+        not os.path.isdir(os.environ.get('V2ECOLI_CACHE_DIR', 'out/cache')),
+        reason="ParCa cache not present; set V2ECOLI_CACHE_DIR or build it.",
+    ),
+]
+
+CACHE = os.environ.get('V2ECOLI_CACHE_DIR', 'out/cache')
+
+
+def test_biological_builds_and_runs_one_step():
+    from process_bigraph import Composite
+    from v2ecoli.core import build_core
+    from v2ecoli.composites.biological import biological
+
+    core = build_core()
+    doc = biological(core=core, seed=0, cache_dir=CACHE, emitter='null')
+    composite = Composite(doc, core=core)
+    composite.run(1)  # must not raise
+
+    agent = composite.state['agents']['0']
+    assert 'cell' in agent and 'molecules' in agent['cell']
+    assert 'bulk' not in agent

--- a/tests/test_biological_equivalence.py
+++ b/tests/test_biological_equivalence.py
@@ -33,3 +33,52 @@ def test_biological_builds_and_runs_one_step():
     agent = composite.state['agents']['0']
     assert 'cell' in agent and 'molecules' in agent['cell']
     assert 'bulk' not in agent
+
+
+N_STEPS = 50  # enough to exercise transcription/translation/metabolism/replication
+
+
+def _data_pairs(baseline_agent, bio_agent):
+    """Yield (label, baseline_value, biological_value) for every data store we
+    assert on: the bulk pool, all unique molecules, and the listeners tree."""
+    from v2ecoli.composites._remap import REMAP, UNIQUE_REMAP
+
+    def _dig(tree, path):
+        node = tree
+        for seg in path:
+            node = node[seg]
+        return node
+
+    # bulk + listeners (relocated whole)
+    for old_key in ('bulk', 'listeners'):
+        yield (old_key, baseline_agent[old_key], _dig(bio_agent, REMAP[old_key]))
+    # every unique molecule present in baseline
+    for uname, val in baseline_agent['unique'].items():
+        target = UNIQUE_REMAP.get(uname, ('cell', uname))
+        yield (f'unique/{uname}', val, _dig(bio_agent, target))
+
+
+def test_biological_is_bit_identical_to_baseline():
+    from process_bigraph import Composite
+    from v2ecoli.core import build_core
+    from v2ecoli.composites.baseline import baseline, load_cache_bundle
+    from v2ecoli.composites.biological import biological
+    from _state_equal import deep_equal  # tests/ is on sys.path under pytest
+
+    bundle = load_cache_bundle(CACHE)  # one load -> identical initial state
+
+    core_b = build_core()
+    base = Composite(baseline(core=core_b, seed=0, bundle=bundle, emitter='null'),
+                     core=core_b)
+    core_x = build_core()
+    bio = Composite(biological(core=core_x, seed=0, bundle=bundle, emitter='null'),
+                    core=core_x)
+
+    for step in range(N_STEPS):
+        base.run(1)
+        bio.run(1)
+        ba = base.state['agents']['0']
+        xa = bio.state['agents']['0']
+        for label, bval, xval in _data_pairs(ba, xa):
+            ok, reason = deep_equal(bval, xval, path=label)
+            assert ok, f"divergence at step {step+1}, store {label}: {reason}"

--- a/tests/test_remap.py
+++ b/tests/test_remap.py
@@ -136,3 +136,28 @@ def test_biological_wraps_baseline_and_remaps(monkeypatch):
     # The outer document scaffolding is preserved verbatim.
     assert doc['skip_initial_steps'] is True
     assert doc['flow_order'] == ['emitter']
+
+
+def test_edge_instance_not_deepcopied_and_survives_unpicklable():
+    """Regression: remap must SHALLOW-copy edges. An edge holds a live process
+    instance (e.g. ParquetEmitter, which owns a _queue.SimpleQueue) that is
+    unpicklable and must stay the SAME shared object — deep-copying it both
+    crashes (cannot pickle SimpleQueue) and would wrongly clone the process."""
+    import queue
+    from v2ecoli.composites._remap import remap_cell_state
+
+    class _Unpicklable:
+        def __init__(self):
+            self.q = queue.SimpleQueue()  # not deep-copyable / picklable
+
+    inst = _Unpicklable()
+    cell_state = {
+        'bulk': np.array([1]),
+        'emitter': {'_type': 'step', 'instance': inst,
+                    'inputs': {'b': ['bulk']}, 'outputs': {}},
+    }
+    out = remap_cell_state(cell_state)              # must not raise
+    assert out['emitter']['instance'] is inst       # shared, not cloned
+    assert out['emitter']['inputs']['b'] == ['cell', 'molecules']
+    # original edge's wires untouched (no-mutation contract)
+    assert cell_state['emitter']['inputs']['b'] == ['bulk']

--- a/tests/test_remap.py
+++ b/tests/test_remap.py
@@ -8,11 +8,16 @@ def test_bulk_relocates_to_cell_molecules():
 def test_bulk_subpath_preserves_tail():
     assert remap_path(['bulk', 'count']) == ['cell', 'molecules', 'count']
 
-def test_unique_rnap_relocates_and_renames():
-    assert remap_path(['unique', 'active_RNAP']) == ['cell', 'transcription', 'rna_polymerases']
+def test_unique_relocates_whole_under_cell():
+    # Phase 1: `unique` relocates WHOLE (like `bulk`), not split per-molecule —
+    # division + the mass listeners consume the whole `unique` store through a
+    # single map-typed port, so molecules must stay co-located. The per-molecule
+    # biological split is deferred to Phase 2 (see UNIQUE_REMAP_PHASE2).
+    assert remap_path(['unique']) == ['cell', 'unique_molecules']
+    assert remap_path(['unique', 'active_RNAP']) == ['cell', 'unique_molecules', 'active_RNAP']
 
-def test_unique_chromosome_groups_under_chromosome():
-    assert remap_path(['unique', 'full_chromosome']) == ['cell', 'chromosome', 'full_chromosome']
+def test_unique_chromosome_molecule_stays_co_located():
+    assert remap_path(['unique', 'full_chromosome']) == ['cell', 'unique_molecules', 'full_chromosome']
 
 def test_listeners_subleaf_relocates():
     assert remap_path(['listeners', 'mass']) == ['cell', 'observables', 'mass']
@@ -70,8 +75,8 @@ def _fake_cell_state():
 def test_data_stores_move_to_biological_paths():
     out = remap_cell_state(_fake_cell_state())
     assert np.array_equal(out['cell']['molecules'], np.array([1, 2, 3]))
-    assert np.array_equal(out['cell']['transcription']['rna_polymerases'], np.array([10, 11]))
-    assert np.array_equal(out['cell']['chromosome']['full_chromosome'], np.array([7]))
+    assert np.array_equal(out['cell']['unique_molecules']['active_RNAP'], np.array([10, 11]))
+    assert np.array_equal(out['cell']['unique_molecules']['full_chromosome'], np.array([7]))
     assert out['cell']['observables']['mass'] == {'cell_mass': 4.0}
     assert out['clock']['global_time'] == 0.0
     assert out['machinery']['process_state'] == {'polypeptide_elongation': {'gtp_to_hydrolyze': 0}}
@@ -88,7 +93,7 @@ def test_edge_stays_at_root_and_wires_rewritten():
     edge = out['ecoli-metabolism']
     assert edge['_type'] == 'step'
     assert edge['inputs']['bulk'] == ['cell', 'molecules']
-    assert edge['inputs']['active_RNAP'] == ['cell', 'transcription', 'rna_polymerases']
+    assert edge['inputs']['active_RNAP'] == ['cell', 'unique_molecules', 'active_RNAP']
     assert edge['inputs']['mass'] == ['cell', 'observables', 'mass']
     assert edge['inputs']['global_time'] == ['clock', 'global_time']
     assert edge['inputs']['_layer_in_1'] == ['_layer_token_0']      # untouched

--- a/tests/test_remap.py
+++ b/tests/test_remap.py
@@ -99,3 +99,35 @@ def test_input_is_not_mutated():
     src = _fake_cell_state()
     remap_cell_state(src)
     assert 'bulk' in src and 'cell' not in src    # original untouched
+
+
+def test_biological_wraps_baseline_and_remaps(monkeypatch):
+    import v2ecoli.composites.biological as biomod
+
+    def fake_baseline(**kwargs):
+        return {
+            'state': {
+                'agents': {'0': {
+                    'bulk': [1],
+                    'unique': {'active_RNAP': [2]},
+                    'listeners': {'mass': {}},
+                    'global_time': 0.0,
+                    'emitter': {'_type': 'step', 'inputs': {'b': ['bulk']},
+                                'outputs': {}},
+                }},
+                'global_time': 0.0,
+            },
+            'skip_initial_steps': True,
+            'sequential_steps': False,
+            'flow_order': ['emitter'],
+        }
+
+    monkeypatch.setattr(biomod, 'baseline', fake_baseline)
+    doc = biomod.biological(seed=0)
+    agent = doc['state']['agents']['0']
+    assert set(agent) >= {'cell', 'clock', 'emitter'}
+    assert 'bulk' not in agent and 'unique' not in agent and 'listeners' not in agent
+    assert agent['emitter']['inputs']['b'] == ['cell', 'molecules']
+    # The outer document scaffolding is preserved verbatim.
+    assert doc['skip_initial_steps'] is True
+    assert doc['flow_order'] == ['emitter']

--- a/tests/test_remap.py
+++ b/tests/test_remap.py
@@ -1,0 +1,33 @@
+from v2ecoli.composites._remap import remap_path
+
+
+def test_bulk_relocates_to_cell_molecules():
+    assert remap_path(['bulk']) == ['cell', 'molecules']
+
+def test_bulk_subpath_preserves_tail():
+    assert remap_path(['bulk', 'count']) == ['cell', 'molecules', 'count']
+
+def test_unique_rnap_relocates_and_renames():
+    assert remap_path(['unique', 'active_RNAP']) == ['cell', 'transcription', 'rna_polymerases']
+
+def test_unique_chromosome_groups_under_chromosome():
+    assert remap_path(['unique', 'full_chromosome']) == ['cell', 'chromosome', 'full_chromosome']
+
+def test_listeners_subleaf_relocates():
+    assert remap_path(['listeners', 'mass']) == ['cell', 'observables', 'mass']
+
+def test_global_time_relocates_to_clock():
+    assert remap_path(['global_time']) == ['clock', 'global_time']
+
+def test_coordination_store_relocates_to_machinery():
+    assert remap_path(['process_state', 'polypeptide_elongation']) == \
+        ['machinery', 'process_state', 'polypeptide_elongation']
+
+def test_flow_token_is_left_untouched():
+    assert remap_path(['_layer_token_3']) == ['_layer_token_3']
+
+def test_unknown_head_is_left_untouched():
+    assert remap_path(['agents', '0']) == ['agents', '0']
+
+def test_empty_path_is_noop():
+    assert remap_path([]) == []

--- a/tests/test_remap.py
+++ b/tests/test_remap.py
@@ -1,4 +1,5 @@
-from v2ecoli.composites._remap import remap_path
+import numpy as np
+from v2ecoli.composites._remap import remap_path, remap_cell_state
 
 
 def test_bulk_relocates_to_cell_molecules():
@@ -31,3 +32,70 @@ def test_unknown_head_is_left_untouched():
 
 def test_empty_path_is_noop():
     assert remap_path([]) == []
+
+
+def _fake_edge():
+    # Mimics make_edge output: wires are {port: [path, segments]} lists.
+    return {
+        '_type': 'step',
+        'priority': 1.0,
+        'instance': object(),
+        '_inputs': {}, '_outputs': {},
+        'inputs': {
+            'bulk': ['bulk'],
+            'active_RNAP': ['unique', 'active_RNAP'],
+            'mass': ['listeners', 'mass'],
+            'global_time': ['global_time'],
+            '_layer_in_1': ['_layer_token_0'],
+        },
+        'outputs': {
+            'bulk': ['bulk'],
+            'next': ['next_update_time', 'metabolism'],
+        },
+    }
+
+
+def _fake_cell_state():
+    return {
+        'bulk': np.array([1, 2, 3]),
+        'unique': {'active_RNAP': np.array([10, 11]),
+                   'full_chromosome': np.array([7])},
+        'listeners': {'mass': {'cell_mass': 4.0}},
+        'global_time': 0.0,
+        'process_state': {'polypeptide_elongation': {'gtp_to_hydrolyze': 0}},
+        'ecoli-metabolism': _fake_edge(),
+    }
+
+
+def test_data_stores_move_to_biological_paths():
+    out = remap_cell_state(_fake_cell_state())
+    assert np.array_equal(out['cell']['molecules'], np.array([1, 2, 3]))
+    assert np.array_equal(out['cell']['transcription']['rna_polymerases'], np.array([10, 11]))
+    assert np.array_equal(out['cell']['chromosome']['full_chromosome'], np.array([7]))
+    assert out['cell']['observables']['mass'] == {'cell_mass': 4.0}
+    assert out['clock']['global_time'] == 0.0
+    assert out['machinery']['process_state'] == {'polypeptide_elongation': {'gtp_to_hydrolyze': 0}}
+
+
+def test_old_top_level_keys_are_gone():
+    out = remap_cell_state(_fake_cell_state())
+    for old in ('bulk', 'unique', 'listeners', 'global_time', 'process_state'):
+        assert old not in out
+
+
+def test_edge_stays_at_root_and_wires_rewritten():
+    out = remap_cell_state(_fake_cell_state())
+    edge = out['ecoli-metabolism']
+    assert edge['_type'] == 'step'
+    assert edge['inputs']['bulk'] == ['cell', 'molecules']
+    assert edge['inputs']['active_RNAP'] == ['cell', 'transcription', 'rna_polymerases']
+    assert edge['inputs']['mass'] == ['cell', 'observables', 'mass']
+    assert edge['inputs']['global_time'] == ['clock', 'global_time']
+    assert edge['inputs']['_layer_in_1'] == ['_layer_token_0']      # untouched
+    assert edge['outputs']['next'] == ['machinery', 'next_update_time', 'metabolism']
+
+
+def test_input_is_not_mutated():
+    src = _fake_cell_state()
+    remap_cell_state(src)
+    assert 'bulk' in src and 'cell' not in src    # original untouched

--- a/v2ecoli/composites/_remap.py
+++ b/v2ecoli/composites/_remap.py
@@ -1,0 +1,120 @@
+"""Pure path-remap: relabel the baseline store hierarchy into a biological
+(compartment -> molecular class) one. See
+docs/superpowers/specs/2026-06-13-biological-composite-design.md.
+
+The transform is a relabel only — no store internals are split and no update
+math changes — so a composite built through it is bit-identical to baseline.
+"""
+from __future__ import annotations
+
+import copy
+
+# Top-level data store -> new biological path. Coordination/clock stores move
+# under machinery/ and clock/ so the cell/ subtree reads as biology, not plumbing.
+REMAP: dict[str, tuple[str, ...]] = {
+    'bulk':               ('cell', 'molecules'),
+    'listeners':          ('cell', 'observables'),
+    'ppgpp_state':        ('cell', 'regulation', 'ppgpp_state'),
+    'attenuation_config': ('cell', 'regulation', 'attenuation_config'),
+    'boundary':           ('environment', 'boundary'),
+    'environment':        ('environment', 'media'),
+    'exchange':           ('environment', 'exchange'),
+    'process':            ('machinery', 'process'),
+    'allocator_rng':      ('machinery', 'allocator_rng'),
+    'process_state':      ('machinery', 'process_state'),
+    'next_update_time':   ('machinery', 'next_update_time'),
+    'request':            ('machinery', 'request'),
+    'allocate':           ('machinery', 'allocate'),
+    'global_time':        ('clock', 'global_time'),
+    'timestep':           ('clock', 'timestep'),
+    'divide':             ('clock', 'divide'),
+    'division_threshold': ('clock', 'division_threshold'),
+}
+
+# Each unique-molecule leaf -> its biological compartment/subsystem path.
+UNIQUE_REMAP: dict[str, tuple[str, ...]] = {
+    'full_chromosome':     ('cell', 'chromosome', 'full_chromosome'),
+    'chromosome_domain':   ('cell', 'chromosome', 'chromosome_domain'),
+    'oriC':                ('cell', 'chromosome', 'oriC'),
+    'DnaA_box':            ('cell', 'chromosome', 'DnaA_box'),
+    'chromosomal_segment': ('cell', 'chromosome', 'chromosomal_segment'),
+    'gene':                ('cell', 'chromosome', 'gene'),
+    'active_replisome':    ('cell', 'chromosome', 'active_replisome'),
+    'active_RNAP':         ('cell', 'transcription', 'rna_polymerases'),
+    'RNA':                 ('cell', 'transcription', 'transcripts'),
+    'promoter':            ('cell', 'transcription', 'promoters'),
+    'active_ribosome':     ('cell', 'translation', 'ribosomes'),
+}
+
+
+def remap_path(path: list) -> list:
+    """Rewrite one wire path (list of segments) into its biological location.
+
+    Leading segment(s) are rewritten through UNIQUE_REMAP (for 'unique/<x>')
+    or REMAP; the tail is preserved. Unknown heads (flow tokens, 'agents', …)
+    pass through unchanged.
+    """
+    if not path:
+        return list(path)
+    head = path[0]
+    if head == 'unique' and len(path) >= 2 and path[1] in UNIQUE_REMAP:
+        return list(UNIQUE_REMAP[path[1]]) + list(path[2:])
+    if head in REMAP:
+        return list(REMAP[head]) + list(path[1:])
+    return list(path)
+
+
+_EDGE_TYPES = ('step', 'process')
+
+
+def _is_edge(value) -> bool:
+    return isinstance(value, dict) and value.get('_type') in _EDGE_TYPES
+
+
+def _set_path(tree: dict, path: tuple, value) -> None:
+    """Place value at nested path, creating intermediate dicts."""
+    node = tree
+    for seg in path[:-1]:
+        node = node.setdefault(seg, {})
+    node[path[-1]] = value
+
+
+def _rewrite_wires(wires):
+    """Rewrite a wire structure (dict of port -> path-list, possibly nested)."""
+    if isinstance(wires, list):
+        return remap_path(wires)
+    if isinstance(wires, dict):
+        return {k: _rewrite_wires(v) for k, v in wires.items()}
+    return wires
+
+
+def remap_cell_state(cell_state: dict) -> dict:
+    """Return a new cell-state tree with data stores relocated to biological
+    paths and every edge's wires rewritten. Edges stay at the root. The input
+    is not mutated.
+
+    Unknown non-edge keys (not in REMAP, not 'unique') are carried over at the
+    root unchanged so nothing is silently dropped.
+    """
+    out: dict = {}
+    for key, value in cell_state.items():
+        if _is_edge(value):
+            edge = copy.deepcopy(value)
+            if 'inputs' in edge:
+                edge['inputs'] = _rewrite_wires(edge['inputs'])
+            if 'outputs' in edge:
+                edge['outputs'] = _rewrite_wires(edge['outputs'])
+            out[key] = edge
+        elif key == 'unique':
+            for uname, uval in value.items():
+                target = UNIQUE_REMAP.get(uname)
+                if target is None:
+                    # Unmapped unique molecule: keep under cell/<name> rather
+                    # than drop it, and make the omission visible.
+                    target = ('cell', uname)
+                _set_path(out, target, uval)
+        elif key in REMAP:
+            _set_path(out, REMAP[key], value)
+        else:
+            out[key] = value
+    return out

--- a/v2ecoli/composites/_remap.py
+++ b/v2ecoli/composites/_remap.py
@@ -11,8 +11,22 @@ import copy
 
 # Top-level data store -> new biological path. Coordination/clock stores move
 # under machinery/ and clock/ so the cell/ subtree reads as biology, not plumbing.
+#
+# `unique` is RELOCATED WHOLE (like `bulk`), not split per-molecule. The spec's
+# target hierarchy split unique molecules across cell/chromosome,
+# cell/transcription and cell/translation on the premise that "processes target
+# unique leaf paths." That premise is false in this codebase: the division
+# process (port schema InPlaceDict) and both mass listeners (port schema
+# map[node]) wire one port to the WHOLE `unique` store and read every molecule
+# through it. Physically moving any molecule out of a shared `unique` store
+# would hand those consumers a partial map and break bit-identity. So Phase 1
+# keeps `unique` co-located under cell/unique_molecules (exactly the treatment
+# `bulk` gets); the per-molecule biological split + renames are deferred to
+# Phase 2 (same gate as splitting `bulk`). See UNIQUE_REMAP below for the
+# intended Phase-2 targets, kept for reference.
 REMAP: dict[str, tuple[str, ...]] = {
     'bulk':               ('cell', 'molecules'),
+    'unique':             ('cell', 'unique_molecules'),
     'listeners':          ('cell', 'observables'),
     'ppgpp_state':        ('cell', 'regulation', 'ppgpp_state'),
     'attenuation_config': ('cell', 'regulation', 'attenuation_config'),
@@ -31,8 +45,24 @@ REMAP: dict[str, tuple[str, ...]] = {
     'division_threshold': ('clock', 'division_threshold'),
 }
 
-# Each unique-molecule leaf -> its biological compartment/subsystem path.
+# Phase-1 location of every unique-molecule leaf: co-located WHOLE under
+# cell/unique_molecules/<name> (see the REMAP['unique'] note). The equivalence
+# test's _data_pairs helper reads this map to locate each molecule in the
+# biological tree. The Phase-2 split/rename targets (chromosome/transcription/
+# translation, e.g. active_RNAP -> rna_polymerases) are recorded in
+# UNIQUE_REMAP_PHASE2 below but are NOT applied in Phase 1.
+_UNIQUE_NAMES = (
+    'full_chromosome', 'chromosome_domain', 'oriC', 'DnaA_box',
+    'chromosomal_segment', 'gene', 'active_replisome', 'active_RNAP',
+    'RNA', 'promoter', 'active_ribosome',
+)
 UNIQUE_REMAP: dict[str, tuple[str, ...]] = {
+    name: ('cell', 'unique_molecules', name) for name in _UNIQUE_NAMES
+}
+
+# Deferred Phase-2 biological split/rename for unique molecules (reference only;
+# not reachable as a pure relabel — see REMAP['unique']).
+UNIQUE_REMAP_PHASE2: dict[str, tuple[str, ...]] = {
     'full_chromosome':     ('cell', 'chromosome', 'full_chromosome'),
     'chromosome_domain':   ('cell', 'chromosome', 'chromosome_domain'),
     'oriC':                ('cell', 'chromosome', 'oriC'),
@@ -50,15 +80,15 @@ UNIQUE_REMAP: dict[str, tuple[str, ...]] = {
 def remap_path(path: list) -> list:
     """Rewrite one wire path (list of segments) into its biological location.
 
-    Leading segment(s) are rewritten through UNIQUE_REMAP (for 'unique/<x>')
-    or REMAP; the tail is preserved. Unknown heads (flow tokens, 'agents', …)
-    pass through unchanged.
+    The leading segment is rewritten through REMAP (``unique`` included — it is
+    relocated whole, so both the bare ``['unique']`` port wire and any
+    ``['unique', <molecule>, …]`` leaf wire repath consistently under
+    ``cell/unique_molecules``); the tail is preserved. Unknown heads (flow
+    tokens, 'agents', …) pass through unchanged.
     """
     if not path:
         return list(path)
     head = path[0]
-    if head == 'unique' and len(path) >= 2 and path[1] in UNIQUE_REMAP:
-        return list(UNIQUE_REMAP[path[1]]) + list(path[2:])
     if head in REMAP:
         return list(REMAP[head]) + list(path[1:])
     return list(path)
@@ -80,7 +110,14 @@ def _set_path(tree: dict, path: tuple, value) -> None:
 
 
 def _rewrite_wires(wires):
-    """Rewrite a wire structure (dict of port -> path-list, possibly nested)."""
+    """Rewrite a wire structure (dict of port -> path-list, possibly nested).
+
+    Every store (``bulk``, ``unique``, ``listeners`` and the coordination/clock
+    stores) relocates whole, so a port wired to a whole subtree (``['unique']``,
+    ``['bulk']``, …) simply repaths to the new root and its sub-ports/children
+    bind underneath exactly as before — a pure relabel, no process internals
+    touched.
+    """
     if isinstance(wires, list):
         return remap_path(wires)
     if isinstance(wires, dict):
@@ -93,8 +130,9 @@ def remap_cell_state(cell_state: dict) -> dict:
     paths and every edge's wires rewritten. Edges stay at the root. The input
     is not mutated.
 
-    Unknown non-edge keys (not in REMAP, not 'unique') are carried over at the
-    root unchanged so nothing is silently dropped.
+    Unknown non-edge keys (not in REMAP) are carried over at the root unchanged
+    so nothing is silently dropped. ``unique`` is in REMAP (relocated whole), so
+    its molecules move together under cell/unique_molecules.
     """
     out: dict = {}
     for key, value in cell_state.items():
@@ -105,14 +143,6 @@ def remap_cell_state(cell_state: dict) -> dict:
             if 'outputs' in edge:
                 edge['outputs'] = _rewrite_wires(edge['outputs'])
             out[key] = edge
-        elif key == 'unique':
-            for uname, uval in value.items():
-                target = UNIQUE_REMAP.get(uname)
-                if target is None:
-                    # Unmapped unique molecule: keep under cell/<name> rather
-                    # than drop it, and make the omission visible.
-                    target = ('cell', uname)
-                _set_path(out, target, uval)
         elif key in REMAP:
             _set_path(out, REMAP[key], value)
         else:

--- a/v2ecoli/composites/_remap.py
+++ b/v2ecoli/composites/_remap.py
@@ -39,6 +39,7 @@ REMAP: dict[str, tuple[str, ...]] = {
     'next_update_time':   ('machinery', 'next_update_time'),
     'request':            ('machinery', 'request'),
     'allocate':           ('machinery', 'allocate'),
+    'pinned_flux_targets': ('machinery', 'pinned_flux_targets'),
     'global_time':        ('clock', 'global_time'),
     'timestep':           ('clock', 'timestep'),
     'divide':             ('clock', 'divide'),

--- a/v2ecoli/composites/_remap.py
+++ b/v2ecoli/composites/_remap.py
@@ -7,8 +7,6 @@ math changes — so a composite built through it is bit-identical to baseline.
 """
 from __future__ import annotations
 
-import copy
-
 # Top-level data store -> new biological path. Coordination/clock stores move
 # under machinery/ and clock/ so the cell/ subtree reads as biology, not plumbing.
 #
@@ -138,7 +136,13 @@ def remap_cell_state(cell_state: dict) -> dict:
     out: dict = {}
     for key, value in cell_state.items():
         if _is_edge(value):
-            edge = copy.deepcopy(value)
+            # SHALLOW copy the edge, then swap in freshly-rewritten wire dicts.
+            # Never deep-copy: the edge holds a live process/step ``instance``
+            # (e.g. ParquetEmitter, which owns a _queue.SimpleQueue) that is
+            # unpicklable AND must stay the same shared object. _rewrite_wires
+            # builds brand-new lists/dicts, so the original edge's inputs/outputs
+            # are left untouched — the no-mutation contract still holds.
+            edge = dict(value)
             if 'inputs' in edge:
                 edge['inputs'] = _rewrite_wires(edge['inputs'])
             if 'outputs' in edge:

--- a/v2ecoli/composites/biological.py
+++ b/v2ecoli/composites/biological.py
@@ -1,0 +1,45 @@
+"""Biologically-organized E. coli whole-cell composite.
+
+Identical simulation to ``baseline()`` — same processes, same update math —
+but the store hierarchy is relabeled into cellular compartments / molecular
+classes via a pure path-remap (see _remap.py and
+docs/superpowers/specs/2026-06-13-biological-composite-design.md).
+
+Phase 1: relabel only -> bit-identical to baseline (see
+tests/test_biological_equivalence.py). Phase 2 (not built here) splits the
+monolithic pools and adds unit-bearing schemas.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from pbg_superpowers.composite_generator import composite_generator
+
+from v2ecoli.composites.baseline import baseline
+from v2ecoli.composites._remap import remap_cell_state
+
+
+@composite_generator(
+    name="biological",
+    description="Biologically-organized E. coli whole-cell model — relabeled store hierarchy",
+    emitters=[
+        {
+            "address": "local:ParquetEmitter",
+            "config": {},
+            # Remapped emit paths (baseline used global_time/bulk/listeners).
+            "paths": ["clock/global_time", "cell/molecules", "cell/observables"],
+        },
+    ],
+)
+def biological(core: Any = None, **kwargs) -> dict:
+    """Build the biological composite document.
+
+    All keyword arguments are forwarded verbatim to :func:`baseline`
+    (seed, cache_dir, emitter, feature toggles, bundle, …). The finished
+    baseline document is then relabeled in place at ``state.agents.<id>``.
+    """
+    doc = baseline(core=core, **kwargs)
+    agents = doc['state']['agents']
+    for agent_id, cell_state in list(agents.items()):
+        agents[agent_id] = remap_cell_state(cell_state)
+    return doc


### PR DESCRIPTION
## Summary

Adds `biological()` — an E. coli whole-cell composite whose store hierarchy is organized by **cellular compartment → molecular class** instead of by representation (`bulk`/`unique`/`listeners`). Phase 1 reorganizes via a **pure path-remap** of the finished `baseline()` document, so the simulation is **provably bit-identical** to baseline. Units/schema hardening + the rich compartment split are Phase 2.

**As-built Phase 1 hierarchy** (bit-identical):
```
cell/  molecules (bulk) · unique_molecules (unique) · observables (listeners) · regulation
environment/  boundary · media · exchange
machinery/  process · allocator_rng · request · allocate · next_update_time · pinned_flux_targets
clock/  global_time · timestep · divide
```
`machinery/`+`clock/` pull bookkeeping out of `cell/` so the biological subtree reads as biology.

## Mechanism
`biological()` calls `baseline()` (all build-time seeding runs on the original layout), then `remap_cell_state()` relocates data subtrees and rewrites every edge's `inputs`/`outputs` wires through one `REMAP` table. No process internals change → identical trajectory.

## Key finding (scope correction)
The original spec assumed `unique.*` molecules could be split across `chromosome`/`transcription`/`translation` in Phase 1. Implementation found `division` + the two mass listeners read the **whole** `unique` map through a single port, so splitting hands them a partial map. `unique` therefore relocates **whole** (same constraint as the monolithic `bulk` pool); the per-molecule split + renames + unit-bearing schemas are deferred to Phase 2 behind an aggregator-view shim (statistical-equivalence bar). Split targets preserved in `UNIQUE_REMAP_PHASE2`. Spec doc updated to match.

## Files
- `v2ecoli/composites/_remap.py` — REMAP tables + `remap_path` / `remap_cell_state`
- `v2ecoli/composites/biological.py` — `biological()` `@composite_generator`
- `tests/test_remap.py` — 15 unit tests (pure)
- `tests/test_biological_equivalence.py` — smoke + the bit-identical gate
- `scripts/compare_biological.py` — baseline-vs-biological mass report (Δ=0)
- `docs/superpowers/{specs,plans}/2026-06-13-biological-composite-*` — design + plan

## Test Plan
- [x] `pytest tests/test_remap.py tests/test_biological_equivalence.py` → **17 passed** (~30s)
- [x] Bit-identical gate: 50 steps, `deep_equal` over bulk + all 11 unique molecules + listeners, no tolerance, two independent composites from one bundle+seed
- [x] `scripts/compare_biological.py --steps 50` → `max cell_mass Δ = 0`
- [x] Rebased on current `origin/main` (234f39c); diff touches only the 7 new files

## Known fast-follows (Minor, from review)
- Reuse baseline's `parameters`/`default_n_steps`/`visualizations` in the decorator for dashboard parity
- Drop redundant `UNIQUE_REMAP` in favor of `remap_path` in the test helper

🤖 Generated with [Claude Code](https://claude.com/claude-code)