### PR TITLE
Reconcile pdmp-01/03 stale de-slop under-claims with the studies' own findings

### DIFF
--- a/workspace/investigations/v2ecoli-pdmp/studies/pdmp-01-metabolism-ode/study.yaml
+++ b/workspace/investigations/v2ecoli-pdmp/studies/pdmp-01-metabolism-ode/study.yaml
@@ -463,8 +463,10 @@ report:
   evidence_quality: first-run-confirmed
   conclusion: 'First run confirmed (2026-05-24): Millard 2017 SBML loads + simulates via pbg-copasi and recovers the published
     reference steady state for central carbon + energy metabolites (G6P, F6P, FDP, PEP, PYR, ATP/ADP, NADH/NADPH, MAL, AKG
-    all match BioModels MODEL1505110000 initial values to solver tolerance). FBA-bridge composite and LQR control layer not
-    yet built; Phase 0 ensemble comparison pending the v2ecoli baseline run.'
+    all match BioModels MODEL1505110000 initial values to solver tolerance). The FBA-bridge flux-pin now integrates the
+    Millard ODE into the WCM FBA (24 active pins) and the LQR was fixed to a real stabilizing gain (||K|| ≈ 4.39, commit
+    cc6a72d); the PDMP-vs-Phase-0 endpoint W₂ comparison is done on M9-glucose (±σ gate MET; cell_mass W₂/σ = 1.00,
+    dry_mass 1.09, commit 6a764fc), with acetate / +aa multi-condition still pending.'
   main_insight: pbg-copasi gives us the published Millard model as a first-class PB process without re-deriving rate laws
     — Phase 1 effort goes to the LQR + FBA-bridge, not to ODE re-implementation.
   caveat: 'LQR reference trajectory must not reintroduce a teleonomic parameter in disguise; the causal/teleonomic partition
@@ -884,9 +886,10 @@ discovery_implications:
     v2ecoli.steps.listeners.* instead of v2ecoli.steps.derivers.*) — its likelihood path was unbuildable
     until fixed in this refresh; (b) in the DEFAULT ''proportional'' ref-growth mode the composite CRASHES
     mid-run with "ValueError: Negative values at equilibrium steady state" (v2ecoli/processes/equilibrium.py)
-    and runs only in the ''consumption_matched'' mode; (c) even in consumption_matched mode the LQR Riccati
-    solve fails ("Failed to find a finite solution"; falls back to zero gain) — the outer controller is
-    degenerate.'
+    and runs only in the ''consumption_matched'' mode; (c) the LQR zero-gain Riccati bug (an A = I + J
+    finite-difference artifact) was root-caused and FIXED (commit cc6a72d; true Jacobian + conserved-moiety
+    CARE shift → ||K|| ≈ 4.39, regression-tested in tests/test_lqr_riccati_stabilizable.py), so the outer
+    controller is no longer degenerate (gain_degenerate=False across 12/12 replicates).'
   - 'The FBA-bridge composite has not been shown to hold interface statistics across ANY Phase-0
     condition; the M9-glucose, M9-acetate and M9-glucose+aa W2 audits are all pending (no condition is
     closed).'
@@ -916,9 +919,10 @@ discovery_implications:
   - mechanism_node_or_edge: metabolism (multi-objective FBA -> kinetic ODE)
     update_type: replace
     rationale: 'Substitute v2ecoli''s multi-objective modular_fba LP with the Millard 2017 kinetic ODE +
-      LQR outer control as the Phase-1-canonical metabolism layer. NOT yet accepted — the ±σ cell_mass /
-      dry_mass gate on M9-glucose is unmet (~ -20 σ / -18 σ at t=600 s) and no true W2 has been computed;
-      the multi-condition FBA-bridge validation is also pending.'
+      LQR outer control as the Phase-1-canonical metabolism layer. NOT yet accepted as canonical — but the
+      ±σ cell_mass / dry_mass gate is now MET on M9-glucose (endpoint W₂/σ = 1.00 / 1.09 after the
+      closed-loop WATER[c] fix, commit 6a764fc); the multi-condition (acetate / +aa) W₂ and the FBA-bridge
+      multi-condition validation remain pending (requires_expert_approval).'
     requires_expert_approval: true
   followup_study_proposals:
   - id: pdmp-01-fba-bridge-multicondition

--- a/workspace/investigations/v2ecoli-pdmp/studies/pdmp-03-inference/study.yaml
+++ b/workspace/investigations/v2ecoli-pdmp/studies/pdmp-03-inference/study.yaml
@@ -494,7 +494,7 @@ tests:
 - name: sbc-calibration-uniform-rank
   classification: primary
   status: planned
