### PR TITLE
Study-level fact-check: align study prose to recorded data + figures

### DIFF
--- a/workspace/investigations/colonies/studies/colonies-01-hpc-readiness/study.yaml
+++ b/workspace/investigations/colonies/studies/colonies-01-hpc-readiness/study.yaml
@@ -741,7 +741,7 @@ findings:
   evidence:
     from_runs: [nsweep-n1, nsweep-n2, nsweep-n4, nsweep-n8]
     from_test: per-cell-cost-within-2x-reference
-    observed: {n1: 78, n2: 77, n4: 77, n8: 75}
+    observed: {n1: 73.6, n2: 73.2, n4: 72.7, n8: 70.4}
     units: ms/tick/cell
   expected:
     summary: per-cell wall stays within 2× of the N=1 reference; flat is the
@@ -788,7 +788,7 @@ findings:
   evidence:
     from_run: nsweep-n8
     from_test: per-cell-cost-within-2x-reference
-    observed: {n1_mb: 1508, n2_mb: 2013, n4_mb: 2946, n8_mb: 4713}
+    observed: {n1_mb: 1508, n2_mb: 2013, n4_mb: 2946, n8_mb: 4712}
     slope_mb_per_cell: 450
     units: MB
   expected:

--- a/workspace/investigations/ketchup-baseline-comparison/studies/ketchup-exchange-comparison/study.yaml
+++ b/workspace/investigations/ketchup-baseline-comparison/studies/ketchup-exchange-comparison/study.yaml
@@ -50,7 +50,7 @@ report:
         glucose + acetate.)
       • KETCHUP k-ecoli74 / k-ecoli307 — MISMATCH (R^2 = -0.89 / -0.72): directions
         agree (uptake −, CO2 secretion +) but per 100 glucose the cores respire
-        far harder (O2 ≈ -135 vs v2ecoli -9; CO2 ≈ +145 vs +33) and secrete acetate
+        far harder (O2 ≈ -135 vs v2ecoli -9; CO2 ≈ +144 vs +33) and secrete acetate
         (≈ +71, absent in v2ecoli → 'lost'). Per-metabolite axes confirm: O2 and
         CO2 mismatch, NH3 drift.
       • v2ecoli + Millard FBA-bridge (millard_fba_bridge_harness) — MISMATCH but

--- a/workspace/investigations/v2ecoli-pdmp/studies/pdmp-00-characterization/study.yaml
+++ b/workspace/investigations/v2ecoli-pdmp/studies/pdmp-00-characterization/study.yaml
@@ -360,8 +360,8 @@ report:
   evidence_quality: bootstrap-run-confirmed
   key_metrics:
   - label: variables categorised
-    status: pass
-    value: all (65 MB/step state captured)
+    status: stub
+    value: planned — variable-categorisation-map not yet produced (65 MB/step raw state captured, but not categorised)
   - label: interface schemas
     status: stub
     value: 6 subprocesses

--- a/workspace/studies/mbp-02-population-aggregation/study.yaml
+++ b/workspace/studies/mbp-02-population-aggregation/study.yaml
@@ -688,7 +688,7 @@ runs:
   runner: v2-parquet (run_multigen_parquet + single_daughters + extra_root_paths)
   note: |
     Long-duration batch-prefix run targeting 6h sim — terminated at
-    sim_min=175 (29% of target) when the sim's RSS reached ~72 GB and
+    sim_min=175 (~49% of target) when the sim's RSS reached ~72 GB and
     the system's 128 GB physical memory was effectively exhausted.
     Salvaged trajectory is more than sufficient for the plateau
     diagnostic that mbp-05 chart 02 surfaces; reaching 6h would not

--- a/workspace/studies/param-uq-00-screen/study.yaml
+++ b/workspace/studies/param-uq-00-screen/study.yaml
@@ -130,7 +130,7 @@ tests:
   classification: primary
   status: passed
   question: |
-    Do at least 2 of the 7 screened config-reachable knobs show a >2% response
+    Do at least 1 of the 7 screened config-reachable knobs show a >2% response
     in instantaneous_growth_rate (i.e., is the UQ parameter surface non-trivial)?
   measure:
     kind: authored

--- a/workspace/studies/param-uq-01-elongation/study.yaml
+++ b/workspace/studies/param-uq-01-elongation/study.yaml
@@ -54,9 +54,10 @@ report:
     | `kS` | `ecoli-polypeptide-elongation.kS` | 60 | 140 | 100 | — | 5.5% | Saturation constant (default 100) in the polypeptide-elongation charging / ppGpp-synthesis kinetics (grouped with the tRNA-charging constants krta/krtf). Couples elongation to amino-acid/ppGpp state. |
     | `chrom.basal_elongation_rate` | `ecoli-chromosome-replication.basal_elongation_rate` | 700 | 1200 | 950 | nt/s | 2.8% | DNA-polymerase (replisome) elongation rate (default 967); the stochastic per-step rate is drawn around this basal value. Sets chromosome-replication speed. |
 
-    Candidates screened out as INERT (≤1.4% response, excluded): `ribosomeElongationRate`
-    (overwritten at runtime each step → config value ignored), `gtpPerElongation`
-    (energy accounting only), `import_threshold`, `D_period`.
+    Candidates screened out as INERT (≤1.4% response, excluded): `k_RelA` (1.4%),
+    `gtpPerElongation` (energy accounting only), `import_threshold`, `D_period`
+    (all 0.0%). `ribosomeElongationRate` is also config-inert (overwritten at
+    runtime each step → config value ignored), and is not one of the 7 screened knobs.
 
     ### Tracked Observable
 
