### PR TITLE
3D viewer: point dashboard + README at the R2-hosted viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > **Explore in your browser — no install:**
 > &nbsp;🖥️ **[Interactive dashboard](https://vivarium-collective.github.io/v2ecoli/dashboard/)** (browse the whole workspace)
-> &nbsp;·&nbsp; 🧬 **[3D *E. coli* cell](https://vivarium-collective.github.io/v2ecoli/dashboard/#visualizations)** (interactive structural model — dashboard → Analyses)
+> &nbsp;·&nbsp; 🧬 **[3D *E. coli* cell](https://pub-eb913fbbdc584bd7add047c823570b13.r2.dev/viewer/index.html?file=https://pub-eb913fbbdc584bd7add047c823570b13.r2.dev/ecoli-3d/viz/3d/ecoli_3d.pack.json)** (interactive whole-cell structural model — opens directly; **"View in VR"** on a Meta Quest)
 > &nbsp;·&nbsp; 📊 **[Baseline Showcase report](https://vivarium-collective.github.io/v2ecoli/investigations/v2ecoli-baseline-showcase.html)** ⭐ (best starting point)
 > &nbsp;·&nbsp; 🗂️ **[Report gallery](https://vivarium-collective.github.io/v2ecoli/)**
 > — see **[Explore v2ecoli](#explore-v2ecoli)** for what each one is.

--- a/workspace.yaml
+++ b/workspace.yaml
@@ -143,3 +143,9 @@ ui:
   # then passes <ptools_data_dir>/<rel> as the data file. Run the container with:
   #   -v <host>/v2ecoli/workspace:/ptools-data/workspace:ro
   ptools_data_dir: "/ptools-data"
+  # External viewer URLs for Analyses-tab 3D cards, keyed by pack name. The
+  # ecoli_3d whole-cell pack is served from Cloudflare R2 (free egress, no
+  # GitHub Pages 429 rate-limiting on the heavy pack + meshes); the dashboard
+  # card links + embeds this instead of the bundled gh-pages viewer.
+  viz_viewer_urls:
+    ecoli_3d: "https://pub-eb913fbbdc584bd7add047c823570b13.r2.dev/viewer/index.html?file=https://pub-eb913fbbdc584bd7add047c823570b13.r2.dev/ecoli-3d/viz/3d/ecoli_3d.pack.json"


### PR DESCRIPTION
The whole-cell 3D viewer now serves from **Cloudflare R2** (free egress, no GitHub Pages 429 throttling on the heavy pack + 825 meshes).

- **`workspace.yaml`** → `ui.viz_viewer_urls.ecoli_3d` = the R2 viewer URL, so the read-only dashboard's **Analyses** card links + embeds R2 instead of the throttled gh-pages viewer. (Needs vivarium-dashboard **#275** for the `viewer_url` plumbing.)
- **`README.md`** → the top "3D *E. coli* cell" link opens the R2 viewer **directly** (also VR-capable: "View in VR" on a Meta Quest).

After both merge, republish the dashboard so the baked `saved-visualizations.json` picks up `viewer_url`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)