### PR TITLE
fix: bound embedded inner-WCM RAMEmitter (per-cell RSS leak)

### DIFF
--- a/v2ecoli/bridge.py
+++ b/v2ecoli/bridge.py
@@ -73,13 +73,29 @@ class EcoliWCM(Process):
 
         internal_core = build_core()
 
-        document = baseline(core=internal_core, seed=seed, cache_dir=cache_dir)
+        # Embedded inner WCM: its in-RAM emitter history is NEVER read — the
+        # bridge reads composite.state directly (see _read_outputs /
+        # _read_chromosome_state). So build the inner composite with the minimal
+        # global_time-only RAMEmitter instead of the default full-state capture
+        # (bulk ~25k molecules + four unique-molecule node arrays appended every
+        # tick into an unbounded, never-read history). That full capture is a
+        # ~7.7 MB/sim-s per-cell RSS leak that OOM-kills a growing colony — found
+        # in the colonies investigation and localized to this inner emitter.
+        # Save/restore the flag so it never leaks into a non-embedded caller that
+        # builds a composite later in the same process.
+        from v2ecoli.composites import _helpers as _helpers_mod
+        _prev_null_emitter = _helpers_mod._NULL_EMITTER_OVERRIDE
+        _helpers_mod.set_null_emitter_override(True)
+        try:
+            document = baseline(core=internal_core, seed=seed, cache_dir=cache_dir)
 
-        # Use the full document directly — preserves agents wrapper.
-        # The division step's '..' wire to parent agents will resolve to
-        # the empty agents dict when there's no outer container, which is
-        # safe because division won't trigger until t=~2500s.
-        self._composite = Composite(document, core=internal_core)
+            # Use the full document directly — preserves agents wrapper.
+            # The division step's '..' wire to parent agents will resolve to
+            # the empty agents dict when there's no outer container, which is
+            # safe because division won't trigger until t=~2500s.
+            self._composite = Composite(document, core=internal_core)
+        finally:
+            _helpers_mod.set_null_emitter_override(_prev_null_emitter)
 
         # Seed previous values for delta computation
         cell_state = self._composite.state.get('agents', {}).get('0', {})


### PR DESCRIPTION
## Problem
Each embedded `EcoliWCM` (e.g. a colony cell) builds an inner `baseline()` Composite whose default emitter captures heavy per-tick state (`bulk` ~25k molecules + listeners/unique structures) into a RAM-buffered history that is **never read** (the bridge reads `composite.state` directly). That's a per-cell RSS leak that OOM-kills a growing colony before it can be HPC-sized (found in the colonies investigation).

> Note: on *current main* the baseline default sink is a **ParquetEmitter** (buffers in RAM), not the full-state RAMEmitter; either way it leaks. See runtime numbers below.

## Fix
`bridge._build_composite` enables main's **existing** minimal-emitter mechanism — `set_null_emitter_override(True)` → a `global_time`-only `RAMEmitter` (`_helpers.py:1247`, higher precedence than the parquet default) — for the embedded inner composite, with **save/restore** so the flag never leaks into a non-embedded caller. Reuses the workflow's external-emitter path; no new emitter logic. Benefits any embedded composite (colonies, multiscale-bioprocess, autopoiesis).

## Runtime verification (mini, on current main, HEAD 580ee7d4, fresh cache)
| | emit-keys | RSS slope |
|---|---|---|
| **Fixed** | `['global_time']` | **0.29 MB/s** (bounded, 980→1734 MB / 1500 ticks) |
| **Unfixed** | full (`bulk`,`listeners`,…) | **6.37 MB/s** (monotonic, 997→4016 MB / 400 ticks) |

**~22× reduction; leak eliminated.** `_NULL_EMITTER_OVERRIDE` confirmed False before & after build (save/restore works).

## Related (NOT in this PR)
Separately, the bridge's `_read_outputs` does `float(mass_data['dry_mass'])` on a unit-carrying `pint` Quantity → errors with a fresh cache, so the bridge returns zero mass each tick. Orthogonal to the emitter leak; flagged as a follow-up (matters for re-running the colony on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)