-  description: 'PLANNED / NOT RUN — the cited script scripts/run_sbc.py does not exist and SBC has not been run. Intended check: ABC-SMC posterior of kinetic-ODE parameters is calibrated under Simulation-Based Calibration (Talts 2018):
+  description: 'INCREMENT 1 (2026-06-12): scripts/run_sbc.py EXISTS and passes at K=150 on a WCM-calibrated count surrogate (χ² rank-uniformity p=0.576); the full-WCM K=1000 multi-modality SBC gate (pass_if below) remains unrun, so status stays planned. Intended full check: ABC-SMC posterior of kinetic-ODE parameters is calibrated under Simulation-Based Calibration (Talts 2018):
     the rank-histogram of true parameter values within posterior draws is uniform (Cramér–von Mises p > 0.05) across L=200
     synthetic experiments. The fundamental check that the inference machinery is correct — deviations diagnose specific failure
     modes.'
@@ -513,9 +513,9 @@ tests:
 - name: posterior-shrinks-with-data
   classification: primary
   status: planned
-  description: PLANNED / NOT RUN — the cited script scripts/run_abc_smc.py does not exist. Intended check; Posterior 95% interval width monotonically decreases with the size of the observed dataset (1, 10, 100, 1000
+  description: 'INCREMENT 1 (2026-06-12): scripts/run_abc_smc.py EXISTS; on a WCM-calibrated count surrogate it recovers theta_true=1.2 → 90% CI [1.198, 1.201], so the posterior is informative. Full-WCM-in-the-loop is deferred to Phase 4, so status stays planned. Intended full check: Posterior 95% interval width monotonically decreases with the size of the observed dataset (1, 10, 100, 1000
     observation points). Asymptote at <30% of the prior width with 1000 points — confirms the data is informative for the
-    posterior. Constant width = inference is ignoring the data.
+    posterior. Constant width = inference is ignoring the data.'
   measure:
     source: scripts/run_abc_smc.py --vary-data-size
     observable: posterior 95% interval width per parameter
@@ -530,7 +530,7 @@ tests:
 - name: ppc-coverage-95-pct
   classification: supporting
   status: planned
-  description: 'PLANNED / NOT RUN — the cited script scripts/run_ppc.py does not exist; no PPC has been run. Intended posterior predictive check: ≥95% of held-out Phase 0 ensemble observations fall within the posterior predictive
+  description: 'INCREMENT 1 (2026-06-12): scripts/run_ppc.py EXISTS; PPC 90% coverage = 0.91 on a WCM-calibrated surrogate; the full-WCM multi-modality PPC remains pending, so status stays planned. Intended full posterior predictive check: ≥95% of held-out Phase 0 ensemble observations fall within the posterior predictive
     95% interval. Higher = overconfidence; lower = underconfidence.'
   measure:
     source: scripts/run_ppc.py


### PR DESCRIPTION
The previously-flagged pdmp reconciliation. Both studies had stale pre-fix prose that **contradicts the study's own later findings** and the on-disk reality — *under*-claiming work that demonstrably landed. Every correction was verified against the study's `findings` block and the files on disk; the honest "full gate still unmet / `status: planned`" is preserved (no `gate_status` changed — all six pdmp studies remain `in_progress`/`blocked`).

**pdmp-01** (verified vs findings: gate MET on M9-glucose, W₂/σ 1.00/1.09 @ 6a764fc; LQR ‖K‖≈4.39 @ cc6a72d; FBA-bridge 24 active pins):
- `mechanism_update` rationale: "±σ gate unmet (~-20σ), no true W2 computed" → gate now MET on M9-glucose; multi-condition + FBA-bridge multi-condition pending.
- `report.conclusion`: "FBA-bridge & LQR not yet built; Phase 0 pending" → both built/fixed, M9-glucose comparison done.
- `remaining_uncertainties (c)`: "LQR Riccati degenerate / zero gain" → root-caused + FIXED (gain_degenerate=False, 12/12 reps).

**pdmp-03** (scripts `run_sbc.py` / `run_abc_smc.py` / `run_ppc.py` verified present on disk):
- 3 test descriptions: "PLANNED / NOT RUN — the cited script does not exist" → Increment-1 RAN on a WCM-calibrated surrogate (SBC χ² p=0.576; ABC θ=1.2 → 90% CI [1.198,1.201]; PPC coverage 0.91). Kept `status: planned` (full-WCM K=1000 gate unmet).

This closes the last deferred fact-check item. Merging auto-republishes (`workspace/**`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)