### PR TITLE
dashboard: show all imported/used pbg repos in the registry

### DIFF
--- a/workspace.yaml
+++ b/workspace.yaml
@@ -107,12 +107,13 @@ imports:
 server:
   enabled: true
 dashboard:
-  # Registry tab: show ONLY this repo's own process/type classes. Without this
-  # the grid lists every installed pbg-* package's classes (pbg-cellpack, …)
-  # auto-registered by allocate_core(). Display-only allow-list by top-level
-  # package; discovery is unchanged.
+  # Registry tab: show v2ecoli's own classes PLUS the pbg-* packages it actually
+  # imports and uses, while still hiding merely-installed-but-unused pbg-* repos
+  # (e.g. pbg-cellpack) that allocate_core() auto-registers. Display-only
+  # allow-list by top-level package (dashes/underscores normalized); discovery
+  # is unchanged. Keep in sync with the pbg-* deps in pyproject.toml.
   registry:
-    include: [v2ecoli]
+    include: [v2ecoli, pbg_superpowers, pbg_copasi, pbg_parsimony, pbg_bioreactordesign, pbg_ketchup, pbg_emitters]
   # Sources page: surface the ecoli-sources bundle (the ParCa/reconstruction
   # input files) with links — inherited files link to the pinned ecoli-sources
   # GitHub commit, local overrides to this repo. See v2ecoli/dashboard_sources.py.


### PR DESCRIPTION
## Problem
The read-only dashboard's Registry tab only showed `v2ecoli`'s own classes. pbg-* packages that v2ecoli imports and uses — most visibly **pbg-ketchup** (`KetchupEstimator`/`KetchupDynamicEstimator`, wired in via `v2ecoli/core.py` `register_link`) — were missing, even though they're installed, imported, and registered.

## Cause
`workspace.yaml` → `dashboard.registry.include` was `[v2ecoli]`. The dashboard's `_apply_registry_include_filter` keeps a class only if its address's top-level package is in that list (emitters + re-exports exempt). KETCHUP classes live under `pbg_ketchup.*`, so they were filtered out of the display. (The filter was originally added to hide *every* auto-registered pbg-* package like pbg-cellpack.)

## Fix
Widen the allow-list to `v2ecoli` + the six pbg-* packages that actually contribute registry classes and are direct `pyproject.toml` deps:
`pbg_superpowers, pbg_copasi, pbg_parsimony, pbg_bioreactordesign, pbg_ketchup, pbg_emitters`.

Verified against the live unfiltered registry — these are exactly the pbg packages with classes (counts: superpowers 22, copasi 8, bioreactordesign 8, emitters 8, ketchup 4, parsimony 2). Merely-installed-but-unused pbg repos (e.g. pbg-cellpack) stay hidden. Display-only; discovery unchanged.

After merge, the dashboard republish (triggered by the `workspace/**` change) will surface these in the live Registry tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)