### PR TITLE
Fact-check investigation prose against actual structure (counts, studies, statuses)

### DIFF
--- a/workspace/investigations/colonies/investigation.yaml
+++ b/workspace/investigations/colonies/investigation.yaml
@@ -25,8 +25,9 @@ hypothesis: |
   processes, not cells per process.
 
 description: |
-  Two-study investigation to certify the colony composite for HPC
-  deployment.
+  Investigation to certify the colony composite for HPC deployment. One study
+  is complete (colonies-01-hpc-readiness); a second (colonies-02-hpc-deployment)
+  is planned.
 
   Study 1 — colonies-01-hpc-readiness (this study):
     Build phase: fix daughter-process hydration so structural _add

--- a/workspace/investigations/ketchup-baseline-comparison/investigation.yaml
+++ b/workspace/investigations/ketchup-baseline-comparison/investigation.yaml
@@ -35,7 +35,7 @@ executive:
     PARTIAL match across four kinetic reference models. The matched exchanges
     agree in DIRECTION (glucose/O2/NH3/SO4 uptake, CO2 secretion) but diverge in
     MAGNITUDE: per 100 glucose, the KETCHUP core models respire far more (O2
-    ~-135 vs v2ecoli -9; CO2 ~+145 vs +33) and secrete acetate (~+71) where
+    ~-135 vs v2ecoli -9; CO2 ~+144 vs +33) and secrete acetate (~+71) where
     v2ecoli's baseline shows none — so acetate is a qualitative mismatch ("lost"
     from v2ecoli's side). Identity-line R^2 is negative for both cores (-0.89 vs
     k-ecoli74, -0.72 vs k-ecoli307). v2ecoli AGREES with the Millard 2017 ODE
@@ -65,7 +65,7 @@ scientific_argument:
     KETCHUP models predict substantially deeper respiration and aerobic acetate
     overflow per glucose, neither of which the v2ecoli baseline exhibits.
   evidence_for:
-  - "Graded via the PR #134 flux_scatter criterion over the 6 shared central-carbon exchanges, glucose-normalized: signs match on all 5 quantitatively-compared fluxes; identity-line R^2 = -0.89 (k-ecoli74) and -0.72 (k-ecoli307). [REALIZED — see ketchup-exchange-comparison.]"
+  - "Graded via the PR #134 flux_scatter criterion over the 6 shared central-carbon exchanges, glucose-normalized: signs match on the quantitatively-compared fluxes (acetate is lost, not compared); identity-line R^2 = -0.89 (k-ecoli74) and -0.72 (k-ecoli307). [REALIZED — see ketchup-exchange-comparison.]"
   - "Acetate is a qualitative mismatch: both KETCHUP models secrete acetate (~+71 per 100 glucose) while v2ecoli's baseline secretes none (0.0), flagged as 'lost' by the grader. [REALIZED.]"
   - "The two KETCHUP models agree closely with each other (shared K-FIT data lineage), so the divergence is v2ecoli-vs-core-kinetic-model, not model-specific noise. [REALIZED.]"
   - "v2ecoli AGREES with the Millard 2017 ODE (flux_scatter R^2 = 1.00): both run glucose-limited with no acetate overflow (narrow — Millard exchanges only glucose + acetate). [REALIZED.]"

--- a/workspace/investigations/multiscale-bioprocess/investigation.yaml
+++ b/workspace/investigations/multiscale-bioprocess/investigation.yaml
@@ -286,13 +286,13 @@ description: |
   Studies, in dependency order (with current `phase` shown — multi-axis
   status is canonical, see each study.yaml):
 
-  1. mbp-01-time-varying-environment — **Build phase** — v2ecoli
+  1. mbp-01-time-varying-environment — **Evaluate phase** — v2ecoli
      enhancement: media / environment becomes externally driven (time-
      varying nutrient pool consumed by the existing Layer-1 Steps). PLUMBING
      + qualitative-extreme tests only (per chris_feedback_2026_05_26 §3);
      gradient-shape / quantitative-biology defer to
      `transport-kinetics-fidelity` candidate-future-study.
