### PR TITLE
Bump vivarium-dashboard pin (Composite Explorer pop-out fix)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -4572,7 +4572,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/3e/87/794e0b4c5dccbca30
 [[package]]
 name = "vivarium-dashboard"
 version = "0.1.0"
-source = { git = "https://github.com/vivarium-collective/vivarium-dashboard.git?branch=main#3d1eb5c66917c3f82ba79d48b49ddbf677fd6b09" }
+source = { git = "https://github.com/vivarium-collective/vivarium-dashboard.git?branch=main#4ddef5ca5c098945dfe263d2fbcc6fb8f41bcb2f" }
 dependencies = [
     { name = "bigraph-loom" },
     { name = "bigraph-schema" },


### PR DESCRIPTION
Bumps the git-pinned `vivarium-dashboard` (branch=main) `3d1eb5c6` -> `4ddef5ca`, which includes the snapshot-mode **Pop out** fix ([vivarium-dashboard #295](https://github.com/vivarium-collective/vivarium-dashboard/pull/295)).

The read-only dashboard SPA is built from this pinned package, so the pop-out fix only reaches gh-pages after this bump + a dashboard republish (`gh workflow run "Publish read-only dashboard" --ref main`).

Companion to #277 (dnaA-leak composite-state cleanup), which also needs that republish to go live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)