### PR TITLE
Reproducible build/publish pipeline for the 3D model

### DIFF
--- a/v2ecoli/structural/publish/01_build_states.sh
+++ b/v2ecoli/structural/publish/01_build_states.sh
@@ -1,0 +1,30 @@
+#!/bin/zsh
+# Build the two-state 3D model (birth + pre-division) at the pinned parameters.
+# Run from the v2ecoli worktree root. See REPRODUCE.md for the full context.
+set -e
+
+# ── config ───────────────────────────────────────────────────────────────
+PARSIMONY_HOME=${PARSIMONY_HOME:-/Users/eranagmon/code/parsimony}
+PY=${PY:-/Users/eranagmon/code/v2ecoli/.venv/bin/python}
+TOP_N=${TOP_N:-400}
+REUSE_STRUCT=${REUSE_STRUCT:-/Users/eranagmon/code/v2e-pdmp-refresh/out/ecoli3d_expanded/structures}
+PARCA_CACHE=${PARCA_CACHE:-/Users/eranagmon/code/v2ecoli/out/cache}
+export PARSIMONY_HOME
+
+# ── prerequisites ────────────────────────────────────────────────────────
+[ -x "$PARSIMONY_HOME/target/release/parsimony" ] || {
+  echo "build the rust binary first: (cd $PARSIMONY_HOME && cargo build --release -p parsimony-cli)"; exit 1; }
+mkdir -p out
+[ -e out/cache ] || ln -s "$PARCA_CACHE" out/cache   # ParCa cache
+# pre-seed structures cache to avoid net fetch (uncached species still fetch)
+mkdir -p out/ecoli3d out/ecoli3d-div
+[ -e out/ecoli3d/structures ] || cp -R "$REUSE_STRUCT" out/ecoli3d/structures
+[ -e out/ecoli3d-div/structures ] || ln -s ../ecoli3d/structures out/ecoli3d-div/structures
+rm -rf .parsimony/cache   # recipe-keyed — clear so geometry rebuilds
+
+# ── build ────────────────────────────────────────────────────────────────
+echo "==== BIRTH (snapshot) top_n=$TOP_N ===="; date
+$PY -m v2ecoli.structural.build --out out/ecoli3d     --state snapshot --top-n "$TOP_N"
+echo "==== DIVISION top_n=$TOP_N ===="; date
+$PY -m v2ecoli.structural.build --out out/ecoli3d-div --state division --top-n "$TOP_N"
+echo "ALL_BUILDS_DONE"; date

