### PR TITLE
Modular config-driven comparison harness + report cards

### DIFF
--- a/comparison.5cond_1x4.json
+++ b/comparison.5cond_1x4.json
@@ -9,6 +9,8 @@
   },
   "defaults": {
     "cards": [
+      "config_diff",
+      "parca",
       "standard"
     ]
   },

--- a/comparison.5cond_1x4.json
+++ b/comparison.5cond_1x4.json
@@ -1,0 +1,13 @@
+{
+  "v2ecoli": { "repo": "https://github.com/vivarium-collective/v2ecoli", "commit": "" },
+  "vecoli":  { "repo": "https://github.com/CovertLab/vEcoli", "commit": "" },
+  "defaults": { "cards": ["standard"] },
+  "configs": [
+    { "config": "configs/cond_basal.json" },
+    { "config": "configs/cond_with_aa.json" },
+    { "config": "configs/cond_succinate.json" },
+    { "config": "configs/cond_no_oxygen.json" },
+    { "config": "configs/cond_acetate.json" }
+  ],
+  "report": { "out": "out/report_5cond_1x4", "title": "v2ecoli ↔ vEcoli — 5 conditions (1×4)" }
+}

--- a/comparison.5cond_1x4.json
+++ b/comparison.5cond_1x4.json
@@ -29,6 +29,15 @@
     },
     {
       "config": "configs/cond_acetate_1x4.json"
+    },
+    {
+      "config": "configs/cond_basal_4x4.json",
+      "name": "basal_4x4",
+      "cards": [
+        "config",
+        "parca",
+        "statistical"
+      ]
     }
   ],
   "report": {

--- a/comparison.5cond_1x4.json
+++ b/comparison.5cond_1x4.json
@@ -9,7 +9,7 @@
   },
   "defaults": {
     "cards": [
-      "config_diff",
+      "config",
       "parca",
       "standard"
     ]

--- a/comparison.5cond_1x4.json
+++ b/comparison.5cond_1x4.json
@@ -1,13 +1,36 @@
 {
-  "v2ecoli": { "repo": "https://github.com/vivarium-collective/v2ecoli", "commit": "" },
-  "vecoli":  { "repo": "https://github.com/CovertLab/vEcoli", "commit": "" },
-  "defaults": { "cards": ["standard"] },
+  "v2ecoli": {
+    "repo": "https://github.com/vivarium-collective/v2ecoli",
+    "commit": ""
+  },
+  "vecoli": {
+    "repo": "https://github.com/CovertLab/vEcoli",
+    "commit": ""
+  },
+  "defaults": {
+    "cards": [
+      "standard"
+    ]
+  },
   "configs": [
-    { "config": "configs/cond_basal.json" },
-    { "config": "configs/cond_with_aa.json" },
-    { "config": "configs/cond_succinate.json" },
-    { "config": "configs/cond_no_oxygen.json" },
-    { "config": "configs/cond_acetate.json" }
+    {
+      "config": "configs/cond_basal_1x4.json"
+    },
+    {
+      "config": "configs/cond_with_aa_1x4.json"
+    },
+    {
+      "config": "configs/cond_succinate_1x4.json"
+    },
+    {
+      "config": "configs/cond_no_oxygen_1x4.json"
+    },
+    {
+      "config": "configs/cond_acetate_1x4.json"
+    }
   ],
-  "report": { "out": "out/report_5cond_1x4", "title": "v2ecoli ↔ vEcoli — 5 conditions (1×4)" }
+  "report": {
+    "out": "out/report_5cond_1x4",
+    "title": "v2ecoli \u2194 vEcoli \u2014 5 conditions (1\u00d74)"
+  }
 }

--- a/comparison.baseline_4x4_statistical.json
+++ b/comparison.baseline_4x4_statistical.json
@@ -1,0 +1,9 @@
+{
+  "v2ecoli": { "repo": "https://github.com/vivarium-collective/v2ecoli", "commit": "" },
+  "vecoli":  { "repo": "https://github.com/CovertLab/vEcoli", "commit": "" },
+  "defaults": { "cards": ["standard"] },
+  "configs": [
+    { "config": "configs/cond_basal_4x4.json", "cards": ["statistical"] }
+  ],
+  "report": { "out": "out/report_baseline_4x4", "title": "v2ecoli ↔ vEcoli — baseline (4×4) statistical" }
+}

--- a/comparison_spec.json
+++ b/comparison_spec.json
@@ -9,6 +9,8 @@
   },
   "defaults": {
     "cards": [
+      "config_diff",
+      "parca",
       "standard"
     ]
   },

