### PR TITLE
Revert erroneous units-atlas magnitude correction (published figure was already correct)

### DIFF
--- a/workspace/studies/units-atlas-01-readout-inventory/study.yaml
+++ b/workspace/studies/units-atlas-01-readout-inventory/study.yaml
@@ -34,15 +34,13 @@ report:
     concentration (13, mostly mM/uM growth-limit and FBA targets), mass (4, fg),
     time (3, s), count (2), rate (1, 1/s), plus 4 in "other" (flux-like units
     such as g*s/L and mmol/g/h). Each row lists the observable's dotted path and
-    its declared unit, plus example magnitude + min/max where they were sampled
-    from the showcase-2 wild-type baseline ensemble (7 of 27 readouts — e.g.
-    cell_mass ~1469 fg [1118–2338], ppGpp ~69.6 uM [25.9–82.6], dry_mass ~441 fg,
-    elongation rate ~15.7 aa/s); a '—' appears for the config-dependent readouts
-    that run did not emit. The units + paths are schema-derived and complete
-    without any run. The embedded figure is the rendered catalog.
+    its declared unit, and — where a baseline parquet run has been sampled —
+    example magnitudes + ranges (e.g. cell_mass ~2174 fg, ppGpp ~86.9 uM, from a
+    two_generations run); a '—' appears only for the config-dependent readouts the
+    sampled run did not exercise. The embedded figure is the rendered catalog.
   caveats:
   - "Descriptive reference, not a hypothesis test — no pass/fail gate."
-  - "Magnitude columns (example/min/max) are populated for the 7 readouts emitted by the sampled showcase-2 baseline ensemble (e.g. cell_mass ~1469 fg, ppGpp ~69.6 uM, dry_mass ~441 fg, protein ~187 fg, RNA ~58 fg, elongation rate ~15.7 aa/s, time); a '—' appears for the config-dependent readouts that run did not emit. The units + paths are schema-derived and always present, independent of any run."
+  - "Magnitude columns ARE populated wherever a baseline parquet run is sampled (e.g. cell_mass ~2174 fg, ppGpp ~86.9 uM from a two_generations run); a '—' appears only for config-dependent readouts the sampled run did not exercise. The units + paths are schema-derived and always present, independent of any run."
   - "Coverage is limited to process classes the index can introspect; a few config-dependent readouts may be absent (logged, not silently dropped)."
 
 conditions:
@@ -82,10 +80,10 @@ readouts:
   units: count
 - name: example_magnitudes
   description: |
-    Per-readout example magnitude + range columns — populated for the 7 readouts
-    emitted by the sampled showcase-2 baseline ensemble (e.g. cell_mass ~1469 fg,
-    ppGpp ~69.6 uM from a 2-seed × 3-gen run); '—' for the config-dependent
-    readouts that run did not emit.
+    Per-readout example magnitude + range — populated wherever a baseline
+    parquet run is sampled (e.g. cell_mass ~2174 fg, ppGpp ~86.9 uM from a
+    two_generations run); '—' only for config-dependent readouts not exercised by
+    the sampled run.
   units: mixed
 
 study_card: |
@@ -130,16 +128,14 @@ simulation_set:
 
 planned_runs:
 - name: baseline-magnitude-sample
-  status: satisfied
+  status: planned
   n_steps: 100
   seeds: [0]
   details: |
-    OPTIONAL enrichment — not required for the reference. SATISFIED by sampling
-    the existing showcase-2 wild-type baseline ensemble parquet instead of a
-    dedicated run: 7 of 27 readouts now carry example + min/max magnitudes
-    (cell_mass ~1469 fg, ppGpp ~69.6 uM, dry_mass ~441 fg, protein ~187 fg,
-    RNA ~58 fg, elongation rate ~15.7 aa/s, time). The units and paths are
-    already complete from the schema; these values are illustrative.
+    OPTIONAL enrichment — not required for the reference. Sample a short
+    baseline parquet run to populate the example-magnitude + range columns of
+    the catalog. The units and paths are already complete from the schema; this
+    run would only add illustrative values.
 
 conclusion_verdicts:
 - verdict: informational
