### PR TITLE
chore(references): trim public bibliography to cited, prominent refs

### DIFF
--- a/workspace/investigations/v2ecoli-pdmp/investigation.yaml
+++ b/workspace/investigations/v2ecoli-pdmp/investigation.yaml
@@ -229,11 +229,7 @@ inputs:
   - birch2014
   - stumpf2021
   - saa2017
-  - choi2023
-  - hari2024
   - talts2018sbc
-  - lyne2015
-  - toth2022
   expert_docs:
   - name: duf-final-report
     path: workspace/references/expert/duf_final_report_2026.pdf

--- a/workspace/investigations/v2ecoli-pdmp/studies/pdmp-01-metabolism-ode/study.yaml
+++ b/workspace/investigations/v2ecoli-pdmp/studies/pdmp-01-metabolism-ode/study.yaml
@@ -454,10 +454,7 @@ bibliography:
   bib_keys:
   - millard2017
   - birch2014
-  - uygun2006
   - saa2017
-  - choi2023
-  - hari2024
 report:
   confidence: design-stage
   evidence_quality: first-run-confirmed
@@ -1015,8 +1012,6 @@ literature_anchors:
   relevance: LQR / optimal-control theory underpinning the outer growth-rate controller.
 - key: villani2008
   relevance: Wasserstein/optimal-transport basis for the W2 interface-fidelity metric.
-- key: uygun2006
-  relevance: Kinetic/identifiability modelling context for the metabolic ODE.
 model_change: 'Replace the multi-objective FBA (wholecell.utils.modular_fba, glpk-linear) central-carbon
   block with the Millard 2017 kinetic ODE + an LQR outer controller, integrated via an FBA-bridge that pins
   ODE-predicted central fluxes into the remaining WCM FBA. NOT yet accepted (requires_expert_approval: true).'

--- a/workspace/investigations/v2ecoli-pdmp/studies/pdmp-02-jump-processes/study.yaml
+++ b/workspace/investigations/v2ecoli-pdmp/studies/pdmp-02-jump-processes/study.yaml
@@ -350,10 +350,7 @@ interventions: []
 runs: []
 bibliography:
   bib_keys:
-  - dibaeinia2020
-  - blom2023
   - kuritz2017
-  - metz1986
 report:
   confidence: design-stage
   evidence_quality: scaffold
@@ -810,10 +807,6 @@ biological_summary: 'Aims to represent the cell''s discrete molecular events (tr
   mass, pools) wash out per-event variance via homeostatic regulation (~0.03% cross-seed CV), while the
   direct event counts (rna_init) carry ~30× more variance, so the stochasticity lives at the count level.'
 literature_anchors:
-- key: dibaeinia2020
-  relevance: Stochastic gene-expression / network simulation context for the jump-process layer.
-- key: metz1986
-  relevance: First-passage-time / renewal-theory basis for division-time distributions.
 - key: kuritz2017
   relevance: Inference/identifiability framing for stochastic single-cell dynamics.
 model_change: 'Replace fixed-timestep discrete updates of the stochastic subprocesses with a continuous-time

--- a/workspace/investigations/v2ecoli-pdmp/studies/pdmp-03-inference/study.yaml
+++ b/workspace/investigations/v2ecoli-pdmp/studies/pdmp-03-inference/study.yaml
@@ -269,13 +269,10 @@ interventions: []
 runs: []
 bibliography:
   bib_keys:
-  - chirho2024
-  - ahman2020
   - saa2017
   - backman2023
   - talts2018sbc
   - cook2006posterior
-  - xarray2017
 report:
   confidence: design-stage
   evidence_quality: scaffold
@@ -707,8 +704,6 @@ biological_summary: 'Builds the likelihood + Bayesian-inference layer that lets 
 literature_anchors:
 - key: talts2018sbc
   relevance: Simulation-Based Calibration — the core posterior-validation method used here.
-- key: chirho2024
-  relevance: Probabilistic / causal-probabilistic inference framing for the observe-intervene machinery.
 - key: saa2017
   relevance: Bayesian inference for kinetic/metabolic model parameters.
 - key: cook2006posterior

--- a/workspace/investigations/v2ecoli-pdmp/studies/pdmp-04-compilation/study.yaml
+++ b/workspace/investigations/v2ecoli-pdmp/studies/pdmp-04-compilation/study.yaml
@@ -254,11 +254,6 @@ variants:
     parallelism: 1000
 interventions: []
 runs: []
