### PR TITLE
chore: bump vivarium-dashboard pin to include evaluated->ran fix (#281)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -4572,7 +4572,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/3e/87/794e0b4c5dccbca30
 [[package]]
 name = "vivarium-dashboard"
 version = "0.1.0"
-source = { git = "https://github.com/vivarium-collective/vivarium-dashboard.git?branch=main#ce5e3f9e2bcc74eb7a878532a0b3629a82c908a0" }
+source = { git = "https://github.com/vivarium-collective/vivarium-dashboard.git?branch=main#b776f22a3ec22d74be7d124b0c177e9f3d92168c" }
 dependencies = [
     { name = "bigraph-loom" },
     { name = "bigraph-schema" },


### PR DESCRIPTION
Bumps the locked `vivarium-dashboard` commit `ce5e3f9e → b776f22a` so the read-only publish (runs via `uv run`, lock-synced) picks up dashboard #281 (an `evaluated` study satisfies a `ran` prerequisite).

Needed together with #261 (sm-02/sm-03 prerequisite `condition: ran`) for the **surrogate-modeling** investigation to stop rendering its terminally-`evaluated` studies as `blocked` on the published dashboard.

`uv.lock`-only changes don't match the publish trigger paths, so after merge:
```
gh workflow run "Publish read-only dashboard" --ref main
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)