### PR TITLE
investigation(surrogate-modeling): mark complete

### DIFF
--- a/workspace/investigations/surrogate-modeling/investigation.yaml
+++ b/workspace/investigations/surrogate-modeling/investigation.yaml
@@ -2,7 +2,7 @@ schema_version: 2
 name: surrogate-modeling
 title: "Surrogate Modeling — can a neural net emulate the v2ecoli baseline?"
 created: '2026-06-16'
-status: running
+status: complete
 
 question: |
   Can a neural-network surrogate, trained on v2ecoli baseline rollouts, emulate


### PR DESCRIPTION
## What

Flip the `surrogate-modeling` investigation's lifecycle `status` from `running` → `complete`.

## Why

All four member studies are fully `evaluated` with recorded run outcomes and written conclusion verdicts, and the investigation's `executive.verdict_status` is already `passed`. Only the top-level lifecycle `status` field lagged at `running`, so the public dashboard was rendering an otherwise-finished investigation as in-progress.

| Study | Gate | Result |
|---|---|---|
| sm-00 data-collection | PASS | 2000×11569 transition dataset built |
| sm-01 nn-surrogate | FAIL (intentional) | NN does not beat linear; refuted as designed |
| sm-02 utility-and-limits | PASS | linear emulator amortizes (~3.8e6× speedup) |
| sm-03 improving-the-surrogate | PASS | rollout-loss fixes instability, still loses to linear |

The `sm-01` FAIL is an intentional refutation (a negative result is still a finished result), not unfinished work. No study content changed — this is a single-field status correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)