### PR TITLE
chore: bump vivarium-dashboard pin (DAG-card clamp + evaluated rollup, #282)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -4572,7 +4572,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/3e/87/794e0b4c5dccbca30
 [[package]]
 name = "vivarium-dashboard"
 version = "0.1.0"
-source = { git = "https://github.com/vivarium-collective/vivarium-dashboard.git?branch=main#b776f22a3ec22d74be7d124b0c177e9f3d92168c" }
+source = { git = "https://github.com/vivarium-collective/vivarium-dashboard.git?branch=main#31e707c9007f8ef52c48c57d85a69656046f61c4" }
 dependencies = [
     { name = "bigraph-loom" },
     { name = "bigraph-schema" },


### PR DESCRIPTION
Bumps the locked vivarium-dashboard commit `b776f22a → 31e707c9` so the read-only publish picks up dashboard #282 (DAG card line-clamp + evaluated/decided counted as done in the investigation rollup).

After merge: `gh workflow run "Publish read-only dashboard" --ref main` (uv.lock-only changes don't auto-trigger publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)