### PR TITLE
surrogate-modeling: sm-02/sm-03 depend on sm-01 having run, not passed

### DIFF
--- a/workspace/studies/sm-02-utility-and-limits/study.yaml
+++ b/workspace/studies/sm-02-utility-and-limits/study.yaml
@@ -111,7 +111,13 @@ embed_visualizations:
 
 pipeline_gate:
   prerequisites:
-  - sm-01-nn-surrogate
+  # Depends on sm-01 having been EVALUATED (its surrogate-vs-baseline result is
+  # the input), NOT on sm-01 passing — sm-01's behaviour tests intentionally
+  # FAIL (the finding is the surrogate does not beat baselines), and this study
+  # exists to characterise that failure. A bare-string prerequisite defaults to
+  # condition `tests-passed`, which would (wrongly) keep this study blocked.
+  - study: sm-01-nn-surrogate
+    condition: ran
   enables: []
   gate_status: passed
 

--- a/workspace/studies/sm-03-improving-the-surrogate/study.yaml
+++ b/workspace/studies/sm-03-improving-the-surrogate/study.yaml
@@ -116,7 +116,13 @@ embed_visualizations:
 
 pipeline_gate:
   prerequisites:
-  - sm-01-nn-surrogate
+  # Depends on sm-01 having been EVALUATED, NOT on sm-01 passing — sm-01's
+  # behaviour tests intentionally FAIL (the surrogate does not beat baselines),
+  # and this study follows up by trying to improve it. A bare-string
+  # prerequisite defaults to condition `tests-passed`, which would (wrongly)
+  # keep this study blocked.
+  - study: sm-01-nn-surrogate
+    condition: ran
   enables: []
   gate_status: passed
 


### PR DESCRIPTION
## What

The **Surrogate Modeling** investigation is marked `status: complete` (`verdict_status: passed`), but the dashboard rendered it as not-complete because `sm-02-utility-and-limits` and `sm-03-improving-the-surrogate` computed as `blocked`.

## Why they were blocked

Both declared `pipeline_gate.prerequisites: [sm-01-nn-surrogate]` as a **bare string**, which the dashboard defaults to the condition **`tests-passed`**. But `sm-01`'s behaviour tests **intentionally fail** — the scientific finding is that the NN surrogate does *not* beat baselines (0% of observables beat persistence; rollout diverges to NaN; a linear model wins). `sm-02` ("utility and limits") and `sm-03` ("improving the surrogate") exist *to characterise and follow up on that failure* — they depend on `sm-01` having **run/been evaluated**, not on it passing.

## Fix

Make the dependency explicit:
```yaml
pipeline_gate:
  prerequisites:
  - study: sm-01-nn-surrogate
    condition: ran
```

## Companion

Pairs with vivarium-dashboard #281, which lets an `evaluated` study satisfy the `ran` condition (these studies are terminally `evaluated`). Verified end-to-end: with both changes, all four `sm-*` studies report `blocked: false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)