### PR TITLE
references: correct 3 wrong DOIs in papers.bib

### DIFF
--- a/workspace/references/papers.bib
+++ b/workspace/references/papers.bib
@@ -265,7 +265,7 @@
   number  = {1},
   pages   = {1690},
   year    = {2024},
-  doi     = {10.1038/s42003-024-07434-5},
+  doi     = {10.1038/s42003-024-07359-z},
   note    = {DUF ref [14].}
 }
 
@@ -335,7 +335,7 @@
   volume  = {11},
   number  = {1},
   year    = {2023},
-  doi     = {10.1515/jci-2022-0019},
+  doi     = {10.1515/jci-2021-0005},
   note    = {DUF ref [20].}
 }
 
@@ -347,7 +347,7 @@
   number  = {25},
   pages   = {8554--8564},
   year    = {2006},
-  doi     = {10.1021/ie050979g},
+  doi     = {10.1021/ie060218f},
   note    = {Reference design for the Phase 1 LQR control layer. DUF ref [21].}
 }
 


### PR DESCRIPTION
## What

Fact-checked all 57 entries in `workspace/references/papers.bib` against Crossref/publishers. **All 57 cite real works.** Three `@article` entries carried a DOI that resolves to a *different* paper — fixed here:

| Key | Old DOI | Problem | New DOI |
|---|---|---|---|
| `yang2024` | `10.1038/s42003-024-07434-5` | resolves to an unrelated audiovisual-neuroscience paper | `10.1038/s42003-024-07359-z` |
| `blom2023` | `10.1515/jci-2022-0019` | resolves to a different J. Causal Inference article | `10.1515/jci-2021-0005` |
| `uygun2006` | `10.1021/ie050979g` | dead link (404) | `10.1021/ie060218f` |

All three corrected DOIs verified via Crossref to resolve to the cited title/authors/year.

## Not changed (intentionally)

- The DnaA `@misc` block is provenance-faithful by design (URL + verbatim plan-PDF description, no asserted metadata per the file header) — left as-is; it is not untruthful, just sparse.
- `Lee1996TrendsBiotechnol` and `Korz1995JBiotechnol` are real but currently cited by nothing (candidates to wire into `mbp-05`/`mbp-06` or drop — flagged separately, not touched here).
- `mass-spec-nbt-3418` and `schmidt2016` are the same paper (both `10.1038/nbt.3418`) — a duplicate worth consolidating later, but both point to the real paper so not a correctness bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)