### PR TITLE
chore: bump vivarium-dashboard pin (sim-db nested-study discovery, #283)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -4572,7 +4572,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/3e/87/794e0b4c5dccbca30
 [[package]]
 name = "vivarium-dashboard"
 version = "0.1.0"
-source = { git = "https://github.com/vivarium-collective/vivarium-dashboard.git?branch=main#31e707c9007f8ef52c48c57d85a69656046f61c4" }
+source = { git = "https://github.com/vivarium-collective/vivarium-dashboard.git?branch=main#f3ef4bd4e239f702bea40dc165c7c824ec51f105" }
 dependencies = [
     { name = "bigraph-loom" },
     { name = "bigraph-schema" },

--- a/uv.lock
+++ b/uv.lock
@@ -4572,7 +4572,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/3e/87/794e0b4c5dccbca30
 [[package]]
 name = "vivarium-dashboard"
 version = "0.1.0"
-source = { git = "https://github.com/vivarium-collective/vivarium-dashboard.git?branch=main#f3ef4bd4e239f702bea40dc165c7c824ec51f105" }
+source = { git = "https://github.com/vivarium-collective/vivarium-dashboard.git?branch=main#dfbab67a970b37a05a30598da6328765e4af3b41" }
 dependencies = [
     { name = "bigraph-loom" },
     { name = "bigraph-schema" },


### PR DESCRIPTION
Bumps the locked vivarium-dashboard commit `31e707c9 → f3ef4bd4` so the read-only publish picks up dashboard #283 (Simulations DB discovers nested investigations/<inv>/studies/<slug>/ runs).

After merge: `gh workflow run "Publish read-only dashboard" --ref main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)