### PR TITLE
dashboard: switchable two-state 3D viewer in Analyses tab

### DIFF
--- a/workspace.yaml
+++ b/workspace.yaml
@@ -157,5 +157,7 @@ ui:
   # ecoli_3d whole-cell pack is served from Cloudflare R2 (free egress, no
   # GitHub Pages 429 rate-limiting on the heavy pack + meshes); the dashboard
   # card links + embeds this instead of the bundled gh-pages viewer.
+  # ?models= loads a manifest so a single card switches between states in-viewer
+  # (birth — 1.8 µm rod; pre-division — 3.06 µm, 2 chromosomes + septum).
   viz_viewer_urls:
-    ecoli_3d: "https://pub-eb913fbbdc584bd7add047c823570b13.r2.dev/viewer/index.html?file=https://pub-eb913fbbdc584bd7add047c823570b13.r2.dev/ecoli-3d/viz/3d/ecoli_3d.pack.json"
+    ecoli_3d: "https://pub-eb913fbbdc584bd7add047c823570b13.r2.dev/viewer/index.html?models=https://pub-eb913fbbdc584bd7add047c823570b13.r2.dev/ecoli-3d/viz/3d/models.json"


### PR DESCRIPTION
Points the read-only dashboard's Analyses-tab 3D card (`ui.viz_viewer_urls.ecoli_3d`) at the **switchable** viewer link (`?models=…/models.json`) instead of the single birth pack (`?file=…ecoli_3d.pack.json`).

A single card now switches in-viewer between:
- **Birth** — 1.8 µm rod (1 chromosome, 2 forks)
- **Pre-division** — 3.06 µm (2 chromosomes segregated to poles, 4 forks, septum constriction)

The `models.json` manifest and both packs are already live on R2; verified the switchable URL loads both. No mesh/asset changes — config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)