### PR TITLE
PTools: filesystem-mode data dir config (ui.ptools_data_dir)

### DIFF
--- a/workspace.yaml
+++ b/workspace.yaml
@@ -137,3 +137,9 @@ ui:
   # host.docker.internal lets the container reach the dashboard on the host.
   # Adjust the port to match how you serve the dashboard.
   dashboard_public_base_url: "http://host.docker.internal:8771"
+  # sms-ptools 0.8.2 reads the omics file from its OWN filesystem (it does not
+  # fetch the URL over HTTP). Mount the workspace into the container and set the
+  # container-side path of the dashboard's --workspace root here; the launcher
+  # then passes <ptools_data_dir>/<rel> as the data file. Run the container with:
+  #   -v <host>/v2ecoli/workspace:/ptools-data/workspace:ro
+  ptools_data_dir: "/ptools-data"


### PR DESCRIPTION
Sets `ui.ptools_data_dir: "/ptools-data"` so the PTools launcher passes a server-local file path (sms-ptools 0.8.2 reads omics from disk, it doesn't fetch the URL). Pairs with vivarium-dashboard #272.

Run the PTools container with the workspace mounted:
```bash
docker run -d --name sms-ptools -p 1555:1555 \
  -v /path/to/v2ecoli/workspace:/ptools-data/workspace:ro \
  ghcr.io/vivarium-collective/sms-ptools:0.8.2
```
Verified end-to-end: protein abundances overlay on the E. coli map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)