-bibliography:
-  bib_keys:
-  - loman2023
-  - jumpprocessesjl
-  - xarray2017
 report:
   confidence: design-stage
   evidence_quality: scaffold
@@ -662,13 +657,6 @@ enforced_params:
 biological_summary: 'No biology is added: Phase 4 is a performance/runtime re-implementation of the
   already-defined PDMP whole-cell model, targeting many-trajectory / many-cell HPC throughput (≥1e3
   parallel trajectories, 1024 cells/node) needed by the inference (Phase 3) and colony (downstream) work.'
-literature_anchors:
-- key: loman2023
-  relevance: Catalyst.jl — the symbolic reaction-network compilation toolchain targeted.
-- key: jumpprocessesjl
-  relevance: JumpProcesses.jl — compiled jump-process integration backend.
-- key: xarray2017
-  relevance: XArray/zarr — the column-centric, chunked state representation for compiled output.
 model_change: 'No mechanistic change — a runtime/representation change: compile the PDMP to a fast backend
   and invert the per-step loop to a column-centric layout. Equivalence with Phase 3 must be proven.'
 implementation_requirements:

--- a/workspace/investigations/v2ecoli-pdmp/studies/pdmp-05-causal-discovery/study.yaml
+++ b/workspace/investigations/v2ecoli-pdmp/studies/pdmp-05-causal-discovery/study.yaml
@@ -394,19 +394,6 @@ variants:
     K: 500
 interventions: []
 runs: []
-bibliography:
-  bib_keys:
-  - lyne2015
-  - toth2022
-  - vowels2022
-  - peters2022
-  - bongers2022
-  - blom2023
-  - tejada2025
-  - yang2024
-  - gherman2025
-  - bertin2025
-  - dreyfuss2013
 report:
   confidence: design-stage
   evidence_quality: scaffold
@@ -773,15 +760,6 @@ enforced_params:
 biological_summary: 'Aims to use the inferable PDMP whole-cell model for functional discovery: compare
   candidate gene annotations as causal hypotheses, design maximally-informative interventions, and recover
   known regulatory/functional edges on a benchmark gene set with calibrated false-discovery control.'
-literature_anchors:
-- key: peters2022
-  relevance: Causal-inference / structure-discovery foundations.
-- key: lyne2015
-  relevance: Russian-roulette / unbiased marginal-likelihood estimation for model comparison.
-- key: vowels2022
-  relevance: Survey of causal-discovery methods framing the approach.
-- key: toth2022
-  relevance: Active / Bayesian experimental design (expected information gain) for intervention selection.
 model_change: 'No change to the cell model — Phase 5 adds an analysis layer (Bayesian model comparison +
   active causal discovery) on top of the inferable PDMP. The annotation-as-causal-model mapping is the new commitment.'
 implementation_requirements:

--- a/workspace/references/papers.bib
+++ b/workspace/references/papers.bib
@@ -180,70 +180,11 @@
 }
 
 % ─── Causal modelling & inference ────────────────────────────────────
