### PR TITLE
chore(deps): bump vivarium-dashboard lock (publish stragglers)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -4310,7 +4310,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/3e/87/794e0b4c5dccbca30
 [[package]]
 name = "vivarium-dashboard"
 version = "0.1.0"
-source = { git = "https://github.com/vivarium-collective/vivarium-dashboard.git?branch=main#1d5a266aa3eca8ef46935915207ddc66194b2e18" }
+source = { git = "https://github.com/vivarium-collective/vivarium-dashboard.git?branch=main#4399ad90fe0a77df4724457b51308eac413e9ff4" }
 dependencies = [
     { name = "bigraph-loom" },
     { name = "bigraph-schema" },


### PR DESCRIPTION
Bumps the `vivarium-dashboard` git lock to current main (`4399ad9`, PR #271) so the republished read-only dashboard + investigation reports pick up:
- multiscale-bioprocess report crash fix (`findings.filter`)
- v2ecoli-pdmp "Failed to fetch" fix (string `assumptions` + never-drop-connection)
- Composites tab `baseline`/`parca` de-duplication
- Sim DB Investigation + Emitter columns populated

Lock-only change; merging triggers the publish workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)