--- a/v2ecoli/structural/publish/02_stage_compact.py
+++ b/v2ecoli/structural/publish/02_stage_compact.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Stage compacted array8 packs + metas for R2 publish.
+
+Reads the raw object-format packs from out/ecoli3d{,-div}/ and writes
+compacted (array8, pack-relative mesh URLs) copies to out/_publish/, renaming
+the division pack to the published `ecoli_3d_division` name. See REPRODUCE.md §6.
+
+Run with the v2ecoli venv python from the worktree root:
+    /Users/eranagmon/code/v2ecoli/.venv/bin/python v2ecoli/structural/publish/02_stage_compact.py
+"""
+import json, os, shutil, sys
+from pathlib import Path
+
+ROOT = Path(os.environ.get("BUILD_ROOT", ".")).resolve()
+STAGE = ROOT / "out/_publish"
+from v2ecoli.structural.build import compact_to_array8  # noqa: E402
+
+JOBS = [
+    (ROOT / "out/ecoli3d",     "ecoli_3d"),           # birth
+    (ROOT / "out/ecoli3d-div", "ecoli_3d_division"),  # pre-division
+]
+
+if STAGE.exists():
+    shutil.rmtree(STAGE)
+STAGE.mkdir(parents=True)
+
+for outdir, name in JOBS:
+    src_pack, src_meta = outdir / "ecoli_3d.pack.json", outdir / "ecoli_3d.meta.json"
+    dst_pack, dst_meta = STAGE / f"{name}.pack.json", STAGE / f"{name}.meta.json"
+    if not src_pack.exists():
+        sys.exit(f"MISSING raw pack: {src_pack} (run 01_build_states.sh first)")
+    shutil.copy2(src_pack, dst_pack)
+    shutil.copy2(src_meta, dst_meta)
+    raw_mb = dst_pack.stat().st_size / 1e6
+    compact_to_array8(dst_pack)
+    d = json.loads(dst_pack.read_text())
+    sample = next((l["url"] for ing in d["ingredients"]
+                   for l in ing.get("shape", {}).get("lods", [])), None)
+    print(f"{name}: {raw_mb:.0f}MB -> {dst_pack.stat().st_size/1e6:.0f}MB array8 | "
+          f"{len(d['placements'])} placements, {len(d['ingredients'])} species | url0={sample}")
+
+print(f"\nstaged at {STAGE}")

--- a/v2ecoli/structural/publish/03_assemble_local_view.py
+++ b/v2ecoli/structural/publish/03_assemble_local_view.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Assemble the LOCAL two-state viewer from the RAW (object-format) packs.
+
+The raw packs keep BUILD-relative mesh URLs (out/ecoli3d/meshes/X), so the
+local view needs nested `out/ecoli3d[-div]/meshes` symlinks in addition to the
+plain `meshes` symlink. Assembles out/ecoli3d/_view with a model dropdown, then
+print the serve command. See REPRODUCE.md §7.
+
+    /Users/eranagmon/code/v2ecoli/.venv/bin/python v2ecoli/structural/publish/03_assemble_local_view.py
+    # then:  python -m http.server 8799 --bind 127.0.0.1   (from out/ecoli3d/_view)
+"""
+import os, shutil, sys
+from pathlib import Path
+
+ROOT = Path(os.environ.get("BUILD_ROOT", ".")).resolve()
+VSRC = Path(os.environ.get("VIEWER_SRC",
+            "/Users/eranagmon/code/pbg-parsimony/pbg_parsimony/viewer"))
+VIEW = ROOT / "out/ecoli3d/_view"
+STATES = {"birth": ROOT / "out/ecoli3d", "div": ROOT / "out/ecoli3d-div"}
+MODELS = [("Newborn (birth)", "data/birth/ecoli_3d.pack.json"),
+          ("Pre-division",    "data/div/ecoli_3d.pack.json")]
+
+if VIEW.exists():
+    shutil.rmtree(VIEW)
+VIEW.mkdir(parents=True)
+for f in ("viewer.js", "obj-worker.js", "vr.js"):
+    shutil.copy2(VSRC / f, VIEW / f)
+
+html = (VSRC / "index.html").read_text()
+models_js = ",".join(f'{{"name":{n!r},"file":{p!r}}}'.replace("'", '"') for n, p in MODELS)
+anchor = '<script type="module" src="./viewer.js'
+if anchor not in html:
+    sys.exit("viewer.js script tag not found in index.html")
+html = html.replace(anchor, f'  <script>window.PARSIMONY_MODELS=[{models_js}];</script>\n  ' + anchor, 1)
+html = html.replace("./viewer.js?v=50", "./viewer.js?v=local1")
+(VIEW / "index.html").write_text(html)
+
+for key, outdir in STATES.items():
+    pack = outdir / "ecoli_3d.pack.json"
+    meta = outdir / "ecoli_3d.meta.json"
+    meshes = outdir / "meshes"
+    if not pack.exists() or not meshes.is_dir():
+        sys.exit(f"MISSING raw build at {outdir} (run 01_build_states.sh first)")
+    dd = VIEW / "data" / key
+    dd.mkdir(parents=True)
+    os.symlink(pack, dd / "ecoli_3d.pack.json")
+    os.symlink(meta, dd / "ecoli_3d.meta.json")
+    os.symlink(meshes, dd / "meshes")
+    # nested symlink so the build-relative urls (out/<dir>/meshes/X) resolve
+    nested = dd / "out" / outdir.name
+    nested.mkdir(parents=True)
+    os.symlink(meshes, nested / "meshes")
+    print(f"{key}: linked {pack.name} + meshes ({len(list(meshes.glob('*.obj')))} objs)")
+
+print(f"\n_view at {VIEW}")
+print(f"serve:  (cd {VIEW} && /Users/eranagmon/code/v2ecoli/.venv/bin/python -m http.server 8799 --bind 127.0.0.1)")
+print("open:   http://127.0.0.1:8799/")

