### PR TITLE
chore: bump vivarium-dashboard pin (catalog surfaces imports, #286)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -4572,7 +4572,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/3e/87/794e0b4c5dccbca30
 [[package]]
 name = "vivarium-dashboard"
 version = "0.1.0"
-source = { git = "https://github.com/vivarium-collective/vivarium-dashboard.git?branch=main#37d4b145f24dcc9663a56a2cd880c84a64a0b433" }
+source = { git = "https://github.com/vivarium-collective/vivarium-dashboard.git?branch=main#3d1eb5c66917c3f82ba79d48b49ddbf677fd6b09" }
 dependencies = [
     { name = "bigraph-loom" },
     { name = "bigraph-schema" },


### PR DESCRIPTION
Bumps dashboard pin to pick up #286 — the Modules grid now lists every workspace.yaml import (ketchup/parsimony/torch/oxidizeme), not just curated ones. After merge: `gh workflow run "Publish read-only dashboard" --ref main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)