-  2. mbp-02-population-aggregation   — **Build phase** — v2ecoli
+  2. mbp-02-population-aggregation   — **Evaluate phase** — v2ecoli
      enhancement: aggregate per-cell mass into reactor-scale biomass /
      OD600 / cell-count via `cells_per_agent` representative-sampling
      scaling (chris_feedback_2026_05_26 §4; Eran's choice over literal-sum
@@ -322,6 +322,11 @@ description: |
      Walks the mbp-01..05 artifacts, synthesizes gaps across five axes
      (v2ecoli biology / coupling / BiRD physics / Beulig scope /
      methodology), and feeds the next investigation iteration.
+  7. mbp-07-millard-kinetic-metabolism — Evaluate phase — kinetic-metabolism
+     (Millard 2017) drop-in cell engine (baseline_millard) + reactor coupling,
+     validated against the FBA baseline and graded head-to-head against the
+     Beulig WT batch prefix alongside the WCM-FBA and iML1515 arms (3-arm
+     report cards).
 
 
 # ─── Methodology discipline ─────────────────────────────────────────────────
@@ -433,7 +438,9 @@ executive:
     population aggregation with representative-sampling scaling (mbp-02),
     BiRD reactor coupling (mbp-03), multigeneration coupled runs (mbp-04),
     a structured sim-vs-Beulig comparison report (mbp-05, EVALUATION
-    phase), and gap analysis feeding the next iteration (mbp-06).
+    phase), gap analysis feeding the next iteration (mbp-06), and a
+    kinetic-metabolism (Millard 2017) drop-in engine with 3-arm Beulig
+    report cards (mbp-07).
 
   verdict: |
     **Build phase complete for mbp-01 and mbp-02; ready for Evaluate

--- a/workspace/investigations/parameter-uq/investigation.yaml
+++ b/workspace/investigations/parameter-uq/investigation.yaml
@@ -67,7 +67,7 @@ executive:
     ribosome speed → protein-synthesis flux → growth rate.
 
     The broader program is underway: param-uq-00-screen (EXECUTED) established the
-    effective parameter surface; param-uq-02-observables (RUNNING) is testing
+    effective parameter surface; param-uq-02-observables (EXECUTED) tested
     multi-observable robustness at 360 steps; param-uq-03-growth-stratified and
     param-uq-04-deep-params are PLANNED — the former requires multi-generation
     runs + pbg-uq strategy extension, the latter requires sim_data injection +

--- a/workspace/investigations/units-atlas/investigation.yaml
+++ b/workspace/investigations/units-atlas/investigation.yaml
@@ -8,8 +8,8 @@ question: |
   What quantities does the E. coli whole-cell simulation expose on its
   listener and process ports, in what physical units, and over what magnitude
   ranges? This is a DESCRIPTIVE reference, not a hypothesis test — a navigable
-  catalog of every unit-bearing readout, grouped by physical dimension (mass,
-  time, concentration, rate, count, volume, length), built directly from the
+  catalog of every unit-bearing readout, grouped by physical dimension
+  (concentration, count, mass, rate, time, and "other"), built directly from the
   declared `quantity[...]` / `float[unit]` port types via live schema
   resolution (`v2ecoli.library.units_resolver.build_units_index`). It pairs
   with the units-propagation feature that auto-labels plot axes from these same
@@ -54,7 +54,8 @@ biological_story: |
   dry mass in femtograms (mass), metabolite and growth-limiting nutrient levels
   as concentrations in mM/uM (concentration — the largest group, including FBA
   targets), reaction and elongation rates in 1/s (rate), molecule copy numbers
-  as counts, the cell's volume and length as it elongates (volume/length), and a
+  as counts, cell and molecular masses in fg (mass) and characteristic times in
+  seconds (time), and a
   handful of flux-like quantities (e.g. g*s/L, mmol/g/h) in "other". Each of
   these dimensions corresponds to a distinct biological quantity a modeler reads
   off the simulation, and a unit attached to a readout is what lets that number

--- a/workspace/investigations/v2ecoli-baseline-showcase/investigation.yaml
+++ b/workspace/investigations/v2ecoli-baseline-showcase/investigation.yaml
@@ -14,9 +14,12 @@ status: active
 #   4. run ALL four candidate perturbations as a 5-variant sweep and rank how
 #      far each moves the cell off baseline (media-succinate strongest;
 #      ppGpp-off de-represses; dnaA-2x partial; elong-down near-null),
-#   5. stop at the NEXT-direction DECISION, seeded from the showcase-4 ranking.
-# showcase-4 is RUN (5-variant sweep + 8 comparison figures); studies 3 and 5
-# are reviewer-decision studies that stay un-run until a choice is made.
+#   5. stop at the NEXT-direction DECISION, seeded from the showcase-4 ranking,
+#   6. run the 16x16 v1<->v2 equivalence-at-scale ensemble, graded against the
+#      vEcoli reference across 21 axes (in progress; PARTIAL — exchange-flux +
+#      gene-expression below the strict band, a localized #143 divergence).
+# showcase-4 and showcase-6 are RUN; studies 3 and 5 are reviewer-decision
+# studies that stay un-run until a choice is made.
 
 question: |
   Can v2ecoli, starting from the raw ecoli-sources flat files, rebuild the
@@ -30,7 +33,7 @@ question: |
 
 executive:
   what_is_this: |