--- a/v2ecoli/structural/publish/04_publish_r2.sh
+++ b/v2ecoli/structural/publish/04_publish_r2.sh
@@ -1,0 +1,71 @@
+#!/bin/zsh
+# Publish the compacted two-state model to Cloudflare R2 (bucket vivarium-3d).
+# Uploads meshes + packs + metas, writes models.json + the model-wired
+# index.html, all stamped with VERSION. See REPRODUCE.md §7-§8.
+# Prereq: 02_stage_compact.py has populated out/_publish/.
+set -e
+
+# ── config ───────────────────────────────────────────────────────────────
+VERSION=${VERSION:-4}                       # bump on every republish (?v=N cache-bust)
+BUILD_ROOT=${BUILD_ROOT:-$PWD}
+CREDS=${CREDS:-/Users/eranagmon/code/r2-deploy/creds.env}
+PY=${PY:-/Users/eranagmon/code/v2ecoli/.venv/bin/python}
+VIEWER_SRC=${VIEWER_SRC:-/Users/eranagmon/code/pbg-parsimony/pbg_parsimony/viewer}
+PUB_BASE="https://pub-eb913fbbdc584bd7add047c823570b13.r2.dev"
+BIRTH_NAME="Birth — 1.8 µm rod"             # edit counts in the python block below
+DIV_NAME="Pre-division — 3.06 µm rod"
+
+set -a; source "$CREDS"; set +a
+export AWS_ACCESS_KEY_ID=$R2_ACCESS_KEY_ID
+export AWS_SECRET_ACCESS_KEY=$R2_SECRET_ACCESS_KEY
+export AWS_DEFAULT_REGION=us-east-1
+export AWS_REQUEST_CHECKSUM_CALCULATION=when_required   # else R2 rejects checksums
+EP="https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
+DST="s3://vivarium-3d/ecoli-3d/viz/3d"
+STAGE="$BUILD_ROOT/out/_publish"
+
+# ── models.json + index.html (absolute URLs, ?v=VERSION, PARSIMONY_MODELS) ──
+$PY - "$VERSION" "$PUB_BASE" "$STAGE" "$VIEWER_SRC" "$BIRTH_NAME" "$DIV_NAME" <<'PY'
+import json, sys
+v, pub, stage, vsrc, birth, div = sys.argv[1:7]
+base = f"{pub}/ecoli-3d/viz/3d"
+# auto-fill counts from the staged compacted packs
+def stats(p):
+    d = json.load(open(f"{stage}/{p}"))
+    return len(d["ingredients"]), len(d["placements"])
+bsp, bpl = stats("ecoli_3d.pack.json")
+dsp, dpl = stats("ecoli_3d_division.pack.json")
+models = [
+    {"name": f"{birth} ({bsp} species · {bpl/1e6:.2f}M molecules)",
+     "file": f"{base}/ecoli_3d.pack.json?v={v}"},
+    {"name": f"{div} ({dsp} species · {dpl/1e6:.2f}M molecules)",
+     "file": f"{base}/ecoli_3d_division.pack.json?v={v}"},
+]
+open(f"{stage}/models.json", "w").write(json.dumps(models, ensure_ascii=True))
+# inject window.PARSIMONY_MODELS into a COPY of the repo viewer index.html and
+# bump the viewer.js cache-bust stamp (so the bare /viewer/index.html works)
+html = open(f"{vsrc}/index.html").read()
+inject = '  <script>window.PARSIMONY_MODELS=%s;</script>\n  ' % json.dumps(models, ensure_ascii=False)
+anchor = '<script type="module" src="./viewer.js'
+html = html.replace(anchor, inject + anchor, 1)
+import re
+html = re.sub(r'\./viewer\.js\?v=\d+', f'./viewer.js?v={v}', html)
+open(f"{stage}/index.html", "w").write(html)
+print(f"models.json + index.html staged (v={v}); birth {bsp}sp/{bpl}, div {dsp}sp/{dpl}")
+PY
+
+# ── upload ───────────────────────────────────────────────────────────────
+echo "==== sync meshes (both states → shared meshes/) ===="; date
+aws s3 sync "$BUILD_ROOT/out/ecoli3d/meshes"     "$DST/meshes" --endpoint-url "$EP" --size-only --content-type text/plain --exclude "*.bin" | tail -1
+aws s3 sync "$BUILD_ROOT/out/ecoli3d-div/meshes" "$DST/meshes" --endpoint-url "$EP" --size-only --content-type text/plain --exclude "*.bin" | tail -1
+
+echo "==== packs + metas + models.json ===="; date
+for f in ecoli_3d.pack.json ecoli_3d.meta.json ecoli_3d_division.pack.json ecoli_3d_division.meta.json models.json; do
+  aws s3 cp "$STAGE/$f" "$DST/$f" --endpoint-url "$EP" --content-type application/json
+done
+
+echo "==== viewer.js + index.html ===="; date
+aws s3 cp "$VIEWER_SRC/viewer.js" s3://vivarium-3d/viewer/viewer.js --endpoint-url "$EP" --content-type application/javascript
+aws s3 cp "$STAGE/index.html"     s3://vivarium-3d/viewer/index.html --endpoint-url "$EP" --content-type text/html
+
+echo "PUBLISHED v=$VERSION → $PUB_BASE/viewer/index.html"; date

