### PR TITLE
fix(parca): strip compartment tag in balance_translation_efficiencies

### DIFF
--- a/tests/test_balance_translation_efficiencies.py
+++ b/tests/test_balance_translation_efficiencies.py
@@ -1,0 +1,36 @@
+"""Regression test for the r-protein translation-efficiency balancing bug.
+
+balanced_translation_efficiencies groups use BARE monomer IDs, but
+monomer_data['id'] carries a compartment tag ('...-MONOMER[c]'). The balancing
+must strip the tag before matching (mirroring vEcoli's monomer['id'][:-3]);
+otherwise no group matches and ribosomal-protein efficiencies are left at their
+raw per-gene values — the root cause of the vEcoli<->v2ecoli condition
+divergences.
+"""
+import numpy as np
+
+from v2ecoli.processes.parca.steps.step_02_input_adjustments import (
+    balance_translation_efficiencies,
+)
+
+
+def test_balance_strips_compartment_tag_and_averages_group():
+    # monomer_ids carry a compartment tag ([c]/[i]); group IDs are bare.
+    monomer_ids = np.array(
+        ["A-MONOMER[c]", "B-MONOMER[c]", "C-MONOMER[i]", "D-MONOMER[c]"])
+    eff = np.array([0.9, 0.7, 0.5, 2.0])
+    groups = [["A-MONOMER", "B-MONOMER", "C-MONOMER"]]  # bare ids, mixed compartments
+
+    out = balance_translation_efficiencies(monomer_ids, eff.copy(), groups)
+
+    mean = np.mean([0.9, 0.7, 0.5])
+    assert np.allclose(out[:3], mean), \
+        "grouped monomers must be balanced to their mean despite [c]/[i] tags"
+    assert out[3] == 2.0, "a non-group monomer must be untouched"
+
+
+def test_balance_is_noop_when_group_absent():
+    monomer_ids = np.array(["X-MONOMER[c]"])
+    eff = np.array([1.23])
+    out = balance_translation_efficiencies(monomer_ids, eff.copy(), [["Z-MONOMER"]])
+    assert out[0] == 1.23

--- a/v2ecoli/processes/parca/steps/step_02_input_adjustments.py
+++ b/v2ecoli/processes/parca/steps/step_02_input_adjustments.py
@@ -68,10 +68,19 @@ def balance_translation_efficiencies(monomer_ids, efficiencies, groups):
         groups: list of lists — each sub-list is a set of monomer IDs to average.
     Returns:
         the adjusted numpy array.
+
+    The group IDs are *bare* monomer IDs (no compartment), while ``monomer_ids``
+    carry a trailing compartment tag (e.g. ``'EG10866-MONOMER[c]'``). Strip the
+    3-char ``[X]`` tag before matching so the groups actually match — mirroring
+    vEcoli's ``set_balanced_translation_efficiencies`` (``monomer["id"][:-3]``).
+    Without this, no group ever matched and the (ribosomal-protein) groups were
+    left unbalanced, leaving raw per-gene efficiencies that diverged from vEcoli.
     """
+    bare_ids = [m[:-3] for m in monomer_ids]
     for group in groups:
+        group = set(group)
         idx = np.array([
-            i for i, m in enumerate(monomer_ids) if m in group
+            i for i, m in enumerate(bare_ids) if m in group
         ])
         if len(idx) > 0:
             efficiencies[idx] = np.mean(efficiencies[idx])


### PR DESCRIPTION
## Root cause

`balance_translation_efficiencies` (`v2ecoli/processes/parca/steps/step_02_input_adjustments.py`) balances ribosomal-protein operon groups by averaging their translation efficiencies. The group lists use **bare** monomer IDs (`EG10866-MONOMER`), but `monomer_data['id']` carries a **compartment tag** (`EG10866-MONOMER[c]`). The match `if m in group` compared the *tagged* ID against *bare* group IDs, so **no group ever matched** — the 4 ribosomal-protein groups were silently never balanced, leaving raw per-gene efficiencies for 27 monomers (max Δ 0.24 vs vEcoli).

vEcoli strips the tag (`monomer["id"][:-3]`); v2 didn't.

## Fix

Strip the 3-char `[X]` compartment tag before matching (one-liner), mirroring vEcoli's `set_balanced_translation_efficiencies`. Adds a regression test.

## Verified

- `translation_efficiencies_by_monomer` vs vEcoli: max|Δ| **0.24 → 1.1e-16** (exact).
- `fit_cistron_expression['basal']`: total|Δ| **0.00211 → 0.00001**.
- with_aa vEcoli↔v2ecoli growth-condition report card flipped **mismatch → within_tol** (cell_mass −1.6%, growth_rate −4.9% p=0.40; active-RNAP gap +168% → +15.9%).

This is the isolated correctness fix extracted from the comparison-harness branch (#271); it stands alone and carries its own passing regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)