### PR TITLE
ci: republish on root workspace.yaml changes

### DIFF
--- a/.github/workflows/publish-dashboard.yml
+++ b/.github/workflows/publish-dashboard.yml
@@ -20,6 +20,9 @@ on:
     paths:
       # Republish when anything that changes the snapshot changed.
       - 'workspace/**'
+      # Root workspace.yaml is NOT under workspace/** — list it explicitly so
+      # registry/layout/runtime changes (e.g. dashboard.registry.include) republish.
+      - 'workspace.yaml'
       - 'reports/figures/**'
       - 'scripts/publish_dashboard.sh'
       - '.github/workflows/publish-dashboard.yml'

--- a/.github/workflows/publish-reports.yml
+++ b/.github/workflows/publish-reports.yml
@@ -17,6 +17,9 @@ on:
     paths:
       # Only republish when something that changes a report changed.
       - 'workspace/**'
+      # Root workspace.yaml is NOT under workspace/** — list it explicitly so
+      # layout/registry changes republish the reports too.
+      - 'workspace.yaml'
       - 'reports/figures/**'
       - 'scripts/publish_investigation_reports.py'
       - '.github/workflows/publish-reports.yml'


### PR DESCRIPTION
## Problem
`publish-dashboard.yml` and `publish-reports.yml` trigger on `paths: ['workspace/**', ...]`, but the root **`workspace.yaml`** is not under the `workspace/` directory. So edits to `workspace.yaml` (e.g. `dashboard.registry.include`, `layout`, `runtime.default_emitter`) silently do **not** auto-trigger a republish — they have to be kicked manually via `workflow_dispatch`. This just bit the registry-allowlist fix (#240), which needed a manual republish to take effect.

## Fix
Add `'workspace.yaml'` to the `paths:` list of both publish workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)