-@misc{chirho2024,
-  title        = {{ChiRho}: Causal reasoning with {Python}},
-  author       = {{BasisResearch}},
-  year         = {2024},
-  howpublished = {Software},
-  url          = {https://github.com/BasisResearch/chirho},
-  note         = {Reference inspiration for the Vivarium observe(variable, likelihood) / intervene(variable, value) algebraic effects in Phase 3. DUF ref [7].}
-}
 
-@article{vowels2022,
-  title   = {{D'ya Like DAGs?} A Survey on Structure Learning and Causal Discovery},
-  author  = {Vowels, Matthew J. and Camgoz, Necati Cihan and Bowden, Richard},
-  journal = {ACM Computing Surveys},
-  volume  = {55},
-  number  = {4},
-  pages   = {82:1--82:36},
-  year    = {2022},
-  doi     = {10.1145/3527154},
-  note    = {DUF ref [8].}
-}
 
-@inproceedings{toth2022,
-  title     = {Active Bayesian Causal Inference},
-  author    = {Toth, Christian and Lorch, Lars and Knoll, Christian and Krause, Andreas and Pernkopf, Franz and Peharz, Robert and others},
-  booktitle = {Advances in Neural Information Processing Systems},
-  volume    = {35},
-  pages     = {16261--16275},
-  year      = {2022},
-  note      = {Active causal inference framework for Phase 5's intervention-selection loop. DUF ref [9].}
-}
 
-@incollection{peters2022,
-  title     = {Causal Models for Dynamical Systems},
-  author    = {Peters, Jonas and Bauer, Stefan and Pfister, Niklas},
-  booktitle = {Probabilistic and Causal Inference: The Works of Judea Pearl},
-  edition   = {1st},
-  publisher = {Association for Computing Machinery},
-  pages     = {671--690},
-  year      = {2022},
-  doi       = {10.1145/3501714.3501752},
-  note      = {DUF ref [10].}
-}
 
-@misc{bongers2022,
-  title  = {Causal Modeling of Dynamical Systems},
-  author = {Bongers, Stephan and Blom, Tineke and Mooij, Joris M.},
-  year   = {2022},
-  eprint = {2206.13675},
-  archivePrefix = {arXiv},
-  primaryClass  = {stat.ML},
-  note   = {DUF ref [11].}
-}
 
-@article{tejada2025,
-  title   = {Causal machine learning for single-cell genomics},
-  author  = {Tejada-Lapuerta, Alejandro and Bertin, Paul and Bauer, Stefan and Aliee, Hananeh and Bengio, Yoshua and Theis, Fabian J.},
-  journal = {Nature Genetics},
-  volume  = {57},
-  number  = {4},
-  pages   = {797--808},
-  year    = {2025},
-  doi     = {10.1038/s41588-025-02124-2},
-  note    = {DUF ref [12].}
-}
 
 % ─── WCM statistics / inference theory ───────────────────────────────
 @article{stumpf2021,
@@ -257,52 +198,10 @@
   note    = {DUF ref [13].}
 }
 
-@article{yang2024,
-  title   = {Improved enzyme functional annotation prediction using contrastive learning with structural inference},
-  author  = {Yang, Yang and Jerger, Alexander and Feng, Sihao and Wang, Ziqiang and Brasfield, Christian and others},
-  journal = {Communications Biology},
-  volume  = {7},
-  number  = {1},
-  pages   = {1690},
-  year    = {2024},
-  doi     = {10.1038/s42003-024-07359-z},
-  note    = {DUF ref [14].}
-}
 
-@article{dreyfuss2013,
-  title   = {Reconstruction and Validation of a Genome-Scale Metabolic Model for the Filamentous Fungus {Neurospora crassa} Using {FARM}},
-  author  = {Dreyfuss, Jonathan M. and Zucker, Jeremy D. and Hood, Heather M. and Ocasio, Loretta R. and Sachs, Matthew S. and Galagan, James E.},
-  journal = {PLOS Computational Biology},
-  volume  = {9},
-  number  = {7},
-  pages   = {e1003126},
-  year    = {2013},
-  doi     = {10.1371/journal.pcbi.1003126},
-  note    = {DUF ref [15].}
-}
 
-@article{choi2023,
-  title   = {Mitigating biomass composition uncertainties in flux balance analysis using ensemble representations},
-  author  = {Choi, Yoon Mi and Choi, Dong Hyun and Lee, Yi Qing and Koduru, Lokanand and Lewis, Nathan E. and Lakshmanan, Meiyappan and others},
-  journal = {Computational and Structural Biotechnology Journal},
-  volume  = {21},
-  pages   = {3736--3745},
-  year    = {2023},
-  doi     = {10.1016/j.csbj.2023.07.017},
-  note    = {DUF ref [16].}
-}
 
 % ─── Population dynamics ─────────────────────────────────────────────
-@book{metz1986,
-  title     = {The Dynamics of Physiologically Structured Populations},
-  editor    = {Metz, Johan A. J. and Diekmann, Odo},
-  series    = {Lecture Notes in Biomathematics},
-  volume    = {68},
-  publisher = {Springer},
-  address   = {Berlin, Heidelberg},
-  year      = {1986},
-  note      = {Reference for Phase 3 structured-population layer. DUF ref [17].}
-}
 
 @article{kuritz2017,
   title   = {On the relationship between cell cycle analysis with ergodic principles and age-structured cell population models},
@@ -316,130 +215,19 @@
 }
 
 % ─── Single-cell stochastic gene regulation ──────────────────────────
-@article{dibaeinia2020,
-  title   = {{SERGIO}: A Single-Cell Expression Simulator Guided by Gene Regulatory Networks},
-  author  = {Dibaeinia, Payam and Sinha, Saurabh},
-  journal = {Cell Systems},
-  volume  = {11},
-  number  = {3},
-  pages   = {252--271.e11},
-  year    = {2020},
-  doi     = {10.1016/j.cels.2020.08.003},
-  note    = {DUF ref [19].}
-}
 
-@article{blom2023,
-  title   = {Causality and independence in perfectly adapted dynamical systems},
-  author  = {Blom, Tineke and Mooij, Joris M.},
-  journal = {Journal of Causal Inference},
-  volume  = {11},
-  number  = {1},
-  year    = {2023},
-  doi     = {10.1515/jci-2021-0005},
-  note    = {DUF ref [20].}
-}
 
-@article{uygun2006,
-  title   = {{DFBA-LQR}: An Optimal Control Approach to Flux Balance Analysis},
-  author  = {Uygun, Korkut and Matthew, Howard W. T. and Huang, Yinlun},
-  journal = {Industrial \& Engineering Chemistry Research},
-  volume  = {45},
-  number  = {25},
-  pages   = {8554--8564},
-  year    = {2006},
-  doi     = {10.1021/ie060218f},
-  note    = {Reference design for the Phase 1 LQR control layer. DUF ref [21].}
-}
 
-@article{gherman2025,
-  title   = {Accelerated design of {Escherichia coli} reduced genomes using a whole-cell model and machine learning},
-  author  = {Gherman, Iuliana M. and Sharma, Kavya and Rees-Garbutt, Joshua and Pang, Wei and Abdallah, Zahraa S. and Gorochowski, Thomas E. and others},
-  journal = {Cell Systems},
-  volume  = {16},
-  number  = {10},
-  pages   = {101392},
-  year    = {2025},
-  doi     = {10.1016/j.cels.2025.101392},
-  note    = {DUF ref [22].}
-}
 
 % ─── PL / numerical infrastructure ───────────────────────────────────
-@inproceedings{ahman2020,
-  title     = {Runners in Action},
-  author    = {Ahman, Danel and Bauer, Andrej},
-  booktitle = {Programming Languages and Systems: 29th European Symposium on Programming, {ESOP} 2020},
-  year      = {2020},
-  doi       = {10.1007/978-3-030-44914-8\_2},
-  note      = {Algebraic-effect runners — the PL-theoretic framing for the Phase 3 Vivarium runtime extension. DUF ref [23].}
-}
 
-@article{xarray2017,
-  title   = {xarray: N-D labeled Arrays and Datasets in {Python}},
-  author  = {Hoyer, Stephan and Hamman, Joseph},
-  journal = {Journal of Open Research Software},
-  volume  = {5},
-  number  = {1},
-  pages   = {10},
-  year    = {2017},
-  doi     = {10.5334/jors.148},
-  note    = {The N-D labelled-array library underpinning XArrayEmitter. DUF ref [24].}
-}
 
-@misc{jumpprocessesjl,
-  title        = {{JumpProcesses.jl}: Stochastic Simulation Algorithms for Jump Processes, Jump-{ODE}s, and Jump-Diffusions},
-  author       = {{SciML community}},
-  howpublished = {Software},
-  url          = {https://github.com/SciML/JumpProcesses.jl},
-  note         = {Reference target for Phase 4 PDMP compilation. DUF ref [25].}
-}
 
-@article{loman2023,
-  title   = {{Catalyst}: Fast and flexible modeling of reaction networks},
-  author  = {Loman, Torkel E. and Ma, Yingbo and Ilin, Vasily and Gowda, Shashi and Korsbo, Niklas and Yewale, Nikhil and others},
-  journal = {PLOS Computational Biology},
-  volume  = {19},
-  number  = {10},
-  pages   = {e1011530},
-  year    = {2023},
-  doi     = {10.1371/journal.pcbi.1011530},
-  note    = {Phase 4 compilation target. DUF ref [26].}
-}
 
-@misc{bertin2025,
-  title         = {A scalable gene network model of regulatory dynamics in single cells},
-  author        = {Bertin, Paul and Viviano, Joseph D. and Tejada-Lapuerta, Alejandro and Wang, Wendy and Bauer, Stefan and Theis, Fabian J. and others},
-  year          = {2025},
-  eprint        = {2503.17078},
-  archivePrefix = {arXiv},
-  primaryClass  = {q-bio.MN},
-  note          = {DUF ref [27].}
-}
 
 % ─── Bayesian estimation theory ──────────────────────────────────────
-@article{lyne2015,
-  title   = {On {Russian Roulette} Estimates for {Bayesian} Inference with Doubly-Intractable Likelihoods},
-  author  = {Lyne, Anne-Marie and Girolami, Mark and Atchad{\'e}, Yves and Strathmann, Heiko and Simpson, Daniel},
-  journal = {Statistical Science},
-  volume  = {30},
-  number  = {4},
-  pages   = {443--467},
-  year    = {2015},
-  doi     = {10.1214/15-STS523},
-  note    = {Foundational reference for Phase 5 marginal-likelihood estimation. DUF ref [28].}
-}
 
 % ─── Ontology / model alignment ──────────────────────────────────────
-@article{hari2024,
-  title   = {{mergem}: merging, comparing, and translating genome-scale metabolic models using universal identifiers},
-  author  = {Hari, Archana and Zarrabi, Ali and Lobo, Daniel},
-  journal = {NAR Genomics and Bioinformatics},
-  volume  = {6},
-  number  = {1},
-  pages   = {lqae010},
-  year    = {2024},
-  doi     = {10.1093/nargab/lqae010},
-  note    = {DUF ref [29].}
-}
 
 % ─── Beyond the DUF report: additional anchors for v2ecoli-pdmp ──────
 @article{talts2018sbc,
@@ -465,7 +253,7 @@
 }
 
 @article{toya2010,
-  title   = {13{C}-Metabolic flux analysis for batch culture of {Escherichia coli} and its {Pyk} and {Pgi} gene knockout mutants based on mass isotopomer distribution of intracellular metabolites},
+  title   = {13{C}-metabolic flux analysis for batch culture of {Escherichia coli} and its {pyk} and {pgi} gene knockout mutants based on mass isotopomer distribution of intracellular metabolites},
   author  = {Toya, Yoshihiro and Ishii, Nobuyoshi and Nakahigashi, Kenji and Hirasawa, Takashi and Soga, Tomoyoshi and Tomita, Masaru and Shimizu, Kazuyuki},
   journal = {Biotechnology Progress},
   volume  = {26},
@@ -601,24 +389,4 @@
   note    = {Acetate reconsumption phase; cited in mbp-03.},
 }
 
-@article{Lee1996TrendsBiotechnol,
-  author  = {Lee, Sang Yup},
-  title   = {High cell-density culture of {\em Escherichia coli}},
-  journal = {Trends in Biotechnology},
-  year    = {1996},
-  volume  = {14},
-  pages   = {98--105},
-  doi     = {10.1016/0167-7799(96)80930-9},
-  note    = {Fed-batch operations reference; cited in mbp-04.},
-}
 
-@article{Korz1995JBiotechnol,
-  author  = {Korz, D. J. and Rinas, U. and Hellmuth, K. and Sanders, E. A. and Deckwer, W.-D.},
-  title   = {Simple fed-batch technique for high cell density cultivation of {\em Escherichia coli}},
-  journal = {Journal of Biotechnology},
-  year    = {1995},
-  volume  = {39},
-  pages   = {59--65},
-  doi     = {10.1016/0168-1656(94)00143-Z},
-  note    = {Exponential feed protocol; cited in mbp-04.},
-}


### PR DESCRIPTION
Trims `workspace/references/papers.bib` **57 → 34** to declutter the public read-only dashboard's Sources tab (which renders papers.bib unfiltered).

- Removes 21 marginal v2ecoli-pdmp-only refs (forward-looking "DUF ref" placeholders for unbuilt phases) + 2 true orphans (Korz1995, Lee1996).
- Keeps the 6 substantial/used pdmp refs (talts2018sbc, cook2006posterior, birch2014, backman2023, stumpf2021, saa2017) and everything cited by the curated public investigations (showcase, multiscale-bioprocess, ketchup, dnaa-replication) + claims.yaml.
- De-cites the removed keys from the pdmp study/investigation yamls (bib_keys + literature_anchors, dropping now-empty blocks) so nothing dangles.
- Fixes toya2010 title casing to match the published form.

Conflict note: main's only papers.bib change was DOI fixes on yang2024/blom2023/uygun2006 — three entries this PR deletes — so the deletion supersedes them.

Verified: validator 0 errors, no dangling refs, no orphaned bib entries, published bundle rebuilds with removed keys absent / kept keys present. Landing on main triggers `publish-dashboard.yml` (path `workspace/**`) → republishes the public dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)