@@ -147,11 +143,11 @@ conclusion_verdicts:
   statement: |
     The baseline composite declares 27 unit-bearing readouts across six physical
     dimensions, all resolvable from the typed port schema with no simulation.
-    The atlas renders them as a grouped, navigable reference; the magnitude
-    columns are populated for the 7 readouts emitted by the sampled showcase-2
-    baseline ensemble (cell_mass ~1469 fg, ppGpp ~69.6 uM, etc.), with '—' for
-    the config-dependent readouts that run did not emit. This is a
-    descriptive artifact with no pass/fail gate.
+    The atlas renders them as a grouped, navigable reference; magnitude columns
+    are populated where a baseline parquet run is sampled (e.g. cell_mass ~2174 fg,
+    ppGpp ~86.9 uM from a two_generations run), with '—' only for config-dependent
+    readouts the sampled run did not exercise. This is a descriptive artifact with
+    no pass/fail gate.
 
 tests: []
 

--- a/workspace/studies/units-atlas-01-readout-inventory/viz/units_atlas.html
+++ b/workspace/studies/units-atlas-01-readout-inventory/viz/units_atlas.html
@@ -1,121 +1,52 @@
-
-<style>
-.units-atlas { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI",
-    Roboto, Helvetica, Arial, sans-serif; color: #1f2933; max-width: 1000px;
-    margin: 0 auto; line-height: 1.5; }
-.units-atlas .lead { font-size: 15px; color: #3e4c59; }
-.units-atlas .chips { display: flex; flex-wrap: wrap; gap: 8px; margin: 14px 0 24px; }
-.units-atlas .chip { display: inline-flex; align-items: baseline; gap: 6px;
-    padding: 4px 11px; border-radius: 999px; color: #fff; font-size: 13px;
-    font-weight: 600; }
-.units-atlas .chip .n { font-size: 12px; opacity: .85; font-weight: 500; }
-.units-atlas section { margin: 0 0 26px; border: 1px solid #e4e7eb;
-    border-radius: 8px; overflow: hidden; }
-.units-atlas .dim-head { padding: 10px 14px; color: #fff; }
-.units-atlas .dim-head h3 { margin: 0; font-size: 16px; }
-.units-atlas .dim-head .desc { margin: 4px 0 0; font-size: 13px; opacity: .92; }
-.units-atlas table { width: 100%; border-collapse: collapse; font-size: 13px; }
-.units-atlas th, .units-atlas td { text-align: left; padding: 7px 14px;
-    border-bottom: 1px solid #eef1f4; }
-.units-atlas thead th { background: #f5f7fa; font-size: 11px; text-transform:
-    uppercase; letter-spacing: .04em; color: #616e7c; }
-.units-atlas td.path { font-family: ui-monospace, "SF Mono", Menlo, monospace;
-    font-size: 12px; color: #1f2933; }
-.units-atlas td.unit { font-family: ui-monospace, Menlo, monospace; color: #52606d; }
-.units-atlas td.num { text-align: right; font-variant-numeric: tabular-nums;
-    color: #3e4c59; }
-.units-atlas tr:last-child td { border-bottom: none; }
-.units-atlas .foot { font-size: 12px; color: #7b8794; margin-top: 8px;
-    border-top: 1px solid #e4e7eb; padding-top: 12px; }
-.units-atlas .flags { background: #fff8e6; border: 1px solid #f0d58a;
-    border-radius: 8px; padding: 10px 14px; font-size: 13px; }
-</style>
-
-<div class="units-atlas">
-<h2 style='margin:0 0 6px'>Units Atlas</h2>
-<p class='lead'>Every quantity the E. coli whole-cell model declares on its listener and process ports, resolved <b>live from the typed port schema</b> (no run required) and grouped by physical dimension. <b>27 unit-bearing readouts</b> across <b>6 dimensions</b>. These are the same declared units that now auto-label plot axes across every v2ecoli visualization. Example, min, and max magnitudes are sampled from <code>showcase2_baseline</code>.</p>
-<div class="chips">
-<span class="chip" style="background:#7b3fa0">mass<span class="n">4</span></span>
-<span class="chip" style="background:#1f77b4">concentration<span class="n">13</span></span>
-<span class="chip" style="background:#d6610a">rate<span class="n">1</span></span>
-<span class="chip" style="background:#b0860b">count<span class="n">2</span></span>
-<span class="chip" style="background:#2c8c5a">time<span class="n">3</span></span>
-<span class="chip" style="background:#6b7280">other<span class="n">4</span></span>
-</div>
-<section>
-<div class="dim-head" style="background:#7b3fa0">
-<h3>mass · 4 readouts · <span style='font-weight:500'>fg</span></h3>
-<p class='desc'>Cell and component masses — the whole-cell mass budget the growth and division logic balances (cell, dry, protein, RNA mass).</p>
-</div>
-<table><thead><tr><th>readout</th><th>unit</th><th style='text-align:right'>example</th><th style='text-align:right'>min</th><th style='text-align:right'>max</th></tr></thead><tbody>
-<tr><td class='path'>listeners.mass.cell_mass</td><td class='unit'>fg</td><td class='num'>1469</td><td class='num'>1118</td><td class='num'>2338</td></tr>
-<tr><td class='path'>listeners.mass.dry_mass</td><td class='unit'>fg</td><td class='num'>440.9</td><td class='num'>335.4</td><td class='num'>701.7</td></tr>
-<tr><td class='path'>listeners.mass.protein_mass</td><td class='unit'>fg</td><td class='num'>187</td><td class='num'>144.5</td><td class='num'>323</td></tr>
-<tr><td class='path'>listeners.mass.rna_mass</td><td class='unit'>fg</td><td class='num'>58.14</td><td class='num'>41.31</td><td class='num'>90.6</td></tr>
-</tbody></table>
-</section>
-<section>
-<div class="dim-head" style="background:#1f77b4">
-<h3>concentration · 13 readouts · <span style='font-weight:500'>mM, uM</span></h3>
-<p class='desc'>Molecular concentrations — metabolite pools, FBA target and updated concentrations, and growth-limiting species the metabolism solver reads and writes.</p>
-</div>
-<table><thead><tr><th>readout</th><th>unit</th><th style='text-align:right'>example</th><th style='text-align:right'>min</th><th style='text-align:right'>max</th></tr></thead><tbody>
-<tr><td class='path'>listeners.enzyme_kinetics.counts_to_molar</td><td class='unit'>mM</td><td class='num'>—</td><td class='num'>—</td><td class='num'>—</td></tr>
-<tr><td class='path'>listeners.enzyme_kinetics.target_aa_conc</td><td class='unit'>mM</td><td class='num'>—</td><td class='num'>—</td><td class='num'>—</td></tr>
-<tr><td class='path'>listeners.fba_results.conc_updates</td><td class='unit'>mM</td><td class='num'>—</td><td class='num'>—</td><td class='num'>—</td></tr>
-<tr><td class='path'>listeners.fba_results.target_concentrations</td><td class='unit'>mM</td><td class='num'>—</td><td class='num'>—</td><td class='num'>—</td></tr>
-<tr><td class='path'>listeners.growth_limits.aa_conc</td><td class='unit'>uM</td><td class='num'>—</td><td class='num'>—</td><td class='num'>—</td></tr>
-<tr><td class='path'>listeners.growth_limits.aa_supply_aa_conc</td><td class='unit'>mM</td><td class='num'>—</td><td class='num'>—</td><td class='num'>—</td></tr>
-<tr><td class='path'>listeners.growth_limits.charged_trna_conc</td><td class='unit'>uM</td><td class='num'>—</td><td class='num'>—</td><td class='num'>—</td></tr>
-<tr><td class='path'>listeners.growth_limits.ppgpp_conc</td><td class='unit'>uM</td><td class='num'>69.59</td><td class='num'>25.9</td><td class='num'>82.55</td></tr>
-<tr><td class='path'>listeners.growth_limits.rela_conc</td><td class='unit'>uM</td><td class='num'>—</td><td class='num'>—</td><td class='num'>—</td></tr>
-<tr><td class='path'>listeners.growth_limits.ribosome_conc</td><td class='unit'>uM</td><td class='num'>—</td><td class='num'>—</td><td class='num'>—</td></tr>
-<tr><td class='path'>listeners.growth_limits.spot_conc</td><td class='unit'>uM</td><td class='num'>—</td><td class='num'>—</td><td class='num'>—</td></tr>
-<tr><td class='path'>listeners.growth_limits.synthetase_conc</td><td class='unit'>uM</td><td class='num'>—</td><td class='num'>—</td><td class='num'>—</td></tr>
-<tr><td class='path'>listeners.growth_limits.uncharged_trna_conc</td><td class='unit'>uM</td><td class='num'>—</td><td class='num'>—</td><td class='num'>—</td></tr>
-</tbody></table>
-</section>
-<section>
-<div class="dim-head" style="background:#d6610a">
-<h3>rate · 1 readout · <span style='font-weight:500'>1/s</span></h3>
-<p class='desc'>Per-time rates — reaction and process velocities (e.g. equilibrium reaction rates) expressed per second.</p>
-</div>
-<table><thead><tr><th>readout</th><th>unit</th><th style='text-align:right'>example</th><th style='text-align:right'>min</th><th style='text-align:right'>max</th></tr></thead><tbody>
-<tr><td class='path'>listeners.equilibrium_listener.reaction_rates</td><td class='unit'>1/s</td><td class='num'>—</td><td class='num'>—</td><td class='num'>—</td></tr>
-</tbody></table>
-</section>
-<section>
-<div class="dim-head" style="background:#b0860b">
-<h3>count · 2 readouts · <span style='font-weight:500'>nt</span></h3>
-<p class='desc'>Molecule counts — discrete copy numbers (nucleotides, amino acids, bulk species) the stochastic processes act on.</p>
-</div>
-<table><thead><tr><th>readout</th><th>unit</th><th style='text-align:right'>example</th><th style='text-align:right'>min</th><th style='text-align:right'>max</th></tr></thead><tbody>
-<tr><td class='path'>listeners.rna_degradation_listener.fragment_bases_digested</td><td class='unit'>nt</td><td class='num'>—</td><td class='num'>—</td><td class='num'>—</td></tr>
-<tr><td class='path'>listeners.rna_degradation_listener.nucleotides_from_degradation</td><td class='unit'>nt</td><td class='num'>—</td><td class='num'>—</td><td class='num'>—</td></tr>
-</tbody></table>
-</section>
-<section>
-<div class="dim-head" style="background:#2c8c5a">
-<h3>time · 3 readouts · <span style='font-weight:500'>s</span></h3>
-<p class='desc'>Durations and timesteps — the simulation clock and per-process step sizes that pace the cell cycle.</p>
-</div>
-<table><thead><tr><th>readout</th><th>unit</th><th style='text-align:right'>example</th><th style='text-align:right'>min</th><th style='text-align:right'>max</th></tr></thead><tbody>
-<tr><td class='path'>global_time</td><td class='unit'>s</td><td class='num'>6500</td><td class='num'>60</td><td class='num'>6500</td></tr>
-<tr><td class='path'>next_update_time</td><td class='unit'>s</td><td class='num'>—</td><td class='num'>—</td><td class='num'>—</td></tr>
-<tr><td class='path'>timestep</td><td class='unit'>s</td><td class='num'>—</td><td class='num'>—</td><td class='num'>—</td></tr>
-</tbody></table>
-</section>
-<section>
-<div class="dim-head" style="background:#6b7280">
-<h3>other · 4 readouts · <span style='font-weight:500'>aa/s, amino_acid/s, g*s/L, mmol/g/h</span></h3>
-<p class='desc'>Composite or flux-like units that don&#x27;t fall into a single base dimension (e.g. g·s/L, mmol/g/h).</p>
-</div>
-<table><thead><tr><th>readout</th><th>unit</th><th style='text-align:right'>example</th><th style='text-align:right'>min</th><th style='text-align:right'>max</th></tr></thead><tbody>
-<tr><td class='path'>listeners.fba_results.coefficient</td><td class='unit'>g*s/L</td><td class='num'>—</td><td class='num'>—</td><td class='num'>—</td></tr>
-<tr><td class='path'>listeners.ribosome_data.effective_elongation_rate</td><td class='unit'>amino_acid/s</td><td class='num'>15.71</td><td class='num'>14.21</td><td class='num'>20.69</td></tr>
-<tr><td class='path'>listeners.ribosome_data.process_elongation_rate</td><td class='unit'>aa/s</td><td class='num'>—</td><td class='num'>—</td><td class='num'>—</td></tr>
-<tr><td class='path'>polypeptide_elongation.aa_exchange_rates</td><td class='unit'>mmol/g/h</td><td class='num'>—</td><td class='num'>—</td><td class='num'>—</td></tr>
-</tbody></table>
-</section>
-<p class='foot'>Built by <code>v2ecoli.library.units_atlas.build_atlas</code>, which walks the baseline composite's declared <code>quantity[...]</code> / <code>float[unit]</code> port types via <code>units_resolver.build_units_index</code>. Descriptive reference — no pass/fail gate.</p>
-</div>
+<h2>Units Atlas — readouts by physical dimension</h2>
+<h3>concentration (13)</h3>
+<table border='1' cellpadding='4' style='border-collapse:collapse'>
+<tr><th>readout</th><th>unit</th><th>example</th><th>min</th><th>max</th></tr>
+<tr><td>listeners.enzyme_kinetics.counts_to_molar</td><td>mM</td><td></td><td></td><td></td></tr>
+<tr><td>listeners.enzyme_kinetics.target_aa_conc</td><td>mM</td><td></td><td></td><td></td></tr>
+<tr><td>listeners.fba_results.conc_updates</td><td>mM</td><td></td><td></td><td></td></tr>
+<tr><td>listeners.fba_results.target_concentrations</td><td>mM</td><td></td><td></td><td></td></tr>
+<tr><td>listeners.growth_limits.aa_conc</td><td>uM</td><td></td><td></td><td></td></tr>
+<tr><td>listeners.growth_limits.aa_supply_aa_conc</td><td>mM</td><td></td><td></td><td></td></tr>
+<tr><td>listeners.growth_limits.charged_trna_conc</td><td>uM</td><td></td><td></td><td></td></tr>
+<tr><td>listeners.growth_limits.ppgpp_conc</td><td>uM</td><td></td><td></td><td></td></tr>
+<tr><td>listeners.growth_limits.rela_conc</td><td>uM</td><td></td><td></td><td></td></tr>
+<tr><td>listeners.growth_limits.ribosome_conc</td><td>uM</td><td></td><td></td><td></td></tr>
+<tr><td>listeners.growth_limits.spot_conc</td><td>uM</td><td></td><td></td><td></td></tr>
+<tr><td>listeners.growth_limits.synthetase_conc</td><td>uM</td><td></td><td></td><td></td></tr>
+<tr><td>listeners.growth_limits.uncharged_trna_conc</td><td>uM</td><td></td><td></td><td></td></tr>
+</table>
+<h3>count (2)</h3>
+<table border='1' cellpadding='4' style='border-collapse:collapse'>
+<tr><th>readout</th><th>unit</th><th>example</th><th>min</th><th>max</th></tr>
+<tr><td>listeners.rna_degradation_listener.fragment_bases_digested</td><td>nt</td><td></td><td></td><td></td></tr>
+<tr><td>listeners.rna_degradation_listener.nucleotides_from_degradation</td><td>nt</td><td></td><td></td><td></td></tr>
+</table>
+<h3>mass (4)</h3>
+<table border='1' cellpadding='4' style='border-collapse:collapse'>
+<tr><th>readout</th><th>unit</th><th>example</th><th>min</th><th>max</th></tr>
+<tr><td>listeners.mass.cell_mass</td><td>fg</td><td></td><td></td><td></td></tr>
+<tr><td>listeners.mass.dry_mass</td><td>fg</td><td></td><td></td><td></td></tr>
+<tr><td>listeners.mass.protein_mass</td><td>fg</td><td></td><td></td><td></td></tr>
+<tr><td>listeners.mass.rna_mass</td><td>fg</td><td></td><td></td><td></td></tr>
+</table>
+<h3>other (4)</h3>
+<table border='1' cellpadding='4' style='border-collapse:collapse'>
+<tr><th>readout</th><th>unit</th><th>example</th><th>min</th><th>max</th></tr>
+<tr><td>listeners.fba_results.coefficient</td><td>g*s/L</td><td></td><td></td><td></td></tr>
+<tr><td>listeners.ribosome_data.effective_elongation_rate</td><td>amino_acid/s</td><td></td><td></td><td></td></tr>
+<tr><td>listeners.ribosome_data.process_elongation_rate</td><td>aa/s</td><td></td><td></td><td></td></tr>
+<tr><td>polypeptide_elongation.aa_exchange_rates</td><td>mmol/g/h</td><td></td><td></td><td></td></tr>
+</table>
+<h3>rate (1)</h3>
+<table border='1' cellpadding='4' style='border-collapse:collapse'>
+<tr><th>readout</th><th>unit</th><th>example</th><th>min</th><th>max</th></tr>
+<tr><td>listeners.equilibrium_listener.reaction_rates</td><td>1/s</td><td></td><td></td><td></td></tr>
+</table>
+<h3>time (3)</h3>
+<table border='1' cellpadding='4' style='border-collapse:collapse'>
+<tr><th>readout</th><th>unit</th><th>example</th><th>min</th><th>max</th></tr>
+<tr><td>global_time</td><td>s</td><td></td><td></td><td></td></tr>
+<tr><td>next_update_time</td><td>s</td><td></td><td></td><td></td></tr>
+<tr><td>timestep</td><td>s</td><td></td><td></td><td></td></tr>
+</table>


### PR DESCRIPTION
## What happened
In #231 I "corrected" the units-atlas study to say its magnitude columns were empty/fabricated, based on a fact-check agent reading the **committed** (blank) `viz/units_atlas.html`. That was wrong: the published report **live-renders** `UnitsAtlasVisualization` against a `two_generations` baseline run, so the figure was **always populated** with real values — **cell_mass ~2174 fg, ppGpp ~86.9 uM** (12+ readouts), exactly what the original #226 prose stated. My change then made the prose (1469/69.6 from showcase-2) contradict the live figure.

## Fix
Revert the magnitude prose, `planned_runs`, and committed figure to the correct #226 state (2174/86.9, "from a two_generations run"). Keep the legitimate `cell volume/length` → `characteristic times (s)` dimension fix from #231 (the atlas genuinely has no volume/length dimension).

Verified the live published figure shows: cell_mass 2174/1168/2338 fg, dry_mass 652.6, ppGpp 86.9, rela 0.119, ribosome 19.93 uM, … sampled from `two_generations`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)