### PR TITLE
chore: bump vivarium-dashboard pin (registry imported-repos panel, #285)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -4572,7 +4572,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/3e/87/794e0b4c5dccbca30
 [[package]]
 name = "vivarium-dashboard"
 version = "0.1.0"
-source = { git = "https://github.com/vivarium-collective/vivarium-dashboard.git?branch=main#dfbab67a970b37a05a30598da6328765e4af3b41" }
+source = { git = "https://github.com/vivarium-collective/vivarium-dashboard.git?branch=main#37d4b145f24dcc9663a56a2cd880c84a64a0b433" }
 dependencies = [
     { name = "bigraph-loom" },
     { name = "bigraph-schema" },


### PR DESCRIPTION
Bumps the dashboard pin to pick up #285 (Registry 'Imported repositories' panel + prominent composites 'Other installed pbg-* modules' heading). After merge: `gh workflow run "Publish read-only dashboard" --ref main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)