--- a/comparison_spec.json
+++ b/comparison_spec.json
@@ -9,7 +9,7 @@
   },
   "defaults": {
     "cards": [
-      "config_diff",
+      "config",
       "parca",
       "standard"
     ]

--- a/comparison_spec.json
+++ b/comparison_spec.json
@@ -1,50 +1,36 @@
 {
   "v2ecoli": {
     "repo": "https://github.com/vivarium-collective/v2ecoli",
-    "commit": "c19ae069ba1549e06e98332de8b24dd868e809a6",
-    "branch": "feat/comparison-harness-config"
+    "commit": ""
   },
   "vecoli": {
     "repo": "https://github.com/CovertLab/vEcoli",
-    "commit": "",
-    "branch": "master"
+    "commit": ""
   },
-  "vecoli_engine": "upstream-wrapper",
-  "from_vecoli_config": "configs/default.json",
   "defaults": {
-    "seeds": 4,
-    "gens": 2
+    "cards": [
+      "standard"
+    ]
   },
-  "conditions": [
+  "configs": [
     {
-      "name": "basal",
-      "config": "cond_basal.json",
-      "seeds": 4,
-      "gens": 2
+      "config": "configs/cond_basal_1x4.json"
     },
     {
-      "name": "with_aa",
-      "config": "cond_with_aa.json",
-      "seeds": 4,
-      "gens": 2
+      "config": "configs/cond_with_aa_1x4.json"
     },
     {
-      "name": "succinate",
-      "config": "cond_succinate.json",
-      "seeds": 4,
-      "gens": 2
+      "config": "configs/cond_succinate_1x4.json"
     },
     {
-      "name": "no_oxygen",
-      "config": "cond_no_oxygen.json",
-      "seeds": 4,
-      "gens": 2
+      "config": "configs/cond_no_oxygen_1x4.json"
     },
     {
-      "name": "acetate",
-      "config": "cond_acetate.json",
-      "seeds": 4,
-      "gens": 2
+      "config": "configs/cond_acetate_1x4.json"
     }
-  ]
+  ],
+  "report": {
+    "out": "out/report",
+    "title": "v2ecoli \u2194 vEcoli \u2014 5 conditions"
+  }
 }

--- a/configs/cond_acetate_1x4.json
+++ b/configs/cond_acetate_1x4.json
@@ -1,0 +1,7 @@
+{
+  "inherit_from": [
+    "cond_acetate.json"
+  ],
+  "n_init_sims": 1,
+  "generations": 4
+}

--- a/configs/cond_basal_1x4.json
+++ b/configs/cond_basal_1x4.json
@@ -1,0 +1,7 @@
+{
+  "inherit_from": [
+    "cond_basal.json"
+  ],
+  "n_init_sims": 1,
+  "generations": 4
+}

--- a/configs/cond_basal_4x4.json
+++ b/configs/cond_basal_4x4.json
@@ -1,0 +1,5 @@
+{
+  "inherit_from": ["cond_basal.json"],
+  "n_init_sims": 4,
+  "generations": 4
+}

--- a/configs/cond_no_oxygen_1x4.json
+++ b/configs/cond_no_oxygen_1x4.json
@@ -1,0 +1,7 @@
+{
+  "inherit_from": [
+    "cond_no_oxygen.json"
+  ],
+  "n_init_sims": 1,
+  "generations": 4
+}

--- a/configs/cond_succinate_1x4.json
+++ b/configs/cond_succinate_1x4.json
@@ -1,0 +1,7 @@
+{
+  "inherit_from": [
+    "cond_succinate.json"
+  ],
+  "n_init_sims": 1,
+  "generations": 4
+}

--- a/configs/cond_with_aa_1x4.json
+++ b/configs/cond_with_aa_1x4.json
@@ -1,0 +1,7 @@
+{
+  "inherit_from": [
+    "cond_with_aa.json"
+  ],
+  "n_init_sims": 1,
+  "generations": 4
+}

--- a/docs/superpowers/plans/2026-06-27-comparison-harness-modular-cards.md
+++ b/docs/superpowers/plans/2026-06-27-comparison-harness-modular-cards.md
@@ -1,0 +1,663 @@
+# Modular Config-Driven Comparison Harness — Plan A (schema + cards + report)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the seeds/gens-duplicating `comparison_spec.json` with a slim manifest that lists vEcoli configs and assigns modular, registry-based report cards per config, and make the report assemble those assigned cards (overview + per-config sections).
+
+**Architecture:** A new `configs` mode in the stdlib parser reads run shape (seeds/gens) from each referenced vEcoli config instead of the manifest. A new `scripts/_compare/report_cards/` package holds one module per card plus a name→callable registry; cards are thin wrappers over the EXISTING section functions (`runs_section`/`eval_section`/`parca_section`) and Chris Long's on-main card library (`report_card_section.build_report_card` → `v2ecoli.library.report_card`). `comparison_report_card.py` is rewired to render, per config, exactly the cards the manifest assigns. Single-variant only (variant=0); full variant execution is Plan B.
+
+**Tech Stack:** Python 3.12, stdlib `json`/`argparse`, pytest. No new dependencies.
+
+## Global Constraints
+
+- stdlib-only in `scripts/_read_spec.py` (called from bash without a venv) — verbatim from the spec.
+- Report cards REUSE the on-main library (`v2ecoli/library/report_card.py`, `card_criteria.py`, `card_plots.py`, `card_vectors.py`); no new grading or plot code.
+- `Section = {"title": str, "kind": "content", "html": str, "anchor": str, "verdict": str | None}` — the existing section dict shape; the assembler stays structurally unchanged.
+- Rendered output keeps the `docs/report_cards/` convention.
+- seeds = a config's `n_init_sims`; gens = a config's `generations` — read from the vEcoli config, never the manifest.
+- Run tests with `/Users/eranagmon/code/v2e-cmp-harness/.venv/bin/python -m pytest` (set up the venv first if absent: `cd /Users/eranagmon/code/v2e-cmp-harness && uv sync --no-install-package vivarium-dashboard`).
+
+---
+
+## File Structure
+
+- Create `scripts/_compare/report_cards/__init__.py` — registry (`REGISTRY`, `@report_card`, `get`, `all_names`), `CardContext` dataclass, `Section` TypedDict, imports the card modules to register them.
+- Create `scripts/_compare/report_cards/standard.py` — `standard_card(ctx)` (runs + eval).
+- Create `scripts/_compare/report_cards/statistical.py` — `statistical_card(ctx)` (Chris's graded card).
+- Create `scripts/_compare/report_cards/parca.py` — `parca_card(ctx)`.
+- Create `scripts/_compare/report_cards/config_diff.py` — `config_diff_card(ctx)`.
+- Modify `scripts/_read_spec.py` — add `config_rows()` + a `configs` mode.
+- Modify `scripts/comparison_report_card.py` — manifest-driven per-config card assembly.
+- Modify `scripts/_compare/config_adapter.py` — add `config_run_shape()` helper.
+- Create `comparison.5cond_1x4.json`, `comparison.baseline_4x4_statistical.json`, `configs/cond_basal_4x4.json`.
+- Modify `tests/test_read_spec.py`; create `tests/test_report_cards.py`.
+
+---
+
+## Task 1: Read run shape (seeds/gens) from a vEcoli config
+
+**Files:**
+- Modify: `scripts/_compare/config_adapter.py` (add `config_run_shape`)
+- Test: `tests/test_config_translation.py` (extend)
+
+**Interfaces:**
+- Consumes: existing `resolve_vecoli_config_local(config_path, fork_dir) -> dict`.
+- Produces: `config_run_shape(config_path: str, fork_dir: str) -> tuple[int, int]` returning `(seeds, gens)` = `(n_init_sims, generations)`, defaulting `n_init_sims` to 1 and `generations` to 1 when absent/None.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_config_translation.py (append)
+from scripts._compare.config_adapter import config_run_shape  # noqa: E402
+
+def test_config_run_shape_reads_n_init_sims_and_generations(tmp_path):
+    cfg = tmp_path / "configs"; cfg.mkdir()
+    (cfg / "c.json").write_text('{"n_init_sims": 4, "generations": 4}')
+    assert config_run_shape("configs/c.json", str(tmp_path)) == (4, 4)
+
+def test_config_run_shape_defaults_when_missing(tmp_path):
+    cfg = tmp_path / "configs"; cfg.mkdir()
+    (cfg / "c.json").write_text('{"condition": "basal", "generations": null}')
+    assert config_run_shape("configs/c.json", str(tmp_path)) == (1, 1)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/test_config_translation.py -k run_shape -q`
+Expected: FAIL with `ImportError: cannot import name 'config_run_shape'`.
+
+- [ ] **Step 3: Implement**
+
+```python
+# scripts/_compare/config_adapter.py (append)
+def config_run_shape(config_path: str, fork_dir: str) -> tuple[int, int]:
+    """Return (seeds, gens) = (n_init_sims, generations) from a vEcoli config.
+
+    seeds/gens are the config's run shape — the single source of truth. Missing
+    or null values default to 1 (one seed, one generation).
+    """
+    cfg = resolve_vecoli_config_local(config_path, fork_dir)
+    seeds = cfg.get("n_init_sims")
+    gens = cfg.get("generations")
+    return int(seeds) if seeds else 1, int(gens) if gens else 1
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/python -m pytest tests/test_config_translation.py -k run_shape -q`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/_compare/config_adapter.py tests/test_config_translation.py
+git commit -m "feat(harness): read run shape (seeds/gens) from a vEcoli config"
+```
+
+---
+
+## Task 2: `configs` mode in `_read_spec.py`
+
+**Files:**
+- Modify: `scripts/_read_spec.py`
+- Test: `tests/test_read_spec.py`
+
+**Interfaces:**
+- Consumes: nothing new (stdlib only — does NOT import config_adapter; the seeds/gens resolution happens in the runner, which has the fork dir).
+- Produces:
+  - `config_rows(spec) -> Iterator[tuple[str, str]]` yielding `(config_path, cards_csv)` per `spec["configs"]` entry, where `cards_csv` is the entry's `cards` joined by `,`, falling back to `spec["defaults"]["cards"]`, else `"standard"`.
+  - CLI `configs` mode printing `config_path<TAB>cards_csv` per row.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_read_spec.py (append)
+import scripts._read_spec as rs  # noqa: E402
+
+SPEC = {
+    "v2ecoli": {"repo": "r1", "commit": "c1"},
+    "vecoli": {"repo": "r2", "commit": "c2"},
+    "defaults": {"cards": ["standard"]},
+    "configs": [
+        {"config": "configs/cond_basal.json", "cards": ["standard", "statistical"]},
+        {"config": "configs/cond_with_aa.json"},
+    ],
+}
+
+def test_config_rows_uses_entry_cards_then_defaults():
+    rows = list(rs.config_rows(SPEC))
+    assert rows == [
+        ("configs/cond_basal.json", "standard,statistical"),
+        ("configs/cond_with_aa.json", "standard"),
+    ]
+
+def test_config_rows_defaults_to_standard_when_no_defaults():
+    spec = {"configs": [{"config": "c.json"}]}
+    assert list(rs.config_rows(spec)) == [("c.json", "standard")]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/test_read_spec.py -k config_rows -q`
+Expected: FAIL with `AttributeError: module 'scripts._read_spec' has no attribute 'config_rows'`.
+
+- [ ] **Step 3: Implement**
+
+```python
+# scripts/_read_spec.py — add near condition_rows()
+def config_rows(spec):
+    """Yield (config_path, cards_csv) per spec['configs'] entry.
+
+    cards: entry 'cards' -> spec defaults.cards -> ['standard'].
+    seeds/gens/variants are NOT here — the runner reads them from each config.
+    """
+    default_cards = (spec.get("defaults", {}) or {}).get("cards") or ["standard"]
+    for entry in spec.get("configs", []):
+        config = entry["config"]
+        cards = entry.get("cards") or default_cards
+        yield config, ",".join(cards)
+```
+
+```python
+# scripts/_read_spec.py — in main(), add an elif branch before the final else
+    elif mode == "configs":
+        for config, cards in config_rows(spec):
+            print("\t".join([config, cards]))
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/python -m pytest tests/test_read_spec.py -k config_rows -q`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/_read_spec.py tests/test_read_spec.py
+git commit -m "feat(harness): configs mode in _read_spec (config -> cards)"
+```
+
+---
+
+## Task 3: Report-card registry + `CardContext`
+
+**Files:**
+- Create: `scripts/_compare/report_cards/__init__.py`
+- Test: `tests/test_report_cards.py`
+
+**Interfaces:**
+- Produces:
+  - `CardContext` dataclass with fields: `config_name: str`, `variant: int`, `v2_dir: str`, `ve_dir: str`, `seeds: int`, `gens: int`, `per_obs: dict`, `plot_trajs: dict`, `v2_bounds: dict`, `config: dict`.
+  - `Section = dict` (keys: `title`, `kind`, `html`, `anchor`, optional `verdict`).
+  - `report_card(name)` decorator registering `name -> fn`.
+  - `get(name) -> Callable[[CardContext], list[Section]]` raising `KeyError` on unknown name.
+  - `all_names() -> list[str]`.
+  - `render(name, ctx) -> list[Section]` — calls the card, normalizes a single Section to `[Section]`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_report_cards.py
+import pytest
+from scripts._compare import report_cards as rc
+
+
+def test_register_and_get():
+    @rc.report_card("dummy_card_xyz")
+    def _c(ctx):
+        return {"title": "T", "kind": "content", "html": "<p>x</p>", "anchor": "a"}
+    assert "dummy_card_xyz" in rc.all_names()
+    fn = rc.get("dummy_card_xyz")
+    out = rc.render("dummy_card_xyz", _ctx())
+    assert out[0]["title"] == "T" and out[0]["html"]
+
+
+def test_get_unknown_raises():
+    with pytest.raises(KeyError):
+        rc.get("does_not_exist")
+
+
+def _ctx():
+    return rc.CardContext(config_name="basal", variant=0, v2_dir="", ve_dir="",
+                          seeds=1, gens=1, per_obs={}, plot_trajs={}, v2_bounds={},
+                          config={})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/test_report_cards.py -k register -q`
+Expected: FAIL with `ModuleNotFoundError: No module named 'scripts._compare.report_cards'`.
+
+- [ ] **Step 3: Implement**
+
+```python
+# scripts/_compare/report_cards/__init__.py
+"""Registry of modular comparison report cards.
+
+A card is Callable[[CardContext], Section | list[Section]]. Register with the
+@report_card("name") decorator; assign by name in the comparison manifest.
+Cards are thin wrappers over the existing section functions and Chris Long's
+on-main card library (v2ecoli.library.report_card).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+Section = dict  # {title, kind, html, anchor, verdict?}
+
+
+@dataclass
+class CardContext:
+    config_name: str
+    variant: int
+    v2_dir: str
+    ve_dir: str
+    seeds: int
+    gens: int
+    per_obs: dict = field(default_factory=dict)
+    plot_trajs: dict = field(default_factory=dict)
+    v2_bounds: dict = field(default_factory=dict)
+    config: dict = field(default_factory=dict)
+
+
+Card = Callable[[CardContext], "Section | list[Section]"]
+REGISTRY: dict[str, Card] = {}
+
+
+def report_card(name: str) -> Callable[[Card], Card]:
+    def deco(fn: Card) -> Card:
+        REGISTRY[name] = fn
+        return fn
+    return deco
+
+
+def get(name: str) -> Card:
+    if name not in REGISTRY:
+        raise KeyError(f"unknown report card {name!r}; known: {sorted(REGISTRY)}")
+    return REGISTRY[name]
+
+
+def all_names() -> list[str]:
+    return sorted(REGISTRY)
+
+
+def render(name: str, ctx: CardContext) -> list[Section]:
+    out = get(name)(ctx)
+    return out if isinstance(out, list) else [out]
+
+
+# Register the built-in cards by importing their modules (each calls
+# @report_card at import). Imported at the bottom to avoid circular imports.
+from scripts._compare.report_cards import standard, statistical, parca, config_diff  # noqa: E402,F401
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+(After Task 4-5 create the imported modules, this import resolves. To unblock this task in isolation, temporarily comment the bottom import, run the test, then restore it — or implement Tasks 4-5 first.) Run: `.venv/bin/python -m pytest tests/test_report_cards.py -k "register or unknown" -q`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/_compare/report_cards/__init__.py tests/test_report_cards.py
+git commit -m "feat(cards): report-card registry + CardContext"
+```
+
+---
+
+## Task 4: `standard` and `statistical` cards
+
+**Files:**
+- Create: `scripts/_compare/report_cards/standard.py`, `scripts/_compare/report_cards/statistical.py`
+- Test: `tests/test_report_cards.py` (extend)
+
+**Interfaces:**
+- Consumes: `report_card`, `CardContext`, `Section` from `scripts._compare.report_cards`; the existing `comparison_report_card.runs_section(cond, per_obs, plot_trajs, v2_bounds)` and `comparison_report_card.eval_section(cond, per_obs)` (both return a Section dict); `scripts._compare.report_card_section.build_report_card(left_by_cell, right_by_cell, *, model_ref, ...) -> (vjson, html)`.
+- Produces: `standard_card(ctx) -> list[Section]`, `statistical_card(ctx) -> Section`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_report_cards.py (append)
+def test_builtin_cards_registered():
+    for name in ("standard", "statistical", "parca", "config_diff"):
+        assert name in rc.all_names()
+
+def test_statistical_card_returns_graded_section():
+    ctx = rc.CardContext(config_name="basal", variant=0, v2_dir="", ve_dir="",
+                         seeds=2, gens=1,
+                         per_obs={"cell_mass": {"ve_cells": [1.0, 1.1],
+                                                "v2_cells": [1.0, 1.05]},
+                                  "growth_rate": {"ve_cells": [2e-4, 2.1e-4],
+                                                  "v2_cells": [2e-4, 2.05e-4]}},
+                         plot_trajs={}, v2_bounds={}, config={})
+    secs = rc.render("statistical", ctx)
+    assert secs[0]["html"] and secs[0]["verdict"] in (
+        "within_tol", "drift", "mismatch", "ungraded")
+```
+
+NOTE: the exact `per_obs` sub-keys (`ve_cells`/`v2_cells`) must match what `comparison_report_card.build()` stores per observable. Before writing the card, open `scripts/comparison_report_card.py`, find where `per_obs[key]` is populated, and use those real keys in both the card and this test.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/test_report_cards.py -k "builtin or statistical_card" -q`
+Expected: FAIL (cards not yet defined / not registered).
+
+- [ ] **Step 3: Implement**
+
+```python
+# scripts/_compare/report_cards/standard.py
+"""`standard` card — matched-time run trajectories + evaluation (the lighter
+card). Thin wrapper over comparison_report_card.runs_section / eval_section."""
+from __future__ import annotations
+
+from scripts._compare.report_cards import report_card, CardContext, Section
+
+
+@report_card("standard")
+def standard_card(ctx: CardContext) -> list[Section]:
+    # Imported lazily: comparison_report_card imports heavy deps; importing it at
+    # module load would slow registry import and risk a cycle.
+    from scripts.comparison_report_card import runs_section, eval_section
+    return [
+        runs_section(ctx.config_name, ctx.per_obs, ctx.plot_trajs, ctx.v2_bounds),
+        eval_section(ctx.config_name, ctx.per_obs),
+    ]
+```
+
+```python
+# scripts/_compare/report_cards/statistical.py
+"""`statistical` card — Chris Long's graded equivalence card (violin/strip +
+<details> dropdown viz bars + within_tol/drift/mismatch pills). Thin wrapper
+over report_card_section.build_report_card -> v2ecoli.library.report_card."""
+from __future__ import annotations
+
+from scripts._compare.report_cards import report_card, CardContext, Section
+from scripts._compare.report_card_section import build_report_card
+
+
+@report_card("statistical")
+def statistical_card(ctx: CardContext) -> Section:
+    # Build per-cell {observable: [scalar per cell]} for vEcoli (reference) and
+    # v2ecoli (measured) from ctx.per_obs. The exact per_obs sub-keys come from
+    # comparison_report_card.build(); map them here.
+    left = {k: list(v.get("ve_cells", [])) for k, v in ctx.per_obs.items()}
+    right = {k: list(v.get("v2_cells", [])) for k, v in ctx.per_obs.items()}
+    vjson, html = build_report_card(
+        left, right, model_ref=f"v2ecoli @ {ctx.config_name} variant {ctx.variant}")
+    return {"title": f"{ctx.config_name} — statistical equivalence",
+            "kind": "content",
+            "anchor": f"{ctx.config_name}-statistical",
+            "html": html,
+            "verdict": vjson.get("overall")}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/python -m pytest tests/test_report_cards.py -k "builtin or statistical_card" -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/_compare/report_cards/standard.py scripts/_compare/report_cards/statistical.py tests/test_report_cards.py
+git commit -m "feat(cards): standard + statistical (Chris's graded) cards"
+```
+
+---
+
+## Task 5: `parca` and `config_diff` cards
+
+**Files:**
+- Create: `scripts/_compare/report_cards/parca.py`, `scripts/_compare/report_cards/config_diff.py`
+- Test: covered by `test_builtin_cards_registered` (Task 4).
+
+**Interfaces:**
+- Consumes: `comparison_report_card.parca_section(cond_data)` and `comparison_report_card.config_sections_for(cond, v2_dir, ve_dir)` (returns list[Section]).
+- Produces: `parca_card(ctx) -> Section`, `config_diff_card(ctx) -> list[Section]`.
+
+- [ ] **Step 1: Implement (registration verified by Task 4's `test_builtin_cards_registered`)**
+
+```python
+# scripts/_compare/report_cards/parca.py
+"""`parca` card — ParCa / initial-state match for one config."""
+from __future__ import annotations
+
+from scripts._compare.report_cards import report_card, CardContext, Section
+
+
+@report_card("parca")
+def parca_card(ctx: CardContext) -> Section:
+    from scripts.comparison_report_card import parca_section
+    # parca_section takes the cond_data map; build a single-cond slice.
+    sec = parca_section({ctx.config_name: (ctx.per_obs, ctx.plot_trajs, ctx.v2_bounds)})
+    sec["anchor"] = f"{ctx.config_name}-parca"
+    return sec
+```
+
+```python
+# scripts/_compare/report_cards/config_diff.py
+"""`config_diff` card — vEcoli vs v2ecoli config comparison for one config."""
+from __future__ import annotations
+
+from scripts._compare.report_cards import report_card, CardContext, Section
+
+
+@report_card("config_diff")
+def config_diff_card(ctx: CardContext) -> list[Section]:
+    from scripts.comparison_report_card import config_sections_for
+    return config_sections_for(ctx.config_name, ctx.v2_dir, ctx.ve_dir)
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `.venv/bin/python -m pytest tests/test_report_cards.py -k builtin -q`
+Expected: PASS (all four names registered).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/_compare/report_cards/parca.py scripts/_compare/report_cards/config_diff.py
+git commit -m "feat(cards): parca + config_diff cards"
+```
+
+---
+
+## Task 6: Manifest-driven report assembly
+
+**Files:**
+- Modify: `scripts/comparison_report_card.py` (`main()`, ~704-830)
+- Test: `tests/test_report_cards.py` (assemble-from-manifest unit)
+
+**Interfaces:**
+- Consumes: `report_cards.render(name, ctx)`, `report_cards.CardContext`, the existing `build(conds, ...) -> cond_data`, `overview_section(cond_data)`.
+- Produces: a `--manifest <path>` arg; when given, assembly = `[overview] + for each config (in manifest order): for each assigned card: render(card, ctx).sections`. The legacy `--only`/`--local-pbg-dir` path is preserved for back-compat.
+
+- [ ] **Step 1: Write the failing test (assembly logic, no full render)**
+
+```python
+# tests/test_report_cards.py (append)
+def test_assemble_sections_mirrors_manifest(monkeypatch):
+    from scripts import comparison_report_card as crc
+    # one config, cards ["parca","standard"] -> overview + parca + (runs+eval)
+    cond_data = {"basal": ({"cell_mass": {"ve_cells": [1.0], "v2_cells": [1.0]}}, {}, {})}
+    manifest = {"configs": [{"config": "configs/cond_basal.json",
+                             "cards": ["parca", "standard"]}]}
+    secs = crc.assemble_from_manifest(
+        manifest, cond_data,
+        conds={"basal": ("v2dir", "vedir")},
+        config_names={"configs/cond_basal.json": "basal"})
+    titles = [s["title"] for s in secs]
+    assert titles[0].startswith("Overview")
+    assert any("ParCa" in t or "parca" in t.lower() for t in titles)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/test_report_cards.py -k assemble -q`
+Expected: FAIL with `AttributeError: ... has no attribute 'assemble_from_manifest'`.
+
+- [ ] **Step 3: Implement `assemble_from_manifest` + wire `--manifest`**
+
+```python
+# scripts/comparison_report_card.py — new function
+def assemble_from_manifest(manifest, cond_data, conds, config_names):
+    """Overview + per-config assigned-card sections, mirroring the manifest.
+
+    config_names maps a manifest config path -> the condition key used in
+    cond_data/conds (the runner names stores by condition).
+    """
+    from scripts._compare import report_cards as rc
+    default_cards = (manifest.get("defaults", {}) or {}).get("cards") or ["standard"]
+    overview = overview_section(cond_data); overview["nav_group"] = "Overall"
+    sections = [overview]
+    for entry in manifest.get("configs", []):
+        name = config_names[entry["config"]]
+        if name not in cond_data:
+            continue
+        per_obs, plot_trajs, v2_bounds = cond_data[name]
+        v2_dir, ve_dir = conds.get(name, ("", ""))
+        ctx = rc.CardContext(config_name=name, variant=0, v2_dir=v2_dir,
+                             ve_dir=ve_dir, seeds=0, gens=0, per_obs=per_obs,
+                             plot_trajs=plot_trajs, v2_bounds=v2_bounds, config={})
+        for card in (entry.get("cards") or default_cards):
+            for sec in rc.render(card, ctx):
+                sec["nav_group"] = name
+                sections.append(sec)
+    return sections
+```
+
+Then in `main()`: add `p.add_argument("--manifest", default=None)`. When `args.manifest` is set, load it, build `conds`/`cond_data` exactly as the `--local-pbg-dir` branch does (per-config dirs under `args.out`), derive `config_names` by reading each config's `condition` field (via `config_adapter.resolve_vecoli_config_local`), and set `sections = assemble_from_manifest(manifest, cond_data, conds, config_names)` instead of the fixed per-condition loop. Leave the existing branches intact for back-compat.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/python -m pytest tests/test_report_cards.py -k assemble -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/comparison_report_card.py tests/test_report_cards.py
+git commit -m "feat(report): manifest-driven per-config card assembly"
+```
+
+---
+
+## Task 7: Example manifests + a 4x4 baseline config
+
+**Files:**
+- Create: `comparison.5cond_1x4.json`, `comparison.baseline_4x4_statistical.json`, `configs/cond_basal_4x4.json`
+- Test: `tests/test_read_spec.py` (parse the example manifests)
+
+**Interfaces:**
+- Consumes: `config_rows` (Task 2).
+- Produces: two tracked manifests + a 4x4 baseline config that inherits the basal condition config.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_read_spec.py (append)
+import json, pathlib  # noqa: E402
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+def test_example_manifest_5cond_parses():
+    spec = json.loads((ROOT / "comparison.5cond_1x4.json").read_text())
+    rows = list(rs.config_rows(spec))
+    assert len(rows) == 5
+    assert all(cards == "standard" for _, cards in rows)
+
+def test_example_manifest_baseline_statistical_parses():
+    spec = json.loads((ROOT / "comparison.baseline_4x4_statistical.json").read_text())
+    rows = list(rs.config_rows(spec))
+    assert rows == [("configs/cond_basal_4x4.json", "statistical")]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/python -m pytest tests/test_read_spec.py -k example_manifest -q`
+Expected: FAIL with `FileNotFoundError`.
+
+- [ ] **Step 3: Create the files**
+
+```json
+// comparison.5cond_1x4.json
+{
+  "v2ecoli": { "repo": "https://github.com/vivarium-collective/v2ecoli", "commit": "" },
+  "vecoli":  { "repo": "https://github.com/CovertLab/vEcoli", "commit": "" },
+  "defaults": { "cards": ["standard"] },
+  "configs": [
+    { "config": "configs/cond_basal.json" },
+    { "config": "configs/cond_with_aa.json" },
+    { "config": "configs/cond_succinate.json" },
+    { "config": "configs/cond_no_oxygen.json" },
+    { "config": "configs/cond_acetate.json" }
+  ],
+  "report": { "out": "out/report_5cond_1x4", "title": "v2ecoli ↔ vEcoli — 5 conditions (1×4)" }
+}
+```
+
+```json
+// comparison.baseline_4x4_statistical.json
+{
+  "v2ecoli": { "repo": "https://github.com/vivarium-collective/v2ecoli", "commit": "" },
+  "vecoli":  { "repo": "https://github.com/CovertLab/vEcoli", "commit": "" },
+  "defaults": { "cards": ["standard"] },
+  "configs": [
+    { "config": "configs/cond_basal_4x4.json", "cards": ["statistical"] }
+  ],
+  "report": { "out": "out/report_baseline_4x4", "title": "v2ecoli ↔ vEcoli — baseline (4×4) statistical" }
+}
+```
+
+```json
+// configs/cond_basal_4x4.json — 4 seeds × 4 gens baseline (inherits the basal condition config)
+{
+  "inherit_from": ["cond_basal.json"],
+  "n_init_sims": 4,
+  "generations": 4
+}
+```
+
+NOTE: confirm `configs/cond_basal.json` (and the other `cond_*.json`) exist in the repo root `configs/` (they are referenced by the legacy `comparison_spec.json`); if the per-condition configs live elsewhere, update the manifest paths to match.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/python -m pytest tests/test_read_spec.py -k example_manifest -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add comparison.5cond_1x4.json comparison.baseline_4x4_statistical.json configs/cond_basal_4x4.json tests/test_read_spec.py
+git commit -m "feat(harness): example manifests (5cond 1x4 standard; baseline 4x4 statistical)"
+```
+
+---
+
+## Task 8: Retire the duplicated seeds/gens path
+
+**Files:**
+- Modify: `scripts/_read_spec.py` (remove `condition_rows`/`_resolve` after the runner is migrated), `scripts/comparison_harness.sh` (call `configs` mode; read seeds/gens from each config via the runner), `comparison_spec.json` (convert to the new `configs[]` schema).
+
+NOTE: This task is the migration cut-over and touches the bash orchestrator + the runner's seed/gen wiring. Do it LAST, only after Tasks 1-7 are green, and verify with a 1-seed smoke run end-to-end before removing the legacy `conditions` mode. Keep `condition_rows` until `comparison_harness.sh` no longer calls the `conditions` mode.
+
+- [ ] **Step 1:** Convert `comparison_spec.json` to `{v2ecoli, vecoli, defaults:{cards}, configs:[{config, cards}]}`.
+- [ ] **Step 2:** Update `comparison_harness.sh` to call `_read_spec.py <spec> configs` and, per config, read `(seeds, gens)` from the config (the runner already has the fork; have it print/resolve via `config_run_shape`).
+- [ ] **Step 3:** Smoke: `bash scripts/run_local_4x4x5.sh 1 1 200 out/smoke` equivalent driven by `comparison.5cond_1x4.json` produces a report with overview + 5 per-config standard cards.
+- [ ] **Step 4:** Remove `condition_rows`/`_resolve`/the `conditions` CLI mode; update `tests/test_read_spec.py`.
+- [ ] **Step 5:** Commit `refactor(harness): retire duplicated seeds/gens; configs are source of truth`.
+
+---
+
+## Self-Review
+
+**Spec coverage:** manifest schema (Tasks 2,7,8) ✓; seeds/gens from config (Tasks 1,8) ✓; report-card registry package (Tasks 3,4,5) ✓; statistical=Chris's card (Task 4) ✓; manifest-mirroring report (Task 6) ✓; example manifests (Task 7) ✓; `docs/report_cards/` output convention (unchanged — render_html already writes there; verify in Task 6 smoke). **Variants = Plan B** (explicitly deferred). 
+
+**Placeholder scan:** Task 8 is intentionally coarser (a migration cut-over over bash + runner wiring) and carries explicit NOTEs to verify before deleting; Tasks 1-7 are fully concrete. The `per_obs` sub-key names (`ve_cells`/`v2_cells`) are flagged in Task 4 to confirm against `comparison_report_card.build()` before coding.
+
+**Type consistency:** `CardContext`/`Section` fields match across Tasks 3-6; `config_run_shape -> (int,int)` matches Task 8 usage; `build_report_card` call matches its real signature (Task 4).
+
+## Plan B (separate plan, after A is green)
+
+Full variant execution: read each config's `variants` dict, expand the matrix in `run_comparison_ensemble.py`, run each `(config, variant)` through both engines into `<out>/<config>/variant_<i>/`, and extend `assemble_from_manifest` + `overview_section` with a variant dimension (config → variant → cards).

--- a/docs/superpowers/specs/2026-06-27-comparison-harness-modular-cards-design.md
+++ b/docs/superpowers/specs/2026-06-27-comparison-harness-modular-cards-design.md
@@ -1,0 +1,191 @@
+# Comparison Harness v2 — Modular, Config-Driven Report Cards (Design)
+
+**Status:** approved design → writing-plans next
+**Author:** Eran Agmon (with Claude)
+**Date:** 2026-06-27
+
+## Goal
+
+Clean up how the v2ecoli ↔ vEcoli comparison harness is *defined* and *reported*:
+a single JSON manifest that pins the repos to compare, lists the vEcoli configs
+to run, and assigns **modular, reusable report cards** to each config — rendered
+into a report whose structure mirrors the manifest (overview + a section per
+config, each showing its assigned cards).
+
+## Background / current state
+
+- The harness already exists in `vivarium-collective/v2ecoli`:
+  `scripts/run_comparison_ensemble.py` (per-engine runner), `scripts/comparison_harness.sh`
+  (orchestrator), `scripts/_read_spec.py` (parser), `scripts/comparison_report_card.py`
+  (report assembly), `comparison_spec.json` (manifest).
+- The report is already a list-of-sections assembly with an `overview_section` at
+  the top and per-condition sections (parca, config, eval). It is **close** to the
+  target structure.
+- **Chris Long's report-card library is already on `main` and tracked** —
+  `v2ecoli/library/report_card.py` (grading + HTML render with `<details>`
+  collapsible "dropdown" viz bars + `within_tol/drift/mismatch` verdict pills),
+  `card_criteria.py` (`rel_tol`/`ttest`/`flux_scatter`/`r2`), `card_plots.py`
+  (`violin_strip`/`literature_strip`/`loglog_scatter` → inline SVG), `card_vectors.py`.
+  The harness already calls it via `scripts/_compare/report_card_section.build_report_card`.
+  Reference investigation: PR #235 (cplong90).
+- Rendered cards live under **`docs/report_cards/`** (e.g.
+  `vecoli_v2ecoli_conditions/{basal,with_aa,no_oxygen,succinate}`,
+  `population_phenotype_basal/`). This output convention is established.
+
+## What's wrong today (the cleanup targets)
+
+1. The manifest **duplicates** `seeds`/`gens` per condition (separate entry) and
+   **ignores variants** — runs are variant=0 only. vEcoli configs already carry
+   `n_init_sims` (seeds), `generations` (gens), and `variants`.
+2. Report cards are **not assignable** — the report runs a fixed per-condition
+   section sequence; you cannot say "use the statistical card for baseline, the
+   standard card elsewhere."
+3. Card **code** is flat in `v2ecoli/library/`, not a modular package keyed by
+   card name.
+
+## Design
+
+### 1. Manifest schema (`comparison.json`)
+
+```jsonc
+{
+  "v2ecoli": { "repo": "https://github.com/vivarium-collective/v2ecoli", "commit": "<sha>" },
+  "vecoli":  { "repo": "https://github.com/CovertLab/vEcoli",          "commit": "<sha>" },
+  "defaults": { "cards": ["standard"] },
+  "configs": [
+    { "config": "configs/cond_basal.json", "cards": ["standard"] }
+  ],
+  "report": { "out": "out/report", "title": "..." }
+}
+```
+
+- **`v2ecoli` / `vecoli`**: each `{ repo, commit }`. `commit` is the pin (the old
+  `branch` field is dropped). A run records the resolved commits in the report.
+- **`configs[]`**: each `{ config, cards?, note? }`. `config` is a path to a vEcoli
+  config file (relative to the vEcoli fork root). **`seeds` (`n_init_sims`), `gens`
+  (`generations`), and `variants` are read from that config — never specified in
+  the manifest.** To change scale, point at a different config (vEcoli's
+  `inherit_from` makes a 1-seed vs 4-seed sibling cheap).
+- **`cards`**: list of report-card names for this config; falls back to
+  `defaults.cards` when omitted.
+- **`report`**: `{ out, title }` — output dir + report title.
+
+`_read_spec.py` gains a `configs` mode that emits `config<TAB>cards(csv)` per entry
+and resolves `seeds/gens/variants` by reading each referenced vEcoli config (via
+the existing `config_adapter.resolve_vecoli_config_local`). The old `conditions`
+mode + `defaults.seeds/gens` are removed.
+
+### 2. Report-card registry (modular code package)
+
+New package `scripts/_compare/report_cards/`:
+
+- `__init__.py` — the registry: `REGISTRY: dict[str, Card]`, a `@report_card(name)`
+  decorator, and `get(name) -> Card`. Importing the package registers all cards.
+- One module per card:
+  - `standard.py` → `standard_card(ctx)` — matched-time evaluation + run
+    trajectories (today's `eval_section` + `runs_section`), the lighter card.
+  - `statistical.py` → `statistical_card(ctx)` — wraps
+    `report_card_section.build_report_card(...)` → `v2ecoli.library.report_card`:
+    Chris's graded card with violin/strip distribution plots, the `<details>`
+    dropdown viz bars, and `within_tol/drift/mismatch` verdict pills. **No new viz
+    code** — this exposes the on-main library as an assignable card.
+  - `parca.py` → `parca_card(ctx)` — ParCa / initial-state match (today's
+    `parca_section`).
+  - `config_diff.py` → `config_diff_card(ctx)` — vEcoli-vs-v2 config diff (today's
+    `config_diff_section` / `config_sections_for`).
+
+A **card** is `Callable[[CardContext], Section | list[Section]]`.
+
+```python
+@dataclass
+class CardContext:
+    config_name: str          # e.g. "basal"
+    variant: int              # variant index (0 for the baseline variant)
+    v2_dir: str               # dir holding v2ecoli_seed*.zarr for this (config, variant)
+    ve_dir: str               # dir holding vecoli_seed*.zarr
+    seeds: int                # from the config's n_init_sims
+    gens: int                 # from the config's generations
+    per_obs: dict             # extracted per-observable trajectories/values
+    config: dict              # the resolved vEcoli config
+```
+
+`Section = {"title": str, "kind": "content", "html": str, "anchor": str,
+"verdict": str | None}` — the existing section dict shape (so the assembler is
+unchanged structurally).
+
+Adding a future card = one decorated module; assigning it = a name in the manifest.
+
+### 3. Full variant execution
+
+- For each `configs[]` entry, read the config's `variants` dict and expand it into
+  the variant matrix (variant index 0..N-1). `variants: {}` → a single variant
+  (index 0), identical to today.
+- `run_comparison_ensemble.py` gains a variant dimension: it runs **each
+  (config, variant)** through both engines, writing stores to
+  `<out>/<config_name>/variant_<i>/{v2ecoli,vecoli}_seed<NN>.zarr`. Variant
+  application mirrors vEcoli's variant mechanism (apply the variant's parameter
+  overrides to sim_data/config before the run); v2ecoli applies the same overrides
+  so both engines run the matched variant.
+- Stores are addressed by `(config, variant, engine, seed)` throughout.
+
+### 4. Report assembly (manifest-mirroring)
+
+`comparison_report_card.py main()` is rewritten to be manifest-driven:
+
+1. **Overview** section at the top — one row per `(config, variant)` with its
+   headline verdict(s), as today's `overview_section` (extended with a variant
+   column).
+2. For each `configs[]` entry, in manifest order:
+   - a **config section group** titled by the config name;
+   - for each variant, that config's **assigned cards** rendered in `cards` order,
+     each card producing its Section(s).
+3. The assembled report is written to `report.out` as
+   `standardized_comparison_report.html`; per-card rendered bundles are also
+   written under `docs/report_cards/<run_slug>/<config>/variant_<i>/` following the
+   existing `docs/report_cards/` convention.
+
+### 5. Example manifests (tracked, in-repo)
+
+- **`comparison.5cond_1x4.json`** — 5 conditions
+  (`configs/cond_{basal,with_aa,succinate,no_oxygen,acetate}.json`), each
+  `cards: ["standard"]`, full variant execution. The condition configs carry
+  `n_init_sims: 1, generations: 4`.
+- **`comparison.baseline_4x4_statistical.json`** — baseline only
+  (`configs/cond_basal_4x4.json`, an `inherit_from: cond_basal.json` sibling with
+  `n_init_sims: 4, generations: 4`), `cards: ["statistical"]` (Chris's
+  violin/dropdown graded card).
+
+### Reuse vs new
+
+- **Reuse (tracked, on `main`):** Chris's `report_card.py` + `card_criteria.py` +
+  `card_plots.py` + `card_vectors.py` (violin/strip + `<details>` dropdown +
+  grading); the `docs/report_cards/` output convention; the existing
+  `run_comparison_ensemble` / `comparison_harness.sh` / `config_adapter` plumbing.
+- **New:** the slimmed manifest schema (cards-per-config, no seeds/gens/variants
+  duplication), the `scripts/_compare/report_cards/` registry package, variant
+  expansion in the runner, the manifest-mirroring report assembly, the two example
+  manifests.
+
+## Testing
+
+- **`_read_spec` / schema**: unit tests that a manifest resolves to the right
+  `(config → cards)` map and that seeds/gens/variants come from the referenced
+  config (extend `tests/test_read_spec.py`).
+- **Registry**: a card registers under its name; `get("statistical")` returns a
+  callable; an unknown card name fails loud.
+- **Each card**: given a small fixture `CardContext`, the card returns a Section
+  with a non-empty `html` and a verdict in `{within_tol, drift, mismatch,
+  ungraded}` (reuse existing `report_card` fixtures).
+- **Variant expansion**: a config with `variants: {}` yields one variant; a config
+  with a real variant dict yields the expected matrix (fixture, no full sim).
+- **Report assembly**: an overview at the top + one section group per config in
+  manifest order, each containing exactly its assigned cards (assert on the
+  assembled section list, not a full render).
+
+## Out of scope
+
+- Cloud/Ray orchestration changes (the existing route is unaffected; the manifest
+  is the only new control surface).
+- New grading criteria or plot types — cards reuse Chris's existing
+  `card_criteria` / `card_plots`.
+- Migrating other report consumers (sweep reports, s3 reports) onto the registry.

--- a/scripts/_compare/config_adapter.py
+++ b/scripts/_compare/config_adapter.py
@@ -127,3 +127,15 @@ def resolve_vecoli_config(config_path: str,
         cwd=vecoli_repo, text=True,
     )
     return json.loads(out)
+
+
+def config_run_shape(config_path: str, fork_dir: str) -> tuple[int, int]:
+    """Return (seeds, gens) = (n_init_sims, generations) from a vEcoli config.
+
+    seeds/gens are the config's run shape — the single source of truth. Missing
+    or null values default to 1 (one seed, one generation).
+    """
+    cfg = resolve_vecoli_config_local(config_path, fork_dir)
+    seeds = cfg.get("n_init_sims")
+    gens = cfg.get("generations")
+    return int(seeds) if seeds else 1, int(gens) if gens else 1

--- a/scripts/_compare/report_cards/__init__.py
+++ b/scripts/_compare/report_cards/__init__.py
@@ -56,3 +56,4 @@ def render(name: str, ctx: CardContext) -> list[Section]:
 # Built-in card modules (standard/statistical/parca/config_diff) are imported
 # here once they exist (Tasks 4–5) so importing this package registers them.
 from scripts._compare.report_cards import standard, statistical  # noqa: E402,F401
+from scripts._compare.report_cards import parca, config_diff  # noqa: E402,F401

--- a/scripts/_compare/report_cards/__init__.py
+++ b/scripts/_compare/report_cards/__init__.py
@@ -56,4 +56,4 @@ def render(name: str, ctx: CardContext) -> list[Section]:
 # Built-in card modules (standard/statistical/parca/config_diff) are imported
 # here once they exist (Tasks 4–5) so importing this package registers them.
 from scripts._compare.report_cards import standard, statistical  # noqa: E402,F401
-from scripts._compare.report_cards import parca, config_diff  # noqa: E402,F401
+from scripts._compare.report_cards import parca, config_diff, config  # noqa: E402,F401

--- a/scripts/_compare/report_cards/__init__.py
+++ b/scripts/_compare/report_cards/__init__.py
@@ -1,0 +1,57 @@
+"""Registry of modular comparison report cards.
+
+A card is Callable[[CardContext], Section | list[Section]]. Register with the
+@report_card("name") decorator; assign by name in the comparison manifest.
+Cards are thin wrappers over the existing section functions and Chris Long's
+on-main card library (v2ecoli.library.report_card).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+Section = dict  # {title, kind, html, anchor, verdict?}
+
+
+@dataclass
+class CardContext:
+    config_name: str
+    variant: int
+    v2_dir: str
+    ve_dir: str
+    seeds: int
+    gens: int
+    per_obs: dict = field(default_factory=dict)
+    plot_trajs: dict = field(default_factory=dict)
+    v2_bounds: dict = field(default_factory=dict)
+    config: dict = field(default_factory=dict)
+
+
+Card = Callable[[CardContext], "Section | list[Section]"]
+REGISTRY: dict[str, Card] = {}
+
+
+def report_card(name: str) -> Callable[[Card], Card]:
+    def deco(fn: Card) -> Card:
+        REGISTRY[name] = fn
+        return fn
+    return deco
+
+
+def get(name: str) -> Card:
+    if name not in REGISTRY:
+        raise KeyError(f"unknown report card {name!r}; known: {sorted(REGISTRY)}")
+    return REGISTRY[name]
+
+
+def all_names() -> list[str]:
+    return sorted(REGISTRY)
+
+
+def render(name: str, ctx: CardContext) -> list[Section]:
+    out = get(name)(ctx)
+    return out if isinstance(out, list) else [out]
+
+
+# Built-in card modules (standard/statistical/parca/config_diff) are imported
+# here once they exist (Tasks 4–5) so importing this package registers them.

--- a/scripts/_compare/report_cards/__init__.py
+++ b/scripts/_compare/report_cards/__init__.py
@@ -55,3 +55,4 @@ def render(name: str, ctx: CardContext) -> list[Section]:
 
 # Built-in card modules (standard/statistical/parca/config_diff) are imported
 # here once they exist (Tasks 4–5) so importing this package registers them.
+from scripts._compare.report_cards import standard, statistical  # noqa: E402,F401

--- a/scripts/_compare/report_cards/config.py
+++ b/scripts/_compare/report_cards/config.py
@@ -1,0 +1,48 @@
+"""`config` card — the vEcoli config driving this section's run, rendered
+deterministically from the config file (always available, unlike the Nextflow
+`config_diff` card which needs S3/workflow artifacts). Shows condition, run
+shape (seeds/gens), and the config's other top-level settings."""
+from __future__ import annotations
+
+import html as _html
+
+from scripts._compare.report_cards import report_card, CardContext, Section
+
+# Keys surfaced first, in this order; everything else follows alphabetically.
+_PRIORITY = ["condition", "n_init_sims", "generations", "time_step",
+             "max_duration", "variants", "inherit_from"]
+_LABEL = {"n_init_sims": "seeds (n_init_sims)", "generations": "generations"}
+
+
+@report_card("config")
+def config_card(ctx: CardContext) -> Section:
+    cfg = dict(ctx.config or {})
+    cfg.setdefault("condition", ctx.config_name)
+    if ctx.seeds:
+        cfg.setdefault("n_init_sims", ctx.seeds)
+    if ctx.gens:
+        cfg.setdefault("generations", ctx.gens)
+    keys = [k for k in _PRIORITY if k in cfg] + sorted(
+        k for k in cfg if k not in _PRIORITY and not k.startswith("_"))
+    rows = []
+    for k in keys:
+        v = cfg[k]
+        vs = ", ".join(map(str, v)) if isinstance(v, (list, tuple)) else (
+            _html.escape(str(v)) if not isinstance(v, dict) else _html.escape(repr(v)))
+        rows.append(
+            f'<tr><td style="padding:2px 12px 2px 0;color:#6b7280">'
+            f'{_html.escape(_LABEL.get(k, k))}</td><td style="font-family:monospace">'
+            f'{vs}</td></tr>')
+    table = ('<table style="border-collapse:collapse;font-size:13px">'
+             + "".join(rows) + "</table>") if rows else (
+        f"<p>config for '{_html.escape(ctx.config_name)}' (no fields resolved)</p>")
+    src = ctx.config.get("_source") if isinstance(ctx.config, dict) else None
+    note = (f'<p style="color:#6b7280;font-size:12px">source: '
+            f'{_html.escape(str(src))}</p>') if src else ""
+    return {"title": f"{ctx.config_name} — config",
+            "kind": "content",
+            "anchor": f"{ctx.config_name}-config",
+            "html": f"<p>vEcoli config driving the <b>{_html.escape(ctx.config_name)}</b> "
+                    f"run (config = source of truth for the run shape).</p>"
+                    + table + note,
+            "verdict": None}

--- a/scripts/_compare/report_cards/config.py
+++ b/scripts/_compare/report_cards/config.py
@@ -5,6 +5,7 @@ shape (seeds/gens), and the config's other top-level settings."""
 from __future__ import annotations
 
 import html as _html
+import json as _json
 
 from scripts._compare.report_cards import report_card, CardContext, Section
 
@@ -39,10 +40,20 @@ def config_card(ctx: CardContext) -> Section:
     src = ctx.config.get("_source") if isinstance(ctx.config, dict) else None
     note = (f'<p style="color:#6b7280;font-size:12px">source: '
             f'{_html.escape(str(src))}</p>') if src else ""
+    # Full JSON config in a browsable (collapsible, scrollable) viewer — the
+    # default so every section exposes exactly what was run.
+    full = {k: v for k, v in (ctx.config or {}).items() if k != "_source"}
+    json_viewer = (
+        '<details open style="margin-top:8px"><summary style="cursor:pointer;'
+        'color:#374151;font-weight:600">full JSON config</summary>'
+        '<pre style="background:#f9fafb;border:1px solid #e5e7eb;border-radius:6px;'
+        'padding:10px;font-size:12px;line-height:1.4;max-height:380px;overflow:auto;'
+        'white-space:pre">' + _html.escape(_json.dumps(full, indent=2, sort_keys=True))
+        + '</pre></details>') if full else ""
     return {"title": f"{ctx.config_name} — config",
             "kind": "content",
             "anchor": f"{ctx.config_name}-config",
             "html": f"<p>vEcoli config driving the <b>{_html.escape(ctx.config_name)}</b> "
                     f"run (config = source of truth for the run shape).</p>"
-                    + table + note,
+                    + table + json_viewer + note,
             "verdict": None}

--- a/scripts/_compare/report_cards/config_diff.py
+++ b/scripts/_compare/report_cards/config_diff.py
@@ -1,0 +1,10 @@
+"""`config_diff` card — vEcoli vs v2ecoli config comparison for one config."""
+from __future__ import annotations
+
+from scripts._compare.report_cards import report_card, CardContext, Section
+
+
+@report_card("config_diff")
+def config_diff_card(ctx: CardContext) -> list[Section]:
+    from scripts.comparison_report_card import config_sections_for
+    return config_sections_for(ctx.config_name, ctx.v2_dir, ctx.ve_dir)

--- a/scripts/_compare/report_cards/parca.py
+++ b/scripts/_compare/report_cards/parca.py
@@ -10,4 +10,5 @@ def parca_card(ctx: CardContext) -> Section:
     # parca_section takes the cond_data map; build a single-cond slice.
     sec = parca_section({ctx.config_name: (ctx.per_obs, ctx.plot_trajs, ctx.v2_bounds)})
     sec["anchor"] = f"{ctx.config_name}-parca"
+    sec["title"] = f"{ctx.config_name} — ParCa / initial-state match"
     return sec

--- a/scripts/_compare/report_cards/parca.py
+++ b/scripts/_compare/report_cards/parca.py
@@ -1,0 +1,13 @@
+"""`parca` card — ParCa / initial-state match for one config."""
+from __future__ import annotations
+
+from scripts._compare.report_cards import report_card, CardContext, Section
+
+
+@report_card("parca")
+def parca_card(ctx: CardContext) -> Section:
+    from scripts.comparison_report_card import parca_section
+    # parca_section takes the cond_data map; build a single-cond slice.
+    sec = parca_section({ctx.config_name: (ctx.per_obs, ctx.plot_trajs, ctx.v2_bounds)})
+    sec["anchor"] = f"{ctx.config_name}-parca"
+    return sec

--- a/scripts/_compare/report_cards/standard.py
+++ b/scripts/_compare/report_cards/standard.py
@@ -1,0 +1,16 @@
+"""`standard` card — matched-time run trajectories + evaluation (the lighter
+card). Thin wrapper over comparison_report_card.runs_section / eval_section."""
+from __future__ import annotations
+
+from scripts._compare.report_cards import report_card, CardContext, Section
+
+
+@report_card("standard")
+def standard_card(ctx: CardContext) -> list[Section]:
+    # Imported lazily: comparison_report_card imports heavy deps; importing it at
+    # module load would slow registry import and risk a cycle.
+    from scripts.comparison_report_card import runs_section, eval_section
+    return [
+        runs_section(ctx.config_name, ctx.per_obs, ctx.plot_trajs, ctx.v2_bounds),
+        eval_section(ctx.config_name, ctx.per_obs),
+    ]

--- a/scripts/_compare/report_cards/statistical.py
+++ b/scripts/_compare/report_cards/statistical.py
@@ -1,0 +1,24 @@
+"""`statistical` card — Chris Long's graded equivalence card (violin/strip +
+<details> dropdown viz bars + within_tol/drift/mismatch pills). Mirrors the
+per_obs -> build_report_card mapping in comparison_report_card.report_card()."""
+from __future__ import annotations
+
+from scripts._compare.report_cards import report_card, CardContext, Section
+from scripts._compare.report_card_section import build_report_card
+
+
+@report_card("statistical")
+def statistical_card(ctx: CardContext) -> Section:
+    from scripts.comparison_report_card import OBSERVABLES, CARD_KEY, EXTRA_AXES, TOL
+    left: dict = {}   # vEcoli (reference)
+    right: dict = {}  # v2ecoli (measured)
+    for obs in OBSERVABLES:
+        ck = CARD_KEY.get(obs, obs)
+        left[ck] = [s["ve_mean"] for s in ctx.per_obs.get(obs, [])]
+        right[ck] = [s["v2_mean"] for s in ctx.per_obs.get(obs, [])]
+    vjson, html = build_report_card(
+        left, right, extra_axes=EXTRA_AXES,
+        model_ref=f"v2ecoli @ {ctx.config_name} variant {ctx.variant}", tol_rel=TOL)
+    return {"title": f"{ctx.config_name} — statistical equivalence",
+            "kind": "content", "anchor": f"{ctx.config_name}-statistical",
+            "html": html, "verdict": vjson.get("overall")}

--- a/scripts/_read_spec.py
+++ b/scripts/_read_spec.py
@@ -37,7 +37,7 @@ DEFAULT_VECOLI_ENGINE = "upstream-wrapper"
 
 
 def load(path):
-    with open(path) as fh:
+    with open(path, encoding="utf-8") as fh:
         return json.load(fh)
 
 

--- a/scripts/_read_spec.py
+++ b/scripts/_read_spec.py
@@ -21,6 +21,9 @@ Usage:
   _read_spec.py <spec.json> conditions [cli_seeds] [cli_gens]
         -> one line per condition:  name<TAB>config<TAB>seeds<TAB>gens
         Resolution per field: condition value, else defaults value, else CLI value.
+  _read_spec.py <spec.json> configs
+        -> one line per config:  config_path<TAB>cards_csv
+        cards_csv: entry 'cards' -> defaults.cards -> 'standard'.
 
 This is the unit-testable core of the manifest behaviour (feed it a spec, diff
 the rows). Kept separate from comparison_harness.sh so the parsing has tests.
@@ -106,6 +109,19 @@ def condition_rows(spec, cli_seeds, cli_gens):
         yield name, config, int(seeds), int(gens)
 
 
+def config_rows(spec):
+    """Yield (config_path, cards_csv) per spec['configs'] entry.
+
+    cards: entry 'cards' -> spec defaults.cards -> ['standard'].
+    seeds/gens/variants are NOT here — the runner reads them from each config.
+    """
+    default_cards = (spec.get("defaults", {}) or {}).get("cards") or ["standard"]
+    for entry in spec.get("configs", []):
+        config = entry["config"]
+        cards = entry.get("cards") or default_cards
+        yield config, ",".join(cards)
+
+
 def main(argv):
     if len(argv) < 3:
         sys.exit("usage: _read_spec.py <spec.json> {engine v2ecoli|vecoli | "
@@ -129,6 +145,9 @@ def main(argv):
         cli_gens = int(argv[4]) if len(argv) > 4 else 0
         for name, config, seeds, gens in condition_rows(spec, cli_seeds, cli_gens):
             print("\t".join([name, config, str(seeds), str(gens)]))
+    elif mode == "configs":
+        for config, cards in config_rows(spec):
+            print("\t".join([config, cards]))
     else:
         sys.exit("unknown mode: %s" % mode)
 

--- a/scripts/comparison_report_card.py
+++ b/scripts/comparison_report_card.py
@@ -818,7 +818,9 @@ def main(argv=None):
         else:                                         # 3. baked-in CONDITIONS default
             conds = {k: list(v) for k, v in CONDITIONS.items()}
     conds = {k: tuple(v) for k, v in conds.items()}
-    if args.only.strip().lower() != "all":
+    # In manifest mode the manifest's `configs` ARE the selection — don't let
+    # --only (default 'basal') silently drop the other configs.
+    if not manifest_mode and args.only.strip().lower() != "all":
         want = [c.strip() for c in args.only.split(",") if c.strip()]
         conds = {k: conds[k] for k in want if k in conds}
     if not conds:

--- a/scripts/comparison_report_card.py
+++ b/scripts/comparison_report_card.py
@@ -706,7 +706,7 @@ def assemble_from_manifest(manifest, cond_data, conds, config_names):
         # which path resolved.
         for cand in (p, _os.path.join(_repo, p)):
             try:
-                with open(cand) as _fh:
+                with open(cand, encoding="utf-8") as _fh:
                     d = _json.load(_fh)
                 d["_source"] = cand
                 return d
@@ -797,7 +797,7 @@ def main(argv=None):
         import os as _os
         import re as _re
         from scripts._compare.config_adapter import resolve_vecoli_config_local
-        manifest_data = json.loads(Path(args.manifest).read_text())
+        manifest_data = json.loads(Path(args.manifest).read_text(encoding="utf-8"))
         _fork = _os.environ.get("V2E_VECOLI_DIR", "")
 
         def _cond_name(cfg_path):

--- a/scripts/comparison_report_card.py
+++ b/scripts/comparison_report_card.py
@@ -696,6 +696,24 @@ def assemble_from_manifest(manifest, cond_data, conds, config_names):
     """
     from scripts._compare import report_cards as rc
     default_cards = (manifest.get("defaults", {}) or {}).get("cards") or ["standard"]
+    import json as _json
+    import os as _os
+    _repo = _os.path.dirname(_os.path.dirname(_os.path.abspath(__file__)))
+
+    def _load_cfg(p):
+        # Read the manifest's config file deterministically (repo-relative or
+        # absolute) so the `config` card is ALWAYS populated. _source records
+        # which path resolved.
+        for cand in (p, _os.path.join(_repo, p)):
+            try:
+                with open(cand) as _fh:
+                    d = _json.load(_fh)
+                d["_source"] = cand
+                return d
+            except (OSError, ValueError):
+                continue
+        return {}
+
     overview = overview_section(cond_data); overview["nav_group"] = "Overall"
     sections = [overview]
     for entry in manifest.get("configs", []):
@@ -704,9 +722,11 @@ def assemble_from_manifest(manifest, cond_data, conds, config_names):
             continue
         per_obs, plot_trajs, v2_bounds = cond_data[name]
         v2_dir, ve_dir = conds.get(name, ("", ""))
+        _cfg = _load_cfg(entry["config"])
         ctx = rc.CardContext(config_name=name, variant=0, v2_dir=v2_dir,
-                             ve_dir=ve_dir, seeds=0, gens=0, per_obs=per_obs,
-                             plot_trajs=plot_trajs, v2_bounds=v2_bounds, config={})
+                             ve_dir=ve_dir, seeds=int(_cfg.get("n_init_sims") or 0),
+                             gens=int(_cfg.get("generations") or 0), per_obs=per_obs,
+                             plot_trajs=plot_trajs, v2_bounds=v2_bounds, config=_cfg)
         for card in (entry.get("cards") or default_cards):
             for sec in rc.render(card, ctx):
                 sec["nav_group"] = name

--- a/scripts/comparison_report_card.py
+++ b/scripts/comparison_report_card.py
@@ -818,7 +818,10 @@ def main(argv=None):
             # config like cond_basal_1x4 maps to the 'basal' store dir.
             return _re.sub(r"_\d+x\d+$", "", stem)
 
-        _config_names = {_entry["config"]: _cond_name(_entry["config"])
+        # Section/store key: an explicit `name` on the entry (disambiguates two
+        # configs that share a condition, e.g. basal_1x4 vs basal_4x4), else the
+        # config's condition.
+        _config_names = {_entry["config"]: (_entry.get("name") or _cond_name(_entry["config"]))
                          for _entry in manifest_data.get("configs", [])}
         # In manifest mode both engines' stores (v2ecoli_seed*.zarr and
         # vecoli_seed*.zarr) live in the SAME per-condition dir under args.out —

--- a/scripts/comparison_report_card.py
+++ b/scripts/comparison_report_card.py
@@ -688,6 +688,32 @@ def eval_section(cond: str, per_obs: dict) -> dict:
         "rows": rows}
 
 
+def assemble_from_manifest(manifest, cond_data, conds, config_names):
+    """Overview + per-config assigned-card sections, mirroring the manifest.
+
+    config_names maps a manifest config path -> the condition key used in
+    cond_data/conds (the runner names stores by condition).
+    """
+    from scripts._compare import report_cards as rc
+    default_cards = (manifest.get("defaults", {}) or {}).get("cards") or ["standard"]
+    overview = overview_section(cond_data); overview["nav_group"] = "Overall"
+    sections = [overview]
+    for entry in manifest.get("configs", []):
+        name = config_names[entry["config"]]
+        if name not in cond_data:
+            continue
+        per_obs, plot_trajs, v2_bounds = cond_data[name]
+        v2_dir, ve_dir = conds.get(name, ("", ""))
+        ctx = rc.CardContext(config_name=name, variant=0, v2_dir=v2_dir,
+                             ve_dir=ve_dir, seeds=0, gens=0, per_obs=per_obs,
+                             plot_trajs=plot_trajs, v2_bounds=v2_bounds, config={})
+        for card in (entry.get("cards") or default_cards):
+            for sec in rc.render(card, ctx):
+                sec["nav_group"] = name
+                sections.append(sec)
+    return sections
+
+
 def _load_experiments(out_dir: str) -> dict | None:
     """Read condition -> [v2_dir, ve_dir] written by comparison_harness.sh launch.
 
@@ -734,15 +760,47 @@ def main(argv=None):
                         'render the standardized report for any pbg-vs-pbg run.')
     p.add_argument("-o", "--out", default="out/full_compare",
                    help="output directory (also read for experiments.json)")
+    p.add_argument("--manifest", default=None,
+                   help="path to a comparison manifest JSON; when set, loads the "
+                        "manifest and routes assembly through assemble_from_manifest "
+                        "(per-config card assignment). --only still filters configs.")
     args = p.parse_args(argv)
 
     local_pbg = bool(args.local_pbg)
     local_pbg_dir = bool(args.local_pbg_dir)
     pbg_vs_pbg = bool(args.pbg_vs_pbg)
+    manifest_mode = bool(args.manifest)
     # both modes drop the S3/Nextflow-only panels (vecoli side is a pbg zarr, not
     # a Nextflow workflow_config.json); local reads from disk, pbg_vs_pbg from S3.
-    skip_nextflow = local_pbg or local_pbg_dir or pbg_vs_pbg
-    if local_pbg_dir:                                 # 0b. multi-seed local dirs
+    skip_nextflow = local_pbg or local_pbg_dir or pbg_vs_pbg or manifest_mode
+    if manifest_mode:                                 # -1. manifest-driven
+        import os as _os
+        from scripts._compare.config_adapter import resolve_vecoli_config_local
+        manifest_data = json.loads(Path(args.manifest).read_text())
+        _fork = _os.environ.get("V2E_VECOLI_DIR", "")
+
+        def _cond_name(cfg_path):
+            # Config is the source of truth: read its `condition` field when the
+            # vEcoli fork is known (robust to any config filename). Fall back to
+            # the filename stem (strip a leading 'cond_') otherwise.
+            if _fork:
+                try:
+                    cond = resolve_vecoli_config_local(cfg_path, _fork).get("condition")
+                    if cond:
+                        return cond
+                except Exception:  # noqa: BLE001
+                    pass
+            stem = _os.path.splitext(_os.path.basename(cfg_path))[0]
+            return stem[len("cond_"):] if stem.startswith("cond_") else stem
+
+        _config_names = {_entry["config"]: _cond_name(_entry["config"])
+                         for _entry in manifest_data.get("configs", [])}
+        # In manifest mode both engines' stores (v2ecoli_seed*.zarr and
+        # vecoli_seed*.zarr) live in the SAME per-condition dir under args.out —
+        # the same layout as --local-pbg-dir's 4x4x5 run.
+        conds = {_n: (f"{args.out}/{_n}", f"{args.out}/{_n}")
+                 for _n in _config_names.values()}
+    elif local_pbg_dir:                               # 0b. multi-seed local dirs
         conds = json.loads(args.local_pbg_dir)
     elif local_pbg:                                   # 0. pbg-vs-pbg local zarr
         conds = json.loads(args.local_pbg)
@@ -762,10 +820,11 @@ def main(argv=None):
         raise SystemExit("no conditions selected")
     print(f"Conditions: {list(conds)}\n")
 
-    if local_pbg_dir:
+    if local_pbg_dir or manifest_mode:
         # MULTI-SEED local: each cond maps to [v2_dir, ve_dir]; read per-seed
         # v2ecoli-format zarr (v2ecoli_seed<NN>.zarr / vecoli_seed<NN>.zarr) for
-        # seeds 0..N-1 through the same local reader. Enables the local 4x4x5.
+        # seeds 0..N-1 through the same local reader. Enables the local 4x4x5
+        # and manifest-driven runs whose per-config dirs live under args.out.
         cond_data = build(
             conds, seeds=list(range(args.local_pbg_seeds)),
             read_v2=lambda d, s: read_pbg_local(f"{d}/v2ecoli_seed{s:02d}.zarr", OBSERVABLES),
@@ -801,33 +860,38 @@ def main(argv=None):
     # contradictory. The Overview matrix is the high-level view; verdict.json
     # stays as the machine-readable artifact for tooling/dashboard.
     vjson, card_html, _card_section = report_card(cond_data, conditions=graded)
-    overview = overview_section(cond_data)
-    overview["nav_group"] = "Overall"
-    sections = [overview]
-    # 2. ParCa / initial-state comparison — its own nav entry. Renders for ALL
-    #    modes (incl. pbg-vs-pbg): it reads the t~0 emitted masses straight from
-    #    the loaded trajectories (cond_data), NOT any Nextflow config — and in the
-    #    matched-initial-state comparison it IS the headline evidence (both engines
-    #    start from identical molecule counts → t~0 masses agree).
-    parca = parca_section(cond_data)
-    parca["nav_group"] = "ParCa comparison"
-    sections.append(parca)
-    # 3. One block PER CONDITION, fixed order, each reading top-to-bottom as
-    #    config -> simulation runs -> evaluation. All of a condition's sections
-    #    share nav_group=<cond>, so they fold into ONE nav button per condition.
-    #    The config panels read S3/Nextflow workflow_config.json, so they are
-    #    omitted in local-pbg mode (both engines are local pbg composites).
-    for cond in conds:
-        v2_dir, ve_dir = conds[cond]
-        per_obs, plot_trajs, v2_bounds = cond_data[cond]
-        cond_sections = [runs_section(cond, per_obs, plot_trajs, v2_bounds),
-                         eval_section(cond, per_obs)]
-        if not skip_nextflow:
-            cond_sections = (config_sections_for(cond, v2_dir, ve_dir)
-                             + cond_sections)
-        for s in cond_sections:
-            s["nav_group"] = cond
-        sections += cond_sections
+    if manifest_mode:
+        # Manifest-driven: per-config card assignment via assemble_from_manifest.
+        sections = assemble_from_manifest(manifest_data, cond_data, conds,
+                                          _config_names)
+    else:
+        overview = overview_section(cond_data)
+        overview["nav_group"] = "Overall"
+        sections = [overview]
+        # 2. ParCa / initial-state comparison — its own nav entry. Renders for ALL
+        #    modes (incl. pbg-vs-pbg): it reads the t~0 emitted masses straight from
+        #    the loaded trajectories (cond_data), NOT any Nextflow config — and in the
+        #    matched-initial-state comparison it IS the headline evidence (both engines
+        #    start from identical molecule counts → t~0 masses agree).
+        parca = parca_section(cond_data)
+        parca["nav_group"] = "ParCa comparison"
+        sections.append(parca)
+        # 3. One block PER CONDITION, fixed order, each reading top-to-bottom as
+        #    config -> simulation runs -> evaluation. All of a condition's sections
+        #    share nav_group=<cond>, so they fold into ONE nav button per condition.
+        #    The config panels read S3/Nextflow workflow_config.json, so they are
+        #    omitted in local-pbg mode (both engines are local pbg composites).
+        for cond in conds:
+            v2_dir, ve_dir = conds[cond]
+            per_obs, plot_trajs, v2_bounds = cond_data[cond]
+            cond_sections = [runs_section(cond, per_obs, plot_trajs, v2_bounds),
+                             eval_section(cond, per_obs)]
+            if not skip_nextflow:
+                cond_sections = (config_sections_for(cond, v2_dir, ve_dir)
+                                 + cond_sections)
+            for s in cond_sections:
+                s["nav_group"] = cond
+            sections += cond_sections
 
     gen = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     title = (f"vEcoli-pbg ↔ v2ecoli-pbg — process-bigraph comparison ({gen})"

--- a/scripts/comparison_report_card.py
+++ b/scripts/comparison_report_card.py
@@ -775,6 +775,7 @@ def main(argv=None):
     skip_nextflow = local_pbg or local_pbg_dir or pbg_vs_pbg or manifest_mode
     if manifest_mode:                                 # -1. manifest-driven
         import os as _os
+        import re as _re
         from scripts._compare.config_adapter import resolve_vecoli_config_local
         manifest_data = json.loads(Path(args.manifest).read_text())
         _fork = _os.environ.get("V2E_VECOLI_DIR", "")
@@ -791,7 +792,11 @@ def main(argv=None):
                 except Exception:  # noqa: BLE001
                     pass
             stem = _os.path.splitext(_os.path.basename(cfg_path))[0]
-            return stem[len("cond_"):] if stem.startswith("cond_") else stem
+            if stem.startswith("cond_"):
+                stem = stem[len("cond_"):]
+            # strip a trailing scale suffix (e.g. _1x4, _4x4) so an override
+            # config like cond_basal_1x4 maps to the 'basal' store dir.
+            return _re.sub(r"_\d+x\d+$", "", stem)
 
         _config_names = {_entry["config"]: _cond_name(_entry["config"])
                          for _entry in manifest_data.get("configs", [])}

--- a/scripts/run_comparison.py
+++ b/scripts/run_comparison.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Manifest-driven comparison runner — the single, AI-free entry point.
+
+Reads a comparison manifest (the new schema: {v2ecoli/vecoli: repo+commit,
+defaults.cards, configs:[{config, cards}]}), runs BOTH engines for each config
+with the run shape (seeds/gens) read FROM that vEcoli config, writes both
+engines' zarr to <out>/<condition>/, then renders the modular report (overview +
+a section per config showing its assigned cards).
+
+Usage:
+  V2E_VECOLI_DIR=/path/to/vEcoli \\
+  .venv/bin/python scripts/run_comparison.py comparison.5cond_1x4.json --out out/report
+
+  # render only (skip sims; assemble the report from existing stores under --out):
+  .venv/bin/python scripts/run_comparison.py comparison.5cond_1x4.json --out out/report --render-only
+
+Per-engine wiring mirrors run_local_4x4x5.sh: v2ecoli runs on its own ParCa cache
+with matched-initial-state against the upstream simData; genuine vEcoli runs on
+the upstream ParCa cache via the vivarium-process engine. Both write
+v2ecoli_seed*.zarr / vecoli_seed*.zarr into the SAME per-condition dir.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+
+from scripts._compare.config_adapter import (  # noqa: E402
+    config_run_shape, resolve_vecoli_config_local)
+
+PER_GEN_STEPS = 15000  # per-generation tick budget (non-binding cap; division-driven)
+
+
+def condition_of(cfg_path: str, fork: str) -> str:
+    """Condition name for a config: its `condition` field (config = source of
+    truth) when the vEcoli fork is known, else the filename stem with a leading
+    'cond_' and a trailing scale suffix (_1x4/_4x4) stripped."""
+    if fork:
+        try:
+            cond = resolve_vecoli_config_local(cfg_path, fork).get("condition")
+            if cond:
+                return cond
+        except Exception:  # noqa: BLE001
+            pass
+    stem = os.path.splitext(os.path.basename(cfg_path))[0]
+    if stem.startswith("cond_"):
+        stem = stem[len("cond_"):]
+    return re.sub(r"_\d+x\d+$", "", stem)
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("manifest", help="comparison manifest JSON")
+    ap.add_argument("--out", default="out/report", help="output dir (per-condition stores + report)")
+    ap.add_argument("--v2-cache", default="out/cache_full", help="v2ecoli ParCa cache")
+    ap.add_argument("--ve-cache", default="out/compare_harness/vecoli_parca", help="upstream vEcoli ParCa cache")
+    ap.add_argument("--mode", default="serial", help="run_comparison_ensemble --mode (serial|ray)")
+    ap.add_argument("--render-only", action="store_true", help="skip sims; render from existing stores")
+    args = ap.parse_args(argv)
+
+    spec = json.loads(Path(args.manifest).read_text())
+    fork = os.environ.get("V2E_VECOLI_DIR", "")
+    py = str(REPO / ".venv/bin/python")
+    ref_sd = f"{args.ve_cache}/simData.cPickle"
+    configs = spec.get("configs", [])
+    if not configs:
+        sys.exit(f"manifest {args.manifest} has no configs")
+
+    max_seeds = 1
+    for entry in configs:
+        cfg = entry["config"]
+        cond = condition_of(cfg, fork)
+        seeds, gens = config_run_shape(cfg, fork) if fork else (1, 1)
+        max_seeds = max(max_seeds, seeds)
+        out_c = f"{args.out}/{cond}"
+        if args.render_only:
+            print(f"[render-only] {cond}: seeds={seeds} gens={gens}")
+            continue
+        print(f">>> {cond}: seeds={seeds} gens={gens} -> {out_c}", flush=True)
+        cap = str(gens * PER_GEN_STEPS)
+        # v2ecoli engine (its own ParCa cache + matched-initial-state)
+        subprocess.run([py, "scripts/run_comparison_ensemble.py",
+                        "--composite", "v2ecoli", "--condition", cond,
+                        "--cache-dir", args.v2_cache, "--n-seeds", str(seeds),
+                        "--max-generations", str(gens), "--max-steps", cap,
+                        "--chunk", "60", "--mode", args.mode,
+                        "--match-initial-state", "--match-vecoli-simdata", ref_sd,
+                        "--out-root", out_c], cwd=REPO, check=True)
+        # genuine vEcoli engine (upstream ParCa cache, vivarium-process)
+        subprocess.run([py, "scripts/run_comparison_ensemble.py",
+                        "--composite", "vecoli", "--condition", cond,
+                        "--cache-dir", args.ve_cache, "--n-seeds", str(seeds),
+                        "--max-generations", str(gens), "--max-steps",
+                        str(PER_GEN_STEPS), "--chunk", "60", "--mode", args.mode,
+                        "--vecoli-source", "vivarium-process",
+                        "--out-root", out_c], cwd=REPO, check=True)
+
+    # render the modular report (overview + per-config assigned cards)
+    subprocess.run([py, "scripts/comparison_report_card.py",
+                    "--manifest", args.manifest, "--out", args.out,
+                    "--local-pbg-seeds", str(max_seeds)], cwd=REPO, check=True)
+    print(f"\nreport: {args.out}/standardized_comparison_report.html")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_comparison.py
+++ b/scripts/run_comparison.py
@@ -66,7 +66,7 @@ def main(argv=None) -> int:
     ap.add_argument("--render-only", action="store_true", help="skip sims; render from existing stores")
     args = ap.parse_args(argv)
 
-    spec = json.loads(Path(args.manifest).read_text())
+    spec = json.loads(Path(args.manifest).read_text(encoding="utf-8"))
     fork = os.environ.get("V2E_VECOLI_DIR", "")
     py = str(REPO / ".venv/bin/python")
     ref_sd = f"{args.ve_cache}/simData.cPickle"

--- a/tests/test_config_translation.py
+++ b/tests/test_config_translation.py
@@ -99,3 +99,18 @@ def test_schema_diff_partitions_keys():
     assert d["only_in_vecoli"] == ["a", "b"]
     assert d["only_in_v2"] == ["c"]
     assert d["different"] == {"shared": (1, 9)}
+
+
+from scripts._compare.config_adapter import config_run_shape  # noqa: E402
+
+
+def test_config_run_shape_reads_n_init_sims_and_generations(tmp_path):
+    cfg = tmp_path / "configs"; cfg.mkdir()
+    (cfg / "c.json").write_text('{"n_init_sims": 4, "generations": 4}')
+    assert config_run_shape("configs/c.json", str(tmp_path)) == (4, 4)
+
+
+def test_config_run_shape_defaults_when_missing(tmp_path):
+    cfg = tmp_path / "configs"; cfg.mkdir()
+    (cfg / "c.json").write_text('{"condition": "basal", "generations": null}')
+    assert config_run_shape("configs/c.json", str(tmp_path)) == (1, 1)

--- a/tests/test_read_spec.py
+++ b/tests/test_read_spec.py
@@ -91,3 +91,21 @@ def test_config_rows_uses_entry_cards_then_defaults():
 def test_config_rows_defaults_to_standard_when_no_defaults():
     spec = {"configs": [{"config": "c.json"}]}
     assert list(rs.config_rows(spec)) == [("c.json", "standard")]
+
+
+import json
+import pathlib  # noqa: E402
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+
+def test_example_manifest_5cond_parses():
+    spec = json.loads((ROOT / "comparison.5cond_1x4.json").read_text())
+    rows = list(rs.config_rows(spec))
+    assert len(rows) == 5
+    assert all(cards == "standard" for _, cards in rows)
+
+
+def test_example_manifest_baseline_statistical_parses():
+    spec = json.loads((ROOT / "comparison.baseline_4x4_statistical.json").read_text())
+    rows = list(rs.config_rows(spec))
+    assert rows == [("configs/cond_basal_4x4.json", "statistical")]

--- a/tests/test_read_spec.py
+++ b/tests/test_read_spec.py
@@ -102,7 +102,7 @@ def test_example_manifest_5cond_parses():
     spec = json.loads((ROOT / "comparison.5cond_1x4.json").read_text())
     rows = list(rs.config_rows(spec))
     assert len(rows) == 5
-    assert all(cards == "standard" for _, cards in rows)
+    assert all(cards == "config,parca,standard" for _, cards in rows)
 
 
 def test_example_manifest_baseline_statistical_parses():

--- a/tests/test_read_spec.py
+++ b/tests/test_read_spec.py
@@ -101,8 +101,9 @@ ROOT = pathlib.Path(__file__).resolve().parent.parent
 def test_example_manifest_5cond_parses():
     spec = json.loads((ROOT / "comparison.5cond_1x4.json").read_text())
     rows = list(rs.config_rows(spec))
-    assert len(rows) == 5
-    assert all(cards == "config,parca,standard" for _, cards in rows)
+    assert len(rows) == 6
+    assert [c for _, c in rows][:5] == ["config,parca,standard"] * 5
+    assert rows[5][1] == "config,parca,statistical"
 
 
 def test_example_manifest_baseline_statistical_parses():

--- a/tests/test_read_spec.py
+++ b/tests/test_read_spec.py
@@ -99,7 +99,7 @@ ROOT = pathlib.Path(__file__).resolve().parent.parent
 
 
 def test_example_manifest_5cond_parses():
-    spec = json.loads((ROOT / "comparison.5cond_1x4.json").read_text())
+    spec = json.loads((ROOT / "comparison.5cond_1x4.json").read_text(encoding="utf-8"))
     rows = list(rs.config_rows(spec))
     assert len(rows) == 6
     assert [c for _, c in rows][:5] == ["config,parca,standard"] * 5
@@ -107,6 +107,6 @@ def test_example_manifest_5cond_parses():
 
 
 def test_example_manifest_baseline_statistical_parses():
-    spec = json.loads((ROOT / "comparison.baseline_4x4_statistical.json").read_text())
+    spec = json.loads((ROOT / "comparison.baseline_4x4_statistical.json").read_text(encoding="utf-8"))
     rows = list(rs.config_rows(spec))
     assert rows == [("configs/cond_basal_4x4.json", "statistical")]

--- a/tests/test_read_spec.py
+++ b/tests/test_read_spec.py
@@ -67,3 +67,27 @@ def test_vecoli_engine_default_and_explicit():
 def test_from_vecoli_config():
     assert rs.from_vecoli_config(FULL) == "configs/default.json"
     assert rs.from_vecoli_config({}) == ""
+
+
+SPEC = {
+    "v2ecoli": {"repo": "r1", "commit": "c1"},
+    "vecoli": {"repo": "r2", "commit": "c2"},
+    "defaults": {"cards": ["standard"]},
+    "configs": [
+        {"config": "configs/cond_basal.json", "cards": ["standard", "statistical"]},
+        {"config": "configs/cond_with_aa.json"},
+    ],
+}
+
+
+def test_config_rows_uses_entry_cards_then_defaults():
+    rows = list(rs.config_rows(SPEC))
+    assert rows == [
+        ("configs/cond_basal.json", "standard,statistical"),
+        ("configs/cond_with_aa.json", "standard"),
+    ]
+
+
+def test_config_rows_defaults_to_standard_when_no_defaults():
+    spec = {"configs": [{"config": "c.json"}]}
+    assert list(rs.config_rows(spec)) == [("c.json", "standard")]

--- a/tests/test_report_cards.py
+++ b/tests/test_report_cards.py
@@ -21,3 +21,21 @@ def _ctx():
     return rc.CardContext(config_name="basal", variant=0, v2_dir="", ve_dir="",
                           seeds=1, gens=1, per_obs={}, plot_trajs={}, v2_bounds={},
                           config={})
+
+
+def test_builtin_cards_registered():
+    for name in ("standard", "statistical"):
+        assert name in rc.all_names()
+
+
+def test_statistical_card_returns_graded_section():
+    ctx = rc.CardContext(config_name="basal", variant=0, v2_dir="", ve_dir="",
+                         seeds=2, gens=1,
+                         per_obs={"cell_mass": [{"ve_mean": 1.0, "v2_mean": 1.0},
+                                                {"ve_mean": 1.1, "v2_mean": 1.05}],
+                                  "growth_rate": [{"ve_mean": 2e-4, "v2_mean": 2e-4},
+                                                  {"ve_mean": 2.1e-4, "v2_mean": 2.05e-4}]},
+                         plot_trajs={}, v2_bounds={}, config={})
+    secs = rc.render("statistical", ctx)
+    assert secs[0]["html"] and secs[0]["verdict"] in (
+        "within_tol", "drift", "mismatch", "ungraded")

--- a/tests/test_report_cards.py
+++ b/tests/test_report_cards.py
@@ -39,3 +39,23 @@ def test_statistical_card_returns_graded_section():
     secs = rc.render("statistical", ctx)
     assert secs[0]["html"] and secs[0]["verdict"] in (
         "within_tol", "drift", "mismatch", "ungraded")
+
+
+def test_assemble_sections_mirrors_manifest(monkeypatch):
+    from scripts import comparison_report_card as crc
+    # one config, cards ["parca","standard"] -> overview + parca + (runs+eval)
+    # per_obs uses the REAL shape build() produces: obs -> list of per-seed dicts
+    # (each a full _matched() stat with init_*/*_mean/median_rel/max_rel).
+    seed_stat = {"seed": 0, "init_t": 0.0, "init_v2": 1.0, "init_ve": 1.0,
+                 "init_rel": 0.0, "v2_mean": 1.0, "ve_mean": 1.0,
+                 "median_rel": 0.0, "max_rel": 0.0, "n": 1}
+    cond_data = {"basal": ({"cell_mass": [seed_stat]}, {}, {})}
+    manifest = {"configs": [{"config": "configs/cond_basal.json",
+                             "cards": ["parca", "standard"]}]}
+    secs = crc.assemble_from_manifest(
+        manifest, cond_data,
+        conds={"basal": ("v2dir", "vedir")},
+        config_names={"configs/cond_basal.json": "basal"})
+    titles = [s["title"] for s in secs]
+    assert titles[0].startswith("Overview")
+    assert any("ParCa" in t or "parca" in t.lower() for t in titles)

--- a/tests/test_report_cards.py
+++ b/tests/test_report_cards.py
@@ -1,0 +1,23 @@
+import pytest
+from scripts._compare import report_cards as rc
+
+
+def test_register_and_get():
+    @rc.report_card("dummy_card_xyz")
+    def _c(ctx):
+        return {"title": "T", "kind": "content", "html": "<p>x</p>", "anchor": "a"}
+    assert "dummy_card_xyz" in rc.all_names()
+    fn = rc.get("dummy_card_xyz")
+    out = rc.render("dummy_card_xyz", _ctx())
+    assert out[0]["title"] == "T" and out[0]["html"]
+
+
+def test_get_unknown_raises():
+    with pytest.raises(KeyError):
+        rc.get("does_not_exist")
+
+
+def _ctx():
+    return rc.CardContext(config_name="basal", variant=0, v2_dir="", ve_dir="",
+                          seeds=1, gens=1, per_obs={}, plot_trajs={}, v2_bounds={},
+                          config={})

--- a/tests/test_report_cards.py
+++ b/tests/test_report_cards.py
@@ -24,7 +24,7 @@ def _ctx():
 
 
 def test_builtin_cards_registered():
-    for name in ("standard", "statistical"):
+    for name in ("standard", "statistical", "parca", "config_diff"):
         assert name in rc.all_names()
 
 


### PR DESCRIPTION
## Modular, config-driven comparison harness + report cards

A single JSON manifest pins repos@commit, lists vEcoli configs, and assigns **modular, registry-based report cards per config**. The report mirrors the manifest: **overview at top, then a section per config** showing its assigned cards. seeds/gens/variants are read **from each vEcoli config** (config = source of truth) — the manifest no longer duplicates them.

Spec: `docs/superpowers/specs/2026-06-27-comparison-harness-modular-cards-design.md`
Plan: `docs/superpowers/plans/2026-06-27-comparison-harness-modular-cards.md`

### Validated end-to-end (report side)
`run_comparison.py comparison.5cond_1x4.json --out out/report` (or `comparison_report_card.py --manifest …`) renders the modular report. Verified against the existing 4×4×5 zarr stores: **6 sections** — basal / with_aa / succinate / no_oxygen / acetate (1×4) + **basal_4x4** — each showing:
- **`<name> — config`**: the actual vEcoli config (condition, seeds=`n_init_sims`, gens=`generations`, …) **plus the full JSON config in a browsable collapsible viewer** (default);
- **`<name> — ParCa / initial-state match`** (per-section);
- the assigned run card — `standard` (matched-time eval) or `statistical` (Chris Long's graded card: violin/strip + `<details>` dropdown + within_tol/drift/mismatch pills), reused from his on-main `report_card.py`/`card_criteria.py`/`card_plots.py`.

A manifest `name` override disambiguates configs that share a condition (e.g. `basal_1x4` vs `basal_4x4`) into distinct sections.

### What's here
- Manifest schema + `configs` parse mode (`_read_spec.py`); `config_run_shape()` reads seeds/gens from a config.
- Report-card registry (`scripts/_compare/report_cards/`): `CardContext` + `@report_card`; cards `config`, `standard`, `statistical`, `parca`, `config_diff`.
- Manifest-driven assembly (`assemble_from_manifest` + `--manifest`); `--only` no longer filters manifest mode.
- Run orchestrator `scripts/run_comparison.py` (reads a manifest, runs both engines per config, renders; `--render-only` assembles from existing stores).
- Example manifests + in-repo inherit-override configs (`cond_*_1x4.json`, `cond_basal_4x4.json`); canonical `comparison_spec.json` on the new schema.
- 24 unit tests green; 855 collect clean. Every task was subagent-reviewed clean.

### Follow-ups (not blocking review)
- A full **live-sim** smoke through `run_comparison.py` (the report side is end-to-end validated; the run side mirrors the proven `run_local_4x4x5.sh` wiring but hasn't run live yet).
- Retire the legacy `conditions` mode in `comparison_harness.sh` + `_read_spec`.
- **Plan B**: full variant-matrix execution (this PR is single-variant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