--- a/v2ecoli/structural/publish/REPRODUCE.md
+++ b/v2ecoli/structural/publish/REPRODUCE.md
@@ -1,0 +1,136 @@
+# Reproducing the v2ecoli 3D transcription/translation model
+
+This directory pins **every component** that produced the online two-state 3D
+molecular model (birth + pre-division E. coli) hosted on Cloudflare R2, so the
+exact build can be regenerated and republished reliably.
+
+**Live viewer:** https://pub-eb913fbbdc584bd7add047c823570b13.r2.dev/viewer/index.html
+
+What the model shows (true abundance, all confined inside the cell envelope):
+the chromosome at real genomic geometry, every active RNAP at its real locus,
+nascent RNA off each RNAP, free mRNA, active ribosomes + free 30S/50S subunits,
+nascent peptide coils, enlarged replication markers (oriC/terC/replisome), and —
+for the dividing cell — a septum-confined two-nucleoid pre-division state.
+
+---
+
+## 1. Component pins (the three repos)
+
+| Repo | Path | Commit | What it provides |
+|---|---|---|---|
+| **parsimony** (Rust engine) | `~/code/parsimony` | `7d09ba2` (branch `main`) | geometry: `strand_point` (bp→3D), `generate_rna_strand`, `bubble_point`, `place_chromosome`/`place_translation`, septum-aware `CellShape::Capsule` confinement |
+| **pbg-parsimony** (Python API + viewer) | `~/code/pbg-parsimony` | `a3e54f4` (base) + `217af97` (branch `feat/viewer-crowding-default`) | `Chromosome`/`Ingredient`/`build_pack`; the WebGL viewer with lowered default crowding |
+| **v2ecoli** (state → ingredients) | `~/code/v2ecoli` | `f008f61b` (branch `main`, incl. PR #297) | `v2ecoli/structural/build.py` — state extraction, curated species, septum wiring, `compact_to_array8` |
+
+`pbg-parsimony` must be **editable-installed** into the v2ecoli venv at the
+pinned commit:
+```bash
+/Users/eranagmon/code/v2ecoli/.venv/bin/pip install -e /Users/eranagmon/code/pbg-parsimony --no-deps
+```
+The Rust binary must be built at the pinned parsimony commit:
+```bash
+cd /Users/eranagmon/code/parsimony && cargo build --release -p parsimony-cli
+# → target/release/parsimony   (PARSIMONY_HOME points here)
+```
+
+## 2. Build environment
+
+- **Interpreter:** `/Users/eranagmon/code/v2ecoli/.venv/bin/python` (has `unum`/`xarray`; bare `python` does not).
+- **`PARSIMONY_HOME=/Users/eranagmon/code/parsimony`** (so the build finds the release binary).
+- **ParCa cache:** the build needs `out/cache` (ParCa output). In a fresh
+  worktree, symlink it to a populated checkout:
+  `ln -s /Users/eranagmon/code/v2ecoli/out/cache <workdir>/out/cache`.
+- **`.parsimony/cache` is recipe-keyed, NOT binary-keyed** — `rm -rf .parsimony/cache`
+  after ANY parsimony Rust change or the geometry stage silently reuses the old result.
+- **Stale-branch / worktree hazard:** `git worktree remove` of the build worktree
+  **wipes the gitignored `out/`** (packs + meshes + `_view`). `main` is usually held
+  by another worktree, so build from a fresh `git worktree add --detach <path> <main-sha>`.
+
+## 3. Inputs
+
+- **Cell state snapshots** (committed, in `v2ecoli/structural/data/`):
+  - `v2ecoli_state.npz` — birth (`--state snapshot`)
+  - `v2ecoli_state_division.npz` — pre-division (`--state division`)
+  These carry the unique-molecule arrays (`active_RNAP`, `RNA`, `active_ribosome`,
+  `chromosome_domain`, …) the geometry is built from.
+- **Structure cache (reuse to avoid net fetch):** pre-seed `out/ecoli3d/structures`
+  from `~/code/v2e-pdmp-refresh/out/ecoli3d_expanded/structures` (1074 cached
+  PDB/CIF/AlphaFold files). Uncached species fetch from AlphaFold on demand.
+
+## 4. Build parameters (THIS version)
+
+| Param | Value | Meaning |
+|---|---|---|
+| `--top-n` | **400** | abundant AlphaFold protein monomers added beyond the curated set |
+| `top_complexes` | 150 (build_model default) | assembled CPLX blobs from the bulk |
+| `--scale` | 1.0 | true abundance (1 placement per real copy) |
+| states | `snapshot` + `division` | the two models |
+
+**`--top-n` is the species-richness lever.** It adds protein monomers *on top of*
+the model without disturbing the chromosome/RNAP/RNA/ribosome structure — the
+packer places curated + `pack_first` big assemblies + the chromosome stage FIRST,
+so added monomers fill remaining interior space. Scaling observed:
+`top_n=40` → 205/206 species (1.66M/2.86M placements); `top_n=400` → **563/564
+species (1.90M/3.25M placements)**. ~3484 eligible monomers exist (the ceiling).
+
+## 5. Pipeline (run in order, from the v2ecoli worktree root)
+
+```bash
+cd <v2ecoli-worktree>
+bash v2ecoli/structural/publish/01_build_states.sh      # build birth + division packs (top_n=400)
+python v2ecoli/structural/publish/02_stage_compact.py   # compact_to_array8 → out/_publish/
+python v2ecoli/structural/publish/03_assemble_local_view.py  # local two-state viewer (serve :8799)
+bash v2ecoli/structural/publish/04_publish_r2.sh         # upload packs+meshes+models.json+index.html to R2
+```
+
+Each script has a config block at the top (paths, `TOP_N`, R2 `VERSION`). To bump
+the published version, change `VERSION` in `04_publish_r2.sh` (it stamps `?v=N`
+on the pack URLs in both `models.json` and the injected `index.html`).
+
+## 6. Compaction (why + how)
+
+The raw packs are object-format with **build-relative** mesh URLs
+(`out/ecoli3d/meshes/X`). `compact_to_array8` (in `build.py`) rewrites them to:
+- **array8 placements** `[id, x,y,z, w,qx,qy,qz]` — ~¼ the size (385MB→88MB, 659MB→151MB)
+- **pack-relative** mesh URLs (`meshes/X`) — resolve next to the pack wherever hosted
+
+Compacted packs are what R2 serves; the raw object-format packs are used by the
+**local** viewer (which needs nested `out/ecoli3d[-div]/meshes` symlinks because
+their URLs stay build-relative).
+
+## 7. Viewer configuration
+
+- **Default crowding:** `pbg-parsimony` `viewer.js` `TARGET_DRAWN = 75000`
+  (commit `217af97`); whole-cell packs default to ~75k drawn instances. Bump the
+  `viewer.js?v=` stamp in `index.html` whenever `viewer.js` changes or browsers
+  serve the cached old JS.
+- **Bare-URL model wiring (critical):** the viewer loads models from
+  `window.PARSIMONY_MODELS` or `?models=<url>`; with NEITHER it falls back to a
+  non-existent `data/demo.pack.json` (404) and the page hangs on "loading" —
+  looks like a perf stall but is NOT. `04_publish_r2.sh` injects
+  `window.PARSIMONY_MODELS=[…]` (absolute pack URLs) into the deployed
+  `index.html`, so the bare `/viewer/index.html` shows the dropdown directly.
+
+## 8. R2 publish target
+
+- Bucket `vivarium-3d`; creds `~/code/r2-deploy/creds.env`
+  (`R2_ACCESS_KEY_ID/R2_SECRET_ACCESS_KEY/R2_ACCOUNT_ID/R2_BUCKET`).
+- S3 endpoint `https://$R2_ACCOUNT_ID.r2.cloudflarestorage.com`; public base
+  `https://pub-eb913fbbdc584bd7add047c823570b13.r2.dev`.
+- Layout: viewer assets at `s3://vivarium-3d/viewer/`; packs + metas + meshes +
+  `models.json` at `s3://vivarium-3d/ecoli-3d/viz/3d/` (birth=`ecoli_3d`,
+  division=`ecoli_3d_division`, shared `meshes/`).
+- aws needs `AWS_REQUEST_CHECKSUM_CALCULATION=when_required` or R2 rejects
+  checksums. R2 has **no 100MB file limit** (that's git/gh-pages).
+- Shared-name meshes are structure-derived → identical across the two states,
+  safe to union into one `meshes/`.
+
+## 9. Output of THIS version (verification targets)
+
+| Model | Species | Placements | Compacted pack | R2 file |
+|---|---|---|---|---|
+| Birth — 1.8 µm rod | 563 | 1.90M | 88 MB | `ecoli_3d.pack.json?v=4` |
+| Pre-division — 3.06 µm rod | 564 | 3.25M | 151 MB | `ecoli_3d_division.pack.json?v=4` |
+
+Septum check (division): neck (|x|<800) radial>3500 protrusions = **0**
+(was 22,565 before the septum fix); max neck radial 3198 (was 4997).


### PR DESCRIPTION
Pins every component of the online two-state 3D transcription/translation model in `v2ecoli/structural/publish/` (REPRODUCE.md + 4 pipeline scripts). See REPRODUCE.md for repo pins, env, params (top_n=400), compaction, viewer config, and R2 target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)