### PR TITLE
fix(workflow): daughter rebuild must keep the fresh exchange_data store (FBA bound accumulated in gen >= 1)

### DIFF
--- a/tests/test_workflow_lineage.py
+++ b/tests/test_workflow_lineage.py
@@ -137,6 +137,61 @@ def test_select_carry_daughter_none_when_nothing_to_carry():
     assert select_carry_daughter({"0"}, {"0": {}}, mother_snapshot=None) is None
 
 
+def test_apply_carry_state_preserves_fresh_exchange_data():
+    """Regression: the rebuilt daughter must take ``environment.exchange_data``
+    from its FRESH build, not inherit the mother's raw substore.
+
+    Carrying the mother's raw ``exchange_data`` dict drops the store's overwrite
+    (ListenerStore) updater, so the daughter falls back to ``map[float]`` ACCUMULATE
+    semantics: the per-tick FBA bound write (ExchangeData's glucose uptake = cap)
+    then ADDS up instead of overwriting, ballooning the bound across the generation
+    and silently voiding every exchange constraint in gens >= 1. The biological
+    state still comes from the daughter; only the derived substore is kept fresh."""
+    from v2ecoli.workflow.lineage import apply_carry_state
+
+    fresh_exchange_data = {"constrained": {"GLC[p]": 20.0}, "unconstrained": []}
+    agent = {
+        "bulk": "FRESH_BULK",
+        "unique": {"u": "fresh"},
+        "environment": {"media_id": "FRESH", "exchange_data": fresh_exchange_data},
+        "boundary": {"external": {"GLC": 11.1}},
+        "listeners": {"mass": {}},
+    }
+    carry_state = {
+        "bulk": "CARRIED_BULK",
+        "unique": {"u": "carried"},
+        "environment": {
+            "media_id": "CARRIED",
+            # a mother store whose per-tick bound has already ballooned
+            "exchange_data": {"constrained": {"GLC[p]": 9999.0}, "unconstrained": ["GLC[p]"]},
+        },
+        "boundary": {"external": {"GLC": 5.0}},
+    }
+    apply_carry_state(agent, carry_state)
+
+    # biological + environmental state comes from the daughter ...
+    assert agent["bulk"] == "CARRIED_BULK"
+    assert agent["unique"] == {"u": "carried"}
+    assert agent["boundary"]["external"]["GLC"] == 5.0
+    assert agent["environment"]["media_id"] == "CARRIED"
+    # ... but exchange_data is the FRESH typed substore (identity-checked), NOT the
+    # ballooned carried one — this is the fix.
+    assert agent["environment"]["exchange_data"] is fresh_exchange_data
+    assert agent["environment"]["exchange_data"]["constrained"]["GLC[p]"] == 20.0
+
+
+def test_apply_carry_state_carries_when_no_fresh_exchange_data():
+    """If the fresh build has no exchange_data substore (e.g. a composite without
+    ExchangeData), fall back to carrying the whole environment unchanged."""
+    from v2ecoli.workflow.lineage import apply_carry_state
+
+    agent = {"environment": {"media_id": "FRESH"}, "bulk": "F"}
+    carry_state = {"environment": {"media_id": "CARRIED", "other": 1}, "bulk": "C"}
+    apply_carry_state(agent, carry_state)
+    assert agent["environment"] == {"media_id": "CARRIED", "other": 1}
+    assert agent["bulk"] == "C"
+
+
 def test_divide_flag_detected_when_agent_id_diverges_from_inner_cell():
     """Regression: gen 0 divides but gens >= 1 run to the duration cap.
 

--- a/v2ecoli/workflow/lineage.py
+++ b/v2ecoli/workflow/lineage.py
@@ -43,6 +43,42 @@ def select_carry_daughter(agents_before, agents_now, mother_snapshot):
     return None
 
 
+# Substores under ``environment`` that are RE-DERIVED every tick by their owning
+# Step and must therefore be taken from the freshly-built daughter, not inherited
+# from the mother. ``exchange_data`` (the FBA import constraints, written each tick
+# by the ExchangeData step) is realized as an overwrite store (ListenerStore) in a
+# fresh build, but carrying the mother's *raw* dict drops that updater so the
+# rebuilt daughter falls back to the ``map[float]`` default — which ACCUMULATES on
+# apply. The per-tick bound write (e.g. glucose uptake = cap) then adds up instead
+# of overwriting, ballooning the bound across the generation and silently voiding
+# every exchange constraint in generations >= 1. Keeping the fresh substore is both
+# correct (ExchangeData re-derives it from boundary.external on the first tick) and
+# the minimal fix.
+_FRESH_ENVIRONMENT_SUBSTORES = ("exchange_data",)
+
+
+def apply_carry_state(agent, carry_state):
+    """Overlay an inherited daughter's biological state onto a fresh agent doc.
+
+    Carries ``bulk``/``unique``/``environment``/``boundary`` from ``carry_state``,
+    but PRESERVES the fresh agent's derived ``environment`` substores listed in
+    :data:`_FRESH_ENVIRONMENT_SUBSTORES` so their overwrite updaters survive the
+    daughter rebuild (see the note there).
+    """
+    for key in ("bulk", "unique", "environment", "boundary"):
+        if key not in carry_state:
+            continue
+        if key == "environment":
+            fresh_env = agent.get("environment") or {}
+            carried_env = dict(carry_state["environment"] or {})
+            for sub in _FRESH_ENVIRONMENT_SUBSTORES:
+                if sub in fresh_env:
+                    carried_env[sub] = fresh_env[sub]
+            agent["environment"] = carried_env
+        else:
+            agent[key] = carry_state[key]
+
+
 # Default xarray view: scalar mass gauges (no vector coord arrays needed).
 # Override via emitter_arg["view"] (JSON list roots are accepted). Leaves the
 # composite doesn't emit are filtered out at open time (xarray is strict).
@@ -151,9 +187,7 @@ class LineageProcess(Process):
 
         if self._carry_state is not None:
             agent = doc["state"]["agents"]["0"]
-            for key in ("bulk", "unique", "environment", "boundary"):
-                if key in self._carry_state:
-                    agent[key] = self._carry_state[key]
+            apply_carry_state(agent, self._carry_state)
             agent["listeners"]["mass"] = {"dry_mass": 0.0, "cell_mass": 0.0}
             seed_mass_listener(agent, core)
 


### PR DESCRIPTION
## Summary

The multigeneration lineage carried the mother's **raw** `environment.exchange_data`
dict into each rebuilt daughter. That drops the store's overwrite (`ListenerStore`)
updater, so the daughter falls back to the bare `map[float]` schema default — which
**accumulates (adds) on apply**. The `ExchangeData` step writes the FBA import bound
every tick, so in generations ≥ 1 that per-tick write *added up* instead of
overwriting: the carbon-uptake bound ballooned across the generation, silently
voiding every exchange constraint in daughters. Generation 0 (fresh store) was
unaffected, which is why it went unnoticed.

## Evidence

Instrumenting what metabolism reads as the glucose upper bound (`map[float]`
`constrained` store), with a binding aerobic cap of 2.0 mmol/gDCW/h:

```
gen 0:  constrained_GLC = 2.0   (constant every tick)        → glucose pinned -2.0
gen 1:  tick=0    constrained_GLC = 24.0
        tick=2400 constrained_GLC = 4824.0
        tick=2800 constrained_GLC = 5624.0   → bound = b0 + 2*tick  (exact)
```

End-to-end, identical setup (basal, 1 seed, 2 generations, aerobic carbon cap = 2.0),
the only difference being this carry fix:

| | gen 0 glucose | gen 1 glucose |
|---|---|---|
| before | −2.00 (pinned) | **−4.90** (bound ballooned → unconstrained) |
| after  | −2.00 (pinned) | **−2.00** (pinned) |

## Why it mattered / didn't surface

The default aerobic carbon cap (20 mmol/gDCW/h) sits **above** the FBA's realized
glucose optimum (~5–7), so even when the daughter bound balloons the realized
glucose flux is unchanged — the defect is invisible for the stock basal config.
It only bites when an exchange constraint is actually **binding** (e.g. a
glucose-uptake titration), where every daughter generation silently ignores the
constraint. This is a latent multigeneration correctness bug: any study grading
generations ≥ 1 under a binding exchange bound is affected.

## Fix

Re-derive `environment.exchange_data` from the **fresh** build on each daughter
rather than inheriting the mother's raw substore. `ExchangeData` recomputes it from
`boundary.external` on the daughter's first tick anyway, so keeping the fresh typed
store is both correct and the minimal change. The carry is extracted into
`apply_carry_state()` with a focused regression test (asserts the daughter takes its
biological/environmental state from the inherited cell but keeps the fresh, typed
`exchange_data` substore).

## Tests

- New unit tests in `tests/test_workflow_lineage.py` (`apply_carry_state` preserves
  the fresh `exchange_data`; falls back cleanly when a composite has none).
- Regression suite green: `test_workflow_lineage`, `test_workflow_smoke`,
  `test_meta_composite_build`, `test_division_step_units`,
  `test_lineage_injected_threading`, `test_prune_to_followed_lineage`,
  `test_population_phenotype_basal`, `test_workflow_xarray`
  (46 passed, 1 skipped).

## Follow-up worth considering (not in this PR)

A deeper, schema-level guard: declare the bound store as `overwrite[map[float]]` so
it can never accumulate regardless of how state is carried/rebuilt. That touches
metabolism's input schema + store realization across composites, so it warrants its
own review — flagging it for your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