-    A five-study walkthrough of the v2ecoli pipeline, built as a demonstration
+    A six-study walkthrough of the v2ecoli pipeline, built as a demonstration
     rather than a hypothesis test:
       • showcase-1-parca — rebuild the ParCa in full from the ~133
         ecoli-sources flat files (--mode full, 51 TF conditions) and confirm
@@ -58,8 +61,15 @@ executive:
         seeded from the showcase-4 ranking: deepen the strongest contrast (a
         growth-condition panel), chase the ppGpp-off surprise (synthesis vs
         regulation 2x2), push the dnaA knob, or rescue the elong-down null.
-    showcase-4 is RUN (the 5-variant sweep + 8 figures are complete); the two
-    decision studies (3 and 5) stay un-run until a reviewer chooses.
+      • showcase-6-equivalence-large — run the 16x16 v1<->v2 equivalence-at-scale
+        ensemble and grade v2ecoli against the vEcoli reference across 21 axes.
+        In progress; PARTIAL — physiology, composition, and ribosomes fall within
+        tolerance, while exchange-flux (O2/CO2) and gene-expression sit below the
+        strict band (a localized, expected divergence, issue #143), so the overall
+        report card reads MISMATCH.
+    showcase-4 and showcase-6 are RUN (the 5-variant sweep + 8 figures, and the
+    16x16 equivalence ensemble); the two decision studies (3 and 5) stay un-run
+    until a reviewer chooses.
   verdict_status: in-progress
   verdict_detail: |
     The pipeline is exercised end-to-end and the perturbation-response half is

--- a/workspace/investigations/v2ecoli-pdmp/investigation.yaml
+++ b/workspace/investigations/v2ecoli-pdmp/investigation.yaml
@@ -511,7 +511,7 @@ how_we_run_pdmps: "This section is the operational complement to the conceptual 
   \ across the\n    trajectory axis; downstream emitter writes whole rows to zarr.\n\n## RNG, seeds, replicates\n\n- Each\
   \ replicate has a unique seed (`overrides.seed = <int>`).\n  The composite's stochastic processes (FBA stochasticRound,\
   \ jump\n  timing) draw from a numpy `default_rng(seed)`-derived stream.\n- Ensembles are scheduled as N independent runs\
-  \ with seeds\n  0..N-1 (Phase 0 reference is N=64 per condition × 3 conditions =\n  192 runs). The dashboard's run-runner\
+  \ with seeds\n  0..N-1 (the canonical Phase 0 reference TARGET is N=64 per condition × 3 conditions =\n  192 runs; the committed ensemble is N=32 = 96 runs — do NOT cite as N=64). The dashboard's run-runner\
   \ enforces a CONCURRENCY_CAP\n  so we don't OOM; long ensembles run as a serial queue.\n- PDMP segments are reproducible\
   \ bit-identically when re-simulated\n  with the same (state, seed) — this is the Markov-property\n  verification gate.\n\
   \n## Storage / persistence\n\n- Trajectories: zarr stores under `.pbg/runs/<run_id>/store.zarr/`\n  (chunked on time axis,\


### PR DESCRIPTION
Reviewing the live read-only snapshot surfaced authored prose that contradicts the real data (e.g. the Colony investigation says "Two-study investigation" but the badge shows "1 study"). Fact-checked all 7 published investigations and corrected the contradictions.

| Investigation | Correction |
|---|---|
| **colonies** | "Two-study investigation" → one complete (colonies-01) + one planned (colonies-02), matching the "1 study" badge |
| **v2ecoli-baseline-showcase** | "five-study" → "six-study"; added the missing **showcase-6** to the header-comment list + executive bullets (added 2026-06-12, prose never updated) |
| **multiscale-bioprocess** | added missing **mbp-07** to the numbered study list + executive summary; stale "Build phase" → "Evaluate phase" for mbp-01/mbp-02 |
| **parameter-uq** | param-uq-02 "(RUNNING) is testing" → "(EXECUTED) tested" (study is evaluated/passed) |
| **units-atlas** | dimension list named non-existent "volume, length" and omitted real "mass/time/other" → corrected to the actual 6 groups |
| **ketchup-baseline-comparison** | "all 5 …fluxes" → "the quantitatively-compared fluxes (acetate is lost)"; CO2 ~+145 → ~+144 |
| **v2ecoli-pdmp** | clarified Phase-0 reference is a **target** of N=64 (192 runs); committed ensemble is N=32 (96 runs) — studies warn "do NOT cite as N=64" |

All 7 `investigation.yaml` files validated to parse. **v2ecoli-pdmp** note: it has deeper stale-vs-updated verdict-layer contradictions (some prose under-claims now-passing increments, some verdict text over-claims ahead of `gate_status`); left for the investigation owner to reconcile rather than rewritten here, given it's an active, previously-de-slopped investigation.

Merging auto-triggers the publish workflows (`workspace/**` paths), republishing the corrected investigation reports + dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)