@@ -74,7 +75,7 @@ report:
     | Surrogate | order-2 Polynomial Chaos Expansion, Legendre basis (10 terms), `lsq` regression |
     | Sensitivity | analytic Sobol indices from PCE coefficients (Sudret 2008) |
     | Budget | 30 train + 10 test per seed, **3 PCRV seeds (0, 1, 2)** for robustness |
-    | Window | 120 simulation steps, 1 generation |
+    | Window | 120 simulation steps (~4% of one generation) |
     | Correctness | fresh `initial_state` per sample (v2ecoli PR #197) → samples independent; verified identical params → identical output |
 
   result: |

--- a/workspace/studies/showcase-2-baseline-figures/study.yaml
+++ b/workspace/studies/showcase-2-baseline-figures/study.yaml
@@ -35,7 +35,7 @@ report:
     resumed from the showcase-1 full ParCa cache, reproduces measured wild-type
     E. coli properties across a multiseed/multigen ensemble: doubling time in
     band, physiological mass fractions, FBA flux correlation to Toya 2010, and
-    proteome correlation to Schmidt 2015 / Wisniewski 2014.
+    proteome correlation to Schmidt 2016 / Wisniewski 2014.
 
   setup: |
     Composite: baseline (v2ecoli.composites.baseline.baseline), resumed from the
@@ -68,7 +68,7 @@ report:
     reads short (~10–19 min); the cap-immune measure and the divided-generation
     headline are unaffected. Mass fractions are physiological: protein 0.461
     (per-gen 0.477 / 0.453 / 0.442), rRNA 0.105, tRNA 0.019, DNA 0.018; mean dry
-    mass ≈467 fg, cell mass ≈1556 fg. The proteome correlates with Schmidt 2015
+    mass ≈467 fg, cell mass ≈1556 fg. The proteome correlates with Schmidt 2016
     at r = 0.728 (n=2228 monomers) and Wisniewski 2014 at r = 0.602 (n=2226).
     The native-analysis gallery (11 figures) reproduces the clean 3-generation
     cell-mass ramps, the replication program (oriC 2→4→2 per division, twice
@@ -80,7 +80,7 @@ report:
   interpretation: |
     The v2ecoli baseline reproduces wild-type single-cell physiology: clean
     3-generation growth/division (cell_mass ramps), physiological biomass
-    composition, and a proteome that correlates with Schmidt 2015 (r≈0.73) and
+    composition, and a proteome that correlates with Schmidt 2016 (r≈0.73) and
     Wisniewski 2014 (r≈0.60), consistent with the upstream vEcoli baseline. The
     doubling-time artifact that the prior run carried is RESOLVED: with #173,
     gen-2 now ends at its own division (43–52 min in-band) instead of emitting
@@ -117,7 +117,7 @@ readouts:
 - {name: doubling-time, description: "cap-immune doubling time t2 = ln(2)/mu averaged over the full lineage (min)"}
 - {name: mass-fractions, description: "dry-mass fractions (protein / rRNA / tRNA / DNA) per generation"}
 - {name: fba-flux-vs-toya2010, description: "central-carbon FBA flux vs Toya 2010 C13-MFA (Pearson R over 23 reactions)"}
-- {name: proteome-correlation, description: "proteome correlation vs Schmidt 2015 and Wisniewski 2014 (log10 monomer counts)"}
+- {name: proteome-correlation, description: "proteome correlation vs Schmidt 2016 and Wisniewski 2014 (log10 monomer counts)"}
 - {name: replication-and-regulation, description: "replication program (oriC copy number over the cell cycle) and ppGpp / tRNA-charging traces"}
 
 enforced_params:
@@ -130,7 +130,7 @@ biological_summary: |
   The wild-type baseline is the unperturbed v2ecoli whole cell growing in
   glucose minimal medium. Reproducing the four measured-property classes —
   doubling time, biomass composition (mass fractions), central-carbon flux
-  (vs Toya 2010), and the proteome (vs Schmidt 2015 / Wisniewski 2014) — across
+  (vs Toya 2010), and the proteome (vs Schmidt 2016 / Wisniewski 2014) — across
   a multiseed/multigen ensemble is the evidence that the cell is "the same
   E. coli" the upstream WCM was validated against, and the reference that all
   showcase-4 perturbation variants are measured against.
@@ -386,7 +386,7 @@ runs:
       detail: "Baseline central-carbon FBA fluxes vs Toya 2010 C13-MFA measured fluxes — Pearson R = 0.6990 (p = 2.1e-4) over 23 reactions (central_carbon_metabolism_scatter, multiseed over 2 seeds). Toya flat file (toya_2010_central_carbon_fluxes.tsv) restored; validation_data.reactionFlux.toya2010fluxes now built by build_validation_data."
     proteome-correlates-schmidt-wisniewski:
       result: PASS
-      detail: log10 average monomer counts vs measured proteomics — Schmidt 2015 Pearson r = 0.728 (n=2228 overlapping monomers), Wisniewski 2014 r = 0.602 (n=2226) (protein_counts_validation, multiseed over 2 seeds).
+      detail: log10 average monomer counts vs measured proteomics — Schmidt 2016 Pearson r = 0.728 (n=2228 overlapping monomers), Wisniewski 2014 r = 0.602 (n=2226) (protein_counts_validation, multiseed over 2 seeds).
 
   computed_outcomes:
     doubling-time-in-band:
@@ -494,10 +494,10 @@ visualizations:
   source_run: showcase2-baseline-ensemble
   render: ptools_rxns (single, seed 0 gen 1) over the clean sweep — matplotlib heatmap (vl_convert overflows on the ~4500-row mark_rect spec)
 # --- Gene expression / proteome ---
-- name: proteome vs Schmidt 2015 / Wisniewski 2014
+- name: proteome vs Schmidt 2016 / Wisniewski 2014
   address: image:charts/protein_counts_validation.png
   config:
-    title: Proteome vs Schmidt 2015 (r=0.73) and Wisniewski 2014 (r=0.60)
+    title: Proteome vs Schmidt 2016 (r=0.73) and Wisniewski 2014 (r=0.60)
   chart: scatter
   source_run: showcase2-baseline-ensemble
   render: protein_counts_validation (multiseed over 2 seeds) over the clean sweep

--- a/workspace/studies/showcase-3-variant-decide/study.yaml
+++ b/workspace/studies/showcase-3-variant-decide/study.yaml
@@ -35,7 +35,7 @@ report:
   objective: |
     Hand reviewers an explicit, OPEN choice: which perturbation should we run on
     top of the wild-type baseline to demonstrate v2ecoli's response? This study
-    deliberately commits no variant (conditions.variants is empty); it presents
+    deliberately commits no variant (conditions.variants lists four PROPOSED, uncommitted candidates); it presents
     four candidates and stays un-run until a reviewer selects one.
 
   result: |

--- a/workspace/studies/showcase-4-variant-comparison/study.yaml
+++ b/workspace/studies/showcase-4-variant-comparison/study.yaml
@@ -498,8 +498,8 @@ visualizations:
     title: "Cap-immune doubling time per variant (ln2/mean mu)"
     caption: >-
       ppgpp-off is the slowest (mean 61.6 min, wide spread to 77 min);
-      dnaA-2x fastest (48.4); elong-down ~baseline (50.2, the weak contrast);
-      media-succinate slightly slow (56.6).
+      dnaA-2x fastest (48.4); elong-down ~baseline (49.3, the weak contrast);
+      media-succinate slightly slow (52.9).
   chart: box
   source_run: showcase4-variant-sweep
   render: doubling_time_grouped (multivariant) over the sweep

--- a/workspace/studies/showcase-5-next-direction-decide/study.yaml
+++ b/workspace/studies/showcase-5-next-direction-decide/study.yaml
@@ -38,8 +38,9 @@ report:
   objective: |
     Hand reviewers an explicit, OPEN choice for the NEXT direction, grounded in
     the showcase-4 measured contrasts: which follow-up best advances the
-    showcase? This study deliberately commits no variant (conditions.variants is
-    empty); it presents candidate directions seeded from the showcase-4 ranking
+    showcase? This study deliberately commits no variant (conditions.variants
+    lists four PROPOSED, uncommitted candidate directions); it presents candidate
+    directions seeded from the showcase-4 ranking
     and stays un-run until a reviewer selects one.
 
   result: |

--- a/workspace/studies/showcase-6-equivalence-large/study.yaml
+++ b/workspace/studies/showcase-6-equivalence-large/study.yaml
@@ -103,7 +103,7 @@ report:
         fully equivalent.
       • RIBOSOMES (2 ✓ / 2 ≈): active fraction +0.1% ✓, elongation rate +0.2% ✓;
         total ribosomes −5.8% ≈ drift, rRNA-init production −8.7% ≈ drift.
-      • EXCHANGE FLUXES (2 ✓ / 1 ≈ / 2 ✗ — THE DIVERGENCE): overall flux
+      • EXCHANGE FLUXES (3 ✓ / 1 ≈ / 2 ✗ — THE DIVERGENCE): overall flux
         fingerprint R² = 0.9989 ✓ (40 matched, 0 appeared/lost, 6 sub-floor),
         glucose −4.4% ✓, ammonium −2.4% ✓; but O₂ exchange Δ −40.4% ✗ mismatch
         and CO₂ exchange Δ −20.3% ✗ mismatch (acetate sentinel ≈ drift, near

--- a/workspace/studies/units-atlas-01-readout-inventory/study.yaml
+++ b/workspace/studies/units-atlas-01-readout-inventory/study.yaml
@@ -34,13 +34,14 @@ report:
     concentration (13, mostly mM/uM growth-limit and FBA targets), mass (4, fg),
     time (3, s), count (2), rate (1, 1/s), plus 4 in "other" (flux-like units
     such as g*s/L and mmol/g/h). Each row lists the observable's dotted path and
-    its declared unit, and — where a baseline parquet run has been sampled —
-    example magnitudes + ranges (e.g. cell_mass ~2174 fg, ppGpp ~86.9 uM, from a
-    two_generations run); a '—' appears only for the config-dependent readouts the
-    sampled run did not exercise. The embedded figure is the rendered catalog.
+    its declared unit. The example-magnitude and range columns are present in the
+    catalog but currently empty for every readout — no baseline parquet run has
+    been sampled yet (an optional baseline-magnitude-sample run is planned to
+    populate them). The units + paths are schema-derived and complete without any
+    run. The embedded figure is the rendered catalog.
   caveats:
   - "Descriptive reference, not a hypothesis test — no pass/fail gate."
-  - "Magnitude columns ARE populated wherever a baseline parquet run is sampled (e.g. cell_mass ~2174 fg, ppGpp ~86.9 uM from a two_generations run); a '—' appears only for config-dependent readouts the sampled run did not exercise. The units + paths are schema-derived and always present, independent of any run."
+  - "Magnitude columns (example/min/max) are currently empty for all readouts — no baseline parquet run has been sampled, so the catalog is schema-only. A baseline-magnitude-sample run is planned to populate them. The units + paths are schema-derived and always present, independent of any run."
   - "Coverage is limited to process classes the index can introspect; a few config-dependent readouts may be absent (logged, not silently dropped)."
 
 conditions:
@@ -80,10 +81,9 @@ readouts:
   units: count
 - name: example_magnitudes
   description: |
-    Per-readout example magnitude + range — populated wherever a baseline
-    parquet run is sampled (e.g. cell_mass ~2174 fg, ppGpp ~86.9 uM from a
-    two_generations run); '—' only for config-dependent readouts not exercised by
-    the sampled run.
+    Per-readout example magnitude + range columns — currently empty (no baseline
+    parquet run has been sampled yet); they would be filled by the planned
+    baseline-magnitude-sample run.
   units: mixed
 
 study_card: |
@@ -97,8 +97,8 @@ study_card: |
 biological_summary: |
   The cataloged readouts are the cell's measurable quantities: dry mass (fg),
   metabolite / growth-limiting nutrient concentrations (mM, uM), reaction and
-  elongation rates (1/s), molecule counts, cell volume/length, and flux-like
-  terms. Grouping by physical dimension is what makes each observable
+  elongation rates (1/s), molecule counts, characteristic times (s), and
+  flux-like terms. Grouping by physical dimension is what makes each observable
   interpretable and comparable to data; attaching the declared unit is what lets
   a simulation number be checked against a measurement.
 
@@ -143,11 +143,10 @@ conclusion_verdicts:
   statement: |
     The baseline composite declares 27 unit-bearing readouts across six physical
     dimensions, all resolvable from the typed port schema with no simulation.
-    The atlas renders them as a grouped, navigable reference; magnitude columns
-    are populated where a baseline parquet run is sampled (e.g. cell_mass ~2174 fg,
-    ppGpp ~86.9 uM from a two_generations run), with '—' only for config-dependent
-    readouts the sampled run did not exercise. This is a descriptive artifact with
-    no pass/fail gate.
+    The atlas renders them as a grouped, navigable reference; the magnitude
+    columns are present but empty (no baseline parquet run has been sampled yet —
+    a baseline-magnitude-sample run is planned to fill them). This is a
+    descriptive artifact with no pass/fail gate.
 
 tests: []
 

--- a/workspace/studies/units-atlas-01-readout-inventory/study.yaml
+++ b/workspace/studies/units-atlas-01-readout-inventory/study.yaml
@@ -34,14 +34,15 @@ report:
     concentration (13, mostly mM/uM growth-limit and FBA targets), mass (4, fg),
     time (3, s), count (2), rate (1, 1/s), plus 4 in "other" (flux-like units
     such as g*s/L and mmol/g/h). Each row lists the observable's dotted path and
-    its declared unit. The example-magnitude and range columns are present in the
-    catalog but currently empty for every readout — no baseline parquet run has
-    been sampled yet (an optional baseline-magnitude-sample run is planned to
-    populate them). The units + paths are schema-derived and complete without any
-    run. The embedded figure is the rendered catalog.
+    its declared unit, plus example magnitude + min/max where they were sampled
+    from the showcase-2 wild-type baseline ensemble (7 of 27 readouts — e.g.
+    cell_mass ~1469 fg [1118–2338], ppGpp ~69.6 uM [25.9–82.6], dry_mass ~441 fg,
+    elongation rate ~15.7 aa/s); a '—' appears for the config-dependent readouts
+    that run did not emit. The units + paths are schema-derived and complete
+    without any run. The embedded figure is the rendered catalog.
   caveats:
   - "Descriptive reference, not a hypothesis test — no pass/fail gate."
-  - "Magnitude columns (example/min/max) are currently empty for all readouts — no baseline parquet run has been sampled, so the catalog is schema-only. A baseline-magnitude-sample run is planned to populate them. The units + paths are schema-derived and always present, independent of any run."
+  - "Magnitude columns (example/min/max) are populated for the 7 readouts emitted by the sampled showcase-2 baseline ensemble (e.g. cell_mass ~1469 fg, ppGpp ~69.6 uM, dry_mass ~441 fg, protein ~187 fg, RNA ~58 fg, elongation rate ~15.7 aa/s, time); a '—' appears for the config-dependent readouts that run did not emit. The units + paths are schema-derived and always present, independent of any run."
   - "Coverage is limited to process classes the index can introspect; a few config-dependent readouts may be absent (logged, not silently dropped)."
 
 conditions:
@@ -81,9 +82,10 @@ readouts:
   units: count
 - name: example_magnitudes
   description: |
-    Per-readout example magnitude + range columns — currently empty (no baseline
-    parquet run has been sampled yet); they would be filled by the planned
-    baseline-magnitude-sample run.
+    Per-readout example magnitude + range columns — populated for the 7 readouts
+    emitted by the sampled showcase-2 baseline ensemble (e.g. cell_mass ~1469 fg,
+    ppGpp ~69.6 uM from a 2-seed × 3-gen run); '—' for the config-dependent
+    readouts that run did not emit.
   units: mixed
 
 study_card: |
@@ -128,14 +130,16 @@ simulation_set:
 
 planned_runs:
 - name: baseline-magnitude-sample
-  status: planned
+  status: satisfied
   n_steps: 100
   seeds: [0]
   details: |
-    OPTIONAL enrichment — not required for the reference. Sample a short
-    baseline parquet run to populate the example-magnitude + range columns of
-    the catalog. The units and paths are already complete from the schema; this
-    run would only add illustrative values.
+    OPTIONAL enrichment — not required for the reference. SATISFIED by sampling
+    the existing showcase-2 wild-type baseline ensemble parquet instead of a
+    dedicated run: 7 of 27 readouts now carry example + min/max magnitudes
+    (cell_mass ~1469 fg, ppGpp ~69.6 uM, dry_mass ~441 fg, protein ~187 fg,
+    RNA ~58 fg, elongation rate ~15.7 aa/s, time). The units and paths are
+    already complete from the schema; these values are illustrative.
 
 conclusion_verdicts:
 - verdict: informational
@@ -144,8 +148,9 @@ conclusion_verdicts:
     The baseline composite declares 27 unit-bearing readouts across six physical
     dimensions, all resolvable from the typed port schema with no simulation.
     The atlas renders them as a grouped, navigable reference; the magnitude
-    columns are present but empty (no baseline parquet run has been sampled yet —
-    a baseline-magnitude-sample run is planned to fill them). This is a
+    columns are populated for the 7 readouts emitted by the sampled showcase-2
+    baseline ensemble (cell_mass ~1469 fg, ppGpp ~69.6 uM, etc.), with '—' for
+    the config-dependent readouts that run did not emit. This is a
     descriptive artifact with no pass/fail gate.
 
 tests: []

--- a/workspace/studies/units-atlas-01-readout-inventory/viz/units_atlas.html
+++ b/workspace/studies/units-atlas-01-readout-inventory/viz/units_atlas.html
@@ -1,52 +1,121 @@
-<h2>Units Atlas — readouts by physical dimension</h2>
-<h3>concentration (13)</h3>
-<table border='1' cellpadding='4' style='border-collapse:collapse'>
-<tr><th>readout</th><th>unit</th><th>example</th><th>min</th><th>max</th></tr>
-<tr><td>listeners.enzyme_kinetics.counts_to_molar</td><td>mM</td><td></td><td></td><td></td></tr>
-<tr><td>listeners.enzyme_kinetics.target_aa_conc</td><td>mM</td><td></td><td></td><td></td></tr>
-<tr><td>listeners.fba_results.conc_updates</td><td>mM</td><td></td><td></td><td></td></tr>
-<tr><td>listeners.fba_results.target_concentrations</td><td>mM</td><td></td><td></td><td></td></tr>
-<tr><td>listeners.growth_limits.aa_conc</td><td>uM</td><td></td><td></td><td></td></tr>
-<tr><td>listeners.growth_limits.aa_supply_aa_conc</td><td>mM</td><td></td><td></td><td></td></tr>
-<tr><td>listeners.growth_limits.charged_trna_conc</td><td>uM</td><td></td><td></td><td></td></tr>
-<tr><td>listeners.growth_limits.ppgpp_conc</td><td>uM</td><td></td><td></td><td></td></tr>
-<tr><td>listeners.growth_limits.rela_conc</td><td>uM</td><td></td><td></td><td></td></tr>
-<tr><td>listeners.growth_limits.ribosome_conc</td><td>uM</td><td></td><td></td><td></td></tr>
-<tr><td>listeners.growth_limits.spot_conc</td><td>uM</td><td></td><td></td><td></td></tr>
-<tr><td>listeners.growth_limits.synthetase_conc</td><td>uM</td><td></td><td></td><td></td></tr>
-<tr><td>listeners.growth_limits.uncharged_trna_conc</td><td>uM</td><td></td><td></td><td></td></tr>
-</table>
-<h3>count (2)</h3>
-<table border='1' cellpadding='4' style='border-collapse:collapse'>
-<tr><th>readout</th><th>unit</th><th>example</th><th>min</th><th>max</th></tr>
-<tr><td>listeners.rna_degradation_listener.fragment_bases_digested</td><td>nt</td><td></td><td></td><td></td></tr>
-<tr><td>listeners.rna_degradation_listener.nucleotides_from_degradation</td><td>nt</td><td></td><td></td><td></td></tr>
-</table>
-<h3>mass (4)</h3>
-<table border='1' cellpadding='4' style='border-collapse:collapse'>
-<tr><th>readout</th><th>unit</th><th>example</th><th>min</th><th>max</th></tr>
-<tr><td>listeners.mass.cell_mass</td><td>fg</td><td></td><td></td><td></td></tr>
-<tr><td>listeners.mass.dry_mass</td><td>fg</td><td></td><td></td><td></td></tr>
-<tr><td>listeners.mass.protein_mass</td><td>fg</td><td></td><td></td><td></td></tr>
-<tr><td>listeners.mass.rna_mass</td><td>fg</td><td></td><td></td><td></td></tr>
-</table>
-<h3>other (4)</h3>
-<table border='1' cellpadding='4' style='border-collapse:collapse'>
-<tr><th>readout</th><th>unit</th><th>example</th><th>min</th><th>max</th></tr>
-<tr><td>listeners.fba_results.coefficient</td><td>g*s/L</td><td></td><td></td><td></td></tr>
-<tr><td>listeners.ribosome_data.effective_elongation_rate</td><td>amino_acid/s</td><td></td><td></td><td></td></tr>
-<tr><td>listeners.ribosome_data.process_elongation_rate</td><td>aa/s</td><td></td><td></td><td></td></tr>
-<tr><td>polypeptide_elongation.aa_exchange_rates</td><td>mmol/g/h</td><td></td><td></td><td></td></tr>
-</table>
-<h3>rate (1)</h3>
-<table border='1' cellpadding='4' style='border-collapse:collapse'>
-<tr><th>readout</th><th>unit</th><th>example</th><th>min</th><th>max</th></tr>
-<tr><td>listeners.equilibrium_listener.reaction_rates</td><td>1/s</td><td></td><td></td><td></td></tr>
-</table>
-<h3>time (3)</h3>
-<table border='1' cellpadding='4' style='border-collapse:collapse'>
-<tr><th>readout</th><th>unit</th><th>example</th><th>min</th><th>max</th></tr>
-<tr><td>global_time</td><td>s</td><td></td><td></td><td></td></tr>
-<tr><td>next_update_time</td><td>s</td><td></td><td></td><td></td></tr>
-<tr><td>timestep</td><td>s</td><td></td><td></td><td></td></tr>
-</table>
+
+<style>
+.units-atlas { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI",
+    Roboto, Helvetica, Arial, sans-serif; color: #1f2933; max-width: 1000px;
+    margin: 0 auto; line-height: 1.5; }
+.units-atlas .lead { font-size: 15px; color: #3e4c59; }
+.units-atlas .chips { display: flex; flex-wrap: wrap; gap: 8px; margin: 14px 0 24px; }
+.units-atlas .chip { display: inline-flex; align-items: baseline; gap: 6px;
+    padding: 4px 11px; border-radius: 999px; color: #fff; font-size: 13px;
+    font-weight: 600; }
+.units-atlas .chip .n { font-size: 12px; opacity: .85; font-weight: 500; }
+.units-atlas section { margin: 0 0 26px; border: 1px solid #e4e7eb;
+    border-radius: 8px; overflow: hidden; }
+.units-atlas .dim-head { padding: 10px 14px; color: #fff; }
+.units-atlas .dim-head h3 { margin: 0; font-size: 16px; }
+.units-atlas .dim-head .desc { margin: 4px 0 0; font-size: 13px; opacity: .92; }
+.units-atlas table { width: 100%; border-collapse: collapse; font-size: 13px; }
+.units-atlas th, .units-atlas td { text-align: left; padding: 7px 14px;
+    border-bottom: 1px solid #eef1f4; }
+.units-atlas thead th { background: #f5f7fa; font-size: 11px; text-transform:
+    uppercase; letter-spacing: .04em; color: #616e7c; }
+.units-atlas td.path { font-family: ui-monospace, "SF Mono", Menlo, monospace;
+    font-size: 12px; color: #1f2933; }
+.units-atlas td.unit { font-family: ui-monospace, Menlo, monospace; color: #52606d; }
+.units-atlas td.num { text-align: right; font-variant-numeric: tabular-nums;
+    color: #3e4c59; }
+.units-atlas tr:last-child td { border-bottom: none; }
+.units-atlas .foot { font-size: 12px; color: #7b8794; margin-top: 8px;
+    border-top: 1px solid #e4e7eb; padding-top: 12px; }
+.units-atlas .flags { background: #fff8e6; border: 1px solid #f0d58a;
+    border-radius: 8px; padding: 10px 14px; font-size: 13px; }
+</style>
+
+<div class="units-atlas">
+<h2 style='margin:0 0 6px'>Units Atlas</h2>
+<p class='lead'>Every quantity the E. coli whole-cell model declares on its listener and process ports, resolved <b>live from the typed port schema</b> (no run required) and grouped by physical dimension. <b>27 unit-bearing readouts</b> across <b>6 dimensions</b>. These are the same declared units that now auto-label plot axes across every v2ecoli visualization. Example, min, and max magnitudes are sampled from <code>showcase2_baseline</code>.</p>
+<div class="chips">
+<span class="chip" style="background:#7b3fa0">mass<span class="n">4</span></span>
+<span class="chip" style="background:#1f77b4">concentration<span class="n">13</span></span>
+<span class="chip" style="background:#d6610a">rate<span class="n">1</span></span>
+<span class="chip" style="background:#b0860b">count<span class="n">2</span></span>
+<span class="chip" style="background:#2c8c5a">time<span class="n">3</span></span>
+<span class="chip" style="background:#6b7280">other<span class="n">4</span></span>
+</div>
+<section>
+<div class="dim-head" style="background:#7b3fa0">
+<h3>mass · 4 readouts · <span style='font-weight:500'>fg</span></h3>
+<p class='desc'>Cell and component masses — the whole-cell mass budget the growth and division logic balances (cell, dry, protein, RNA mass).</p>
+</div>
+<table><thead><tr><th>readout</th><th>unit</th><th style='text-align:right'>example</th><th style='text-align:right'>min</th><th style='text-align:right'>max</th></tr></thead><tbody>
+<tr><td class='path'>listeners.mass.cell_mass</td><td class='unit'>fg</td><td class='num'>1469</td><td class='num'>1118</td><td class='num'>2338</td></tr>
+<tr><td class='path'>listeners.mass.dry_mass</td><td class='unit'>fg</td><td class='num'>440.9</td><td class='num'>335.4</td><td class='num'>701.7</td></tr>
+<tr><td class='path'>listeners.mass.protein_mass</td><td class='unit'>fg</td><td class='num'>187</td><td class='num'>144.5</td><td class='num'>323</td></tr>
+<tr><td class='path'>listeners.mass.rna_mass</td><td class='unit'>fg</td><td class='num'>58.14</td><td class='num'>41.31</td><td class='num'>90.6</td></tr>
+</tbody></table>
+</section>
+<section>
+<div class="dim-head" style="background:#1f77b4">
+<h3>concentration · 13 readouts · <span style='font-weight:500'>mM, uM</span></h3>
+<p class='desc'>Molecular concentrations — metabolite pools, FBA target and updated concentrations, and growth-limiting species the metabolism solver reads and writes.</p>
+</div>
+<table><thead><tr><th>readout</th><th>unit</th><th style='text-align:right'>example</th><th style='text-align:right'>min</th><th style='text-align:right'>max</th></tr></thead><tbody>
+<tr><td class='path'>listeners.enzyme_kinetics.counts_to_molar</td><td class='unit'>mM</td><td class='num'>—</td><td class='num'>—</td><td class='num'>—</td></tr>
+<tr><td class='path'>listeners.enzyme_kinetics.target_aa_conc</td><td class='unit'>mM</td><td class='num'>—</td><td class='num'>—</td><td class='num'>—</td></tr>
+<tr><td class='path'>listeners.fba_results.conc_updates</td><td class='unit'>mM</td><td class='num'>—</td><td class='num'>—</td><td class='num'>—</td></tr>
+<tr><td class='path'>listeners.fba_results.target_concentrations</td><td class='unit'>mM</td><td class='num'>—</td><td class='num'>—</td><td class='num'>—</td></tr>
+<tr><td class='path'>listeners.growth_limits.aa_conc</td><td class='unit'>uM</td><td class='num'>—</td><td class='num'>—</td><td class='num'>—</td></tr>
+<tr><td class='path'>listeners.growth_limits.aa_supply_aa_conc</td><td class='unit'>mM</td><td class='num'>—</td><td class='num'>—</td><td class='num'>—</td></tr>
+<tr><td class='path'>listeners.growth_limits.charged_trna_conc</td><td class='unit'>uM</td><td class='num'>—</td><td class='num'>—</td><td class='num'>—</td></tr>
+<tr><td class='path'>listeners.growth_limits.ppgpp_conc</td><td class='unit'>uM</td><td class='num'>69.59</td><td class='num'>25.9</td><td class='num'>82.55</td></tr>
+<tr><td class='path'>listeners.growth_limits.rela_conc</td><td class='unit'>uM</td><td class='num'>—</td><td class='num'>—</td><td class='num'>—</td></tr>
+<tr><td class='path'>listeners.growth_limits.ribosome_conc</td><td class='unit'>uM</td><td class='num'>—</td><td class='num'>—</td><td class='num'>—</td></tr>
+<tr><td class='path'>listeners.growth_limits.spot_conc</td><td class='unit'>uM</td><td class='num'>—</td><td class='num'>—</td><td class='num'>—</td></tr>
+<tr><td class='path'>listeners.growth_limits.synthetase_conc</td><td class='unit'>uM</td><td class='num'>—</td><td class='num'>—</td><td class='num'>—</td></tr>
+<tr><td class='path'>listeners.growth_limits.uncharged_trna_conc</td><td class='unit'>uM</td><td class='num'>—</td><td class='num'>—</td><td class='num'>—</td></tr>
+</tbody></table>
+</section>
+<section>
+<div class="dim-head" style="background:#d6610a">
+<h3>rate · 1 readout · <span style='font-weight:500'>1/s</span></h3>
+<p class='desc'>Per-time rates — reaction and process velocities (e.g. equilibrium reaction rates) expressed per second.</p>
+</div>
+<table><thead><tr><th>readout</th><th>unit</th><th style='text-align:right'>example</th><th style='text-align:right'>min</th><th style='text-align:right'>max</th></tr></thead><tbody>
+<tr><td class='path'>listeners.equilibrium_listener.reaction_rates</td><td class='unit'>1/s</td><td class='num'>—</td><td class='num'>—</td><td class='num'>—</td></tr>
+</tbody></table>
+</section>
+<section>
+<div class="dim-head" style="background:#b0860b">
+<h3>count · 2 readouts · <span style='font-weight:500'>nt</span></h3>
+<p class='desc'>Molecule counts — discrete copy numbers (nucleotides, amino acids, bulk species) the stochastic processes act on.</p>
+</div>
+<table><thead><tr><th>readout</th><th>unit</th><th style='text-align:right'>example</th><th style='text-align:right'>min</th><th style='text-align:right'>max</th></tr></thead><tbody>
+<tr><td class='path'>listeners.rna_degradation_listener.fragment_bases_digested</td><td class='unit'>nt</td><td class='num'>—</td><td class='num'>—</td><td class='num'>—</td></tr>
+<tr><td class='path'>listeners.rna_degradation_listener.nucleotides_from_degradation</td><td class='unit'>nt</td><td class='num'>—</td><td class='num'>—</td><td class='num'>—</td></tr>
+</tbody></table>
+</section>
+<section>
+<div class="dim-head" style="background:#2c8c5a">
+<h3>time · 3 readouts · <span style='font-weight:500'>s</span></h3>
+<p class='desc'>Durations and timesteps — the simulation clock and per-process step sizes that pace the cell cycle.</p>
+</div>
+<table><thead><tr><th>readout</th><th>unit</th><th style='text-align:right'>example</th><th style='text-align:right'>min</th><th style='text-align:right'>max</th></tr></thead><tbody>
+<tr><td class='path'>global_time</td><td class='unit'>s</td><td class='num'>6500</td><td class='num'>60</td><td class='num'>6500</td></tr>
+<tr><td class='path'>next_update_time</td><td class='unit'>s</td><td class='num'>—</td><td class='num'>—</td><td class='num'>—</td></tr>
+<tr><td class='path'>timestep</td><td class='unit'>s</td><td class='num'>—</td><td class='num'>—</td><td class='num'>—</td></tr>
+</tbody></table>
+</section>
+<section>
+<div class="dim-head" style="background:#6b7280">
+<h3>other · 4 readouts · <span style='font-weight:500'>aa/s, amino_acid/s, g*s/L, mmol/g/h</span></h3>
+<p class='desc'>Composite or flux-like units that don&#x27;t fall into a single base dimension (e.g. g·s/L, mmol/g/h).</p>
+</div>
+<table><thead><tr><th>readout</th><th>unit</th><th style='text-align:right'>example</th><th style='text-align:right'>min</th><th style='text-align:right'>max</th></tr></thead><tbody>
+<tr><td class='path'>listeners.fba_results.coefficient</td><td class='unit'>g*s/L</td><td class='num'>—</td><td class='num'>—</td><td class='num'>—</td></tr>
+<tr><td class='path'>listeners.ribosome_data.effective_elongation_rate</td><td class='unit'>amino_acid/s</td><td class='num'>15.71</td><td class='num'>14.21</td><td class='num'>20.69</td></tr>
+<tr><td class='path'>listeners.ribosome_data.process_elongation_rate</td><td class='unit'>aa/s</td><td class='num'>—</td><td class='num'>—</td><td class='num'>—</td></tr>
+<tr><td class='path'>polypeptide_elongation.aa_exchange_rates</td><td class='unit'>mmol/g/h</td><td class='num'>—</td><td class='num'>—</td><td class='num'>—</td></tr>
+</tbody></table>
+</section>
+<p class='foot'>Built by <code>v2ecoli.library.units_atlas.build_atlas</code>, which walks the baseline composite's declared <code>quantity[...]</code> / <code>float[unit]</code> port types via <code>units_resolver.build_units_index</code>. Descriptive reference — no pass/fail gate.</p>
+</div>


### PR DESCRIPTION
Study-level fact-check (follow-up to #228) + units-atlas magnitude population.

## Fact-check corrections (12 studies)
units-atlas (volume/length→real dims), showcase-6 axis miscount (2✓→3✓), showcase-4 doubling caption, showcase-3/5 "variants empty", showcase-2 Schmidt year, colonies F-01/F-03 numbers, ketchup CO2 +145→+144, mbp-02 arithmetic (29%→49%), param-uq-00/01 threshold + inert-knob attribution, pdmp-00 "variables categorised" pass→stub.

## units-atlas: magnitudes POPULATED (per the reviewer's question)
The example/min/max columns were blank because the sampling run was never executed. Rather than leave them empty (or keep the earlier fabricated "cell_mass ~2174 fg / ppGpp ~86.9 uM"), I sampled them from the **existing showcase-2 baseline ensemble** parquet — no new sim needed. `build_atlas(run_dir=...)` fills **7 of 27** readouts with real values: cell_mass ~1469 fg [1118–2338], ppGpp ~69.6 uM, dry_mass ~441 fg, protein ~187 fg, RNA ~58 fg, elongation ~15.7 aa/s, time. The other 20 are config-dependent → '—'. Re-rendered `viz/units_atlas.html`, flipped the prose to populated-with-real-values, marked the planned sample run "satisfied". (The fabricated ~2174 was the cell_mass *max* ~2338 misremembered.)

## Deferred for the investigation owner (flagged, not edited)
pdmp-01/pdmp-03 stale de-slop UNDERclaims; mbp-06 stale Design-phase fragments; ambiguous numbers (mbp g/L-vs-mM, 9.6-vs-12.9 g/L, mbp-07 run records, colonies F-06).

Merging auto-triggers the publish workflows (`workspace/**`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)