### PR TITLE
chore(deps): bump vivarium-dashboard pin (#280 snapshot pop-out fix)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -4572,7 +4572,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/3e/87/794e0b4c5dccbca30
 [[package]]
 name = "vivarium-dashboard"
 version = "0.1.0"
-source = { git = "https://github.com/vivarium-collective/vivarium-dashboard.git?branch=main#4399ad90fe0a77df4724457b51308eac413e9ff4" }
+source = { git = "https://github.com/vivarium-collective/vivarium-dashboard.git?branch=main#ce5e3f9e2bcc74eb7a878532a0b3629a82c908a0" }
 dependencies = [
     { name = "bigraph-loom" },
     { name = "bigraph-schema" },


### PR DESCRIPTION
Bumps the `vivarium-dashboard` lock pin to `ce5e3f9e`, which includes vivarium-dashboard #280 (snapshot-aware study-page composite pop-out + alias-override publishing).

Needed so the CI-built read-only dashboard ships the fixed `study-detail.js` and the `publish.py` alias-copy step, paired with the committed `reports/composite-state/` overrides from #258. Without this bump the published build would still use the pre-#280 dashboard and the study pop-outs would keep 404-ing.

After merge: trigger **Publish read-only dashboard** (uv.lock-only changes don't auto-trigger the publish workflow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)