### PR TITLE
Report cards as process-bigraph as_step Steps

### DIFF
--- a/docs/superpowers/plans/2026-06-28-report-cards-as-steps.md
+++ b/docs/superpowers/plans/2026-06-28-report-cards-as-steps.md
@@ -1,0 +1,643 @@
+# Report cards as `as_step` types — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Make each report card a process-bigraph `@as_step` Step registered in the bigraph-schema core, replacing the bespoke `@report_card` registry; the harness resolves cards via `core.access` and invokes `update(state)`.
+
+**Architecture:** Convert the 5 card functions to `update_<card>_report_card(state)` decorated with `as_step(inputs, outputs)`; collect them into `REPORT_CARD_STEPS = {name: StepCls}`; register via `core.register_links` in `build_core`. The harness builds a typed `state` from the study's comparison data, calls `step.update(state)` → `{card_html, verdict, axes}`, and writes `viz/report_card/`. Pure Steps; dashboard + contract unchanged.
+
+**Tech Stack:** Python 3, process-bigraph (`as_step`, already a dep), bigraph-schema core, pytest.
+
+**Repo:** `/Users/eranagmon/code/v2e-main` (branch `feat/report-cards-as-steps`). Run tests via `.venv/bin/python -m pytest`.
+
+**Spec:** `docs/superpowers/specs/2026-06-28-report-cards-as-steps-design.md`
+
+## Global Constraints
+
+- `as_step(inputs, outputs, name=None, aliases=None)` from `process_bigraph.composite`; the decorated function MUST be named `update_*`; it returns a dict matching `outputs`. The result is a `Step` subclass.
+- Card Step name = `<card>_report_card` (e.g. `standard_report_card`), alias = `<card>` (e.g. `standard`). The 5 cards: `config`, `parca`, `standard`, `statistical`, `config_diff`.
+- Outputs of every card: `{card_html: str, verdict: str, axes: list}` — `verdict` ∈ {within_tol, drift, mismatch, ungraded}; `config`/`config_diff` output `verdict="ungraded"`, `axes=[]`.
+- Registration: `core.register_links(REPORT_CARD_STEPS)` in `v2ecoli/core.py::build_core`; resolution `core.access("<card>_report_card")`.
+- The Step is pure (returns outputs); the harness writes `viz/report_card/<card>.{html,verdict.json}` and the per-condition verdict. Verdict VALUES must be identical to today for the same input.
+- All reads/writes `encoding="utf-8"`. Run via the repo `.venv`. Never auto-merge.
+
+---
+
+### Task 1: Pin the schemas + as_step/core round-trip + `_sections_to_html`
+
+**Files:**
+- Modify: `scripts/_compare/report_cards/__init__.py`
+- Test: `tests/test_report_card_steps.py` (create)
+
+**Interfaces:**
+- Produces: `CARD_INPUTS` / `CARD_OUTPUTS` (validated bigraph-schema dicts); `_sections_to_html(sections) -> str`; `REPORT_CARD_STEPS: dict[str, type]` (empty for now). These are additive — the existing `@report_card`/`REGISTRY`/`render`/`CardContext` stay until Task 5.
+
+- [ ] **Step 1: Confirm the bigraph type syntax for the loose inputs**
+
+Run (pin the exact strings the rest of the plan uses):
+```
+.venv/bin/python -c "
+from v2ecoli.core import build_core
+c = build_core()
+for t in ['string','integer','tree[any]','list[float]','overwrite[string]','overwrite[list[tree[any]]]','map']:
+    try: c.access(t); print('OK ', t)
+    except Exception as e: print('BAD', t, type(e).__name__)
+"
+```
+Expected: `string`, `integer`, `tree[any]`, `list[float]`, `overwrite[string]` resolve. If `tree[any]`/`map`/`overwrite[list[tree[any]]]` print `BAD`, fall back to the simplest resolving form (`tree[any]` for nested, `tree[any]` for the axes output) and use THOSE strings verbatim in every later task. Record the chosen strings in the task report.
+
+- [ ] **Step 2: Write the failing test**
+
+```python
+# tests/test_report_card_steps.py
+from process_bigraph.composite import as_step
+from v2ecoli.core import build_core
+from scripts._compare.report_cards import _sections_to_html, CARD_INPUTS, CARD_OUTPUTS
+
+
+def test_sections_to_html_renders_html_and_rows():
+    html = _sections_to_html([
+        {"title": "A", "html": "<b>hi</b>"},
+        {"title": "B", "rows": [{"label": "x", "left": "1", "right": "2",
+                                 "verdict": "within_tol", "reason": "ok"}]},
+    ])
+    assert html.lstrip().startswith("<")
+    assert "<b>hi</b>" in html and "A" in html
+    assert "x" in html and "within_tol" in html        # rows rendered as a table
+
+
+def test_as_step_card_round_trips_through_core():
+    @as_step(inputs=CARD_INPUTS, outputs=CARD_OUTPUTS, name="probe_report_card",
+             aliases=["probe"])
+    def update_probe_report_card(state):
+        return {"card_html": f"<p>{state['name']}</p>", "verdict": "within_tol", "axes": []}
+    core = build_core()
+    core.register_link("probe_report_card", update_probe_report_card)
+    step = core.access("probe_report_card")(config={}, core=core)
+    out = step.update({"name": "basal", "condition": "basal", "seeds": 1,
+                       "generations": 4, "variant": 0, "observables": {},
+                       "plot_trajs": {}, "v2_bounds": [], "config": {},
+                       "v2_dir": "", "ve_dir": ""})
+    assert out["verdict"] == "within_tol" and "basal" in out["card_html"]
+```
+
+- [ ] **Step 3: Run it — expect FAIL** (`ImportError: CARD_INPUTS`)
+
+Run: `.venv/bin/python -m pytest tests/test_report_card_steps.py -q`
+
+- [ ] **Step 4: Add the schemas + helper to `__init__.py`**
+
+Insert near the top (after `Section = dict`), using the strings PINNED in Step 1 (shown here with the expected defaults):
+
+```python
+import html as _html
+
+# Typed contract for a report-card Step. Pragmatic: structural fields typed;
+# the per-seed stat records under `observables` stay loose. Strings pinned in
+# Task 1 Step 1 — substitute the validated forms if any printed BAD.
+CARD_INPUTS = {
+    "name": "string", "condition": "string",
+    "seeds": "integer", "generations": "integer", "variant": "integer",
+    "observables": "tree[any]", "plot_trajs": "tree[any]",
+    "v2_bounds": "list[float]", "config": "tree[any]",
+    "v2_dir": "string", "ve_dir": "string",
+}
+CARD_OUTPUTS = {
+    "card_html": "overwrite[string]",
+    "verdict": "overwrite[string]",
+    "axes": "overwrite[tree[any]]",
+}
+
+REPORT_CARD_STEPS: dict[str, type] = {}   # {name: StepCls}; populated by the card modules
+
+
+def _row_table(rows: list) -> str:
+    cells = []
+    for r in rows:
+        label = _html.escape(str(r.get("label", "")))
+        left = _html.escape(str(r.get("left", "")))
+        right = _html.escape(str(r.get("right", "")))
+        verdict = _html.escape(str(r.get("verdict", "")))
+        reason = _html.escape(str(r.get("reason", "")))
+        cells.append(
+            f'<tr><td style="padding:2px 10px">{label}</td>'
+            f'<td style="padding:2px 10px">{left}</td>'
+            f'<td style="padding:2px 10px">{right}</td>'
+            f'<td style="padding:2px 10px">{verdict}</td>'
+            f'<td style="padding:2px 10px;color:#6b7280">{reason}</td></tr>')
+    return ('<table style="border-collapse:collapse;font-size:13px">'
+            '<thead><tr style="text-align:left">'
+            '<th style="padding:2px 10px">observable</th><th>vEcoli</th>'
+            '<th>v2ecoli</th><th>verdict</th><th>note</th></tr></thead><tbody>'
+            + "".join(cells) + "</tbody></table>')
+
+
+def _sections_to_html(sections: list) -> str:
+    """Render a card's section dicts into one HTML fragment. A section with an
+    `html` field is emitted as-is; a section with `rows` is rendered as a
+    table (eval_section / parca_section produce rows)."""
+    parts = []
+    for sec in sections:
+        if sec.get("title"):
+            parts.append(f'<h3 style="margin:14px 0 6px">{_html.escape(str(sec["title"]))}</h3>')
+        if sec.get("desc"):
+            parts.append(f'<p style="color:#6b7280;font-size:12px">{_html.escape(str(sec["desc"]))}</p>')
+        if sec.get("html"):
+            parts.append(sec["html"])
+        elif sec.get("rows"):
+            parts.append(_row_table(sec["rows"]))
+    return "".join(parts)
+```
+
+- [ ] **Step 5: Run it — expect PASS**
+
+Run: `.venv/bin/python -m pytest tests/test_report_card_steps.py -q`
+Expected: PASS (2 passed).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/_compare/report_cards/__init__.py tests/test_report_card_steps.py
+git commit -m "feat(report-cards): pin Step schemas + _sections_to_html + core round-trip"
+```
+
+---
+
+### Task 2: Convert `standard` + `parca` to `as_step` (rows-based graded cards)
+
+**Files:**
+- Modify: `scripts/_compare/report_cards/standard.py`, `scripts/_compare/report_cards/parca.py`
+- Test: `tests/test_report_card_steps.py` (extend)
+
+**Interfaces:**
+- Consumes: `CARD_INPUTS`, `CARD_OUTPUTS`, `_sections_to_html`, `REPORT_CARD_STEPS`, `worst`.
+- Produces: `update_standard_report_card`/`update_parca_report_card` Step classes registered in `REPORT_CARD_STEPS`. KEEP the existing `@report_card` wrapper in each (dual-registered, transitional — removed in Task 5) so `assemble_from_studies` + the old tests stay green.
+
+- [ ] **Step 1: Write the failing test** (extend `tests/test_report_card_steps.py`)
+
+```python
+def _state(per_obs, name="basal", seeds=1, gens=4, variant=0, config=None):
+    return {"name": name, "condition": "basal", "seeds": seeds, "generations": gens,
+            "variant": variant, "observables": per_obs, "plot_trajs": {},
+            "v2_bounds": [], "config": config or {}, "v2_dir": "", "ve_dir": ""}
+
+
+# 5 seeds so the t-test / median have data; one within-tol observable.
+_PO = {"rna_mass": [{"median_rel": 0.02, "max_rel": 0.05, "init_ve": 100.0,
+                     "init_v2": 101.0, "init_t": 60.0, "ve_mean": 100.0, "v2_mean": 101.0}
+                    for _ in range(5)]}
+
+
+def _run_card(name, state):
+    from v2ecoli.core import build_core
+    from scripts._compare.report_cards import REPORT_CARD_STEPS
+    core = build_core(); core.register_links(REPORT_CARD_STEPS)
+    step = core.access(f"{name}_report_card")(config={}, core=core)
+    return step.update(state)
+
+
+def test_standard_step_grades_and_renders():
+    out = _run_card("standard", _state(_PO))
+    assert out["verdict"] in {"within_tol", "drift", "mismatch", "ungraded"}
+    assert any(a["id"].startswith("standard.") for a in out["axes"])
+    assert "<" in out["card_html"]
+
+
+def test_parca_step_grades_initial_state():
+    out = _run_card("parca", _state(_PO))
+    assert out["verdict"] == "within_tol"
+    assert any(a["id"].startswith("parca.") for a in out["axes"])
+```
+
+- [ ] **Step 2: Run it — expect FAIL** (`standard_report_card` not registered)
+
+Run: `.venv/bin/python -m pytest tests/test_report_card_steps.py::test_standard_step_grades_and_renders -q`
+
+- [ ] **Step 3: Rewrite `standard.py`** (add the Step + register; keep the old wrapper)
+
+```python
+"""`standard` card — matched-time runs + per-observable evaluation. as_step Step;
+the harness invokes it via core.access('standard_report_card')."""
+from __future__ import annotations
+
+from process_bigraph.composite import as_step
+
+from scripts._compare.report_cards import (
+    report_card, CardContext, Section, CARD_INPUTS, CARD_OUTPUTS,
+    _sections_to_html, REPORT_CARD_STEPS)
+from scripts._compare.verdict import worst
+
+
+def _standard_sections_and_axes(name, per_obs, plot_trajs, v2_bounds):
+    from scripts.comparison_report_card import runs_section, eval_section
+    runs = runs_section(name, per_obs, plot_trajs, v2_bounds)
+    ev = eval_section(name, per_obs)
+    axes = []
+    for row in ev.get("rows", []):
+        v = row.get("verdict", "ungraded")
+        if v == "not_compared":
+            v = "ungraded"
+        axes.append({"id": f"standard.{row.get('label', '')}", "label": row.get("label", ""),
+                     "verdict": v, "value": row.get("median_rel"),
+                     "meter": row.get("reason", ""),
+                     "detail": {"median_rel": row.get("median_rel"),
+                                "max_rel": row.get("max_rel")}})
+    return [runs, ev], axes
+
+
+@as_step(inputs=CARD_INPUTS, outputs=CARD_OUTPUTS, name="standard_report_card",
+         aliases=["standard"])
+def update_standard_report_card(state):
+    sections, axes = _standard_sections_and_axes(
+        state["name"], state["observables"], state["plot_trajs"], state["v2_bounds"])
+    return {"card_html": _sections_to_html(sections),
+            "verdict": worst(a["verdict"] for a in axes), "axes": axes}
+
+
+REPORT_CARD_STEPS["standard_report_card"] = update_standard_report_card
+
+
+# --- transitional: keep the old registry wrapper until the Task 5 cutover ---
+@report_card("standard")
+def standard_card(ctx: CardContext) -> list[Section]:
+    sections, axes = _standard_sections_and_axes(
+        ctx.config_name, ctx.per_obs, ctx.plot_trajs, ctx.v2_bounds)
+    ev = sections[1]
+    ev["verdict"] = worst(a["verdict"] for a in axes)
+    ev["verdict_axes"] = axes
+    return sections
+```
+
+- [ ] **Step 4: Rewrite `parca.py`** (add the Step; keep the old wrapper)
+
+```python
+"""`parca` card — ParCa / initial-state match, graded on per-mass t~0 |Δ|.
+as_step Step invoked via core.access('parca_report_card')."""
+from __future__ import annotations
+
+from process_bigraph.composite import as_step
+
+from scripts._compare.report_cards import (
+    report_card, CardContext, Section, CARD_INPUTS, CARD_OUTPUTS,
+    _sections_to_html, REPORT_CARD_STEPS)
+from scripts._compare.verdict import worst
+
+
+def _parca_section_and_axes(name, per_obs, plot_trajs, v2_bounds):
+    from scripts.comparison_report_card import parca_section
+    sec = parca_section({name: (per_obs, plot_trajs, v2_bounds)})
+    sec["anchor"] = f"{name}-parca"
+    sec["title"] = f"{name} — ParCa / initial-state match"
+    axes = []
+    for row in sec.get("rows", []):
+        if "median_rel" not in row:
+            continue
+        v = row.get("verdict", "ungraded")
+        if v == "not_compared":
+            v = "ungraded"
+        axes.append({"id": f"parca.{row['label']}", "label": row["label"], "verdict": v,
+                     "value": row.get("median_rel"), "meter": row.get("reason", ""),
+                     "detail": {"init_rel": row.get("median_rel")}})
+    return sec, axes
+
+
+@as_step(inputs=CARD_INPUTS, outputs=CARD_OUTPUTS, name="parca_report_card",
+         aliases=["parca"])
+def update_parca_report_card(state):
+    sec, axes = _parca_section_and_axes(
+        state["name"], state["observables"], state["plot_trajs"], state["v2_bounds"])
+    return {"card_html": _sections_to_html([sec]),
+            "verdict": worst(a["verdict"] for a in axes), "axes": axes}
+
+
+REPORT_CARD_STEPS["parca_report_card"] = update_parca_report_card
+
+
+@report_card("parca")
+def parca_card(ctx: CardContext) -> Section:
+    sec, axes = _parca_section_and_axes(
+        ctx.config_name, ctx.per_obs, ctx.plot_trajs, ctx.v2_bounds)
+    sec["verdict"] = worst(a["verdict"] for a in axes)
+    sec["verdict_axes"] = axes
+    return sec
+```
+
+- [ ] **Step 5: Run the new + existing card tests**
+
+Run: `.venv/bin/python -m pytest tests/test_report_card_steps.py tests/test_card_verdicts.py -q`
+Expected: PASS (the Step tests + the old-wrapper tests both green — dual registration).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/_compare/report_cards/standard.py scripts/_compare/report_cards/parca.py tests/test_report_card_steps.py
+git commit -m "feat(report-cards): standard + parca as_step Steps (dual-registered)"
+```
+
+---
+
+### Task 3: Convert `statistical` + `config` + `config_diff` to `as_step`
+
+**Files:**
+- Modify: `scripts/_compare/report_cards/statistical.py`, `config.py`, `config_diff.py`
+- Test: `tests/test_report_card_steps.py` (extend)
+
+**Interfaces:**
+- Consumes: the Task 1 schemas/helpers; `REPORT_CARD_STEPS`.
+- Produces: `update_statistical_report_card`, `update_config_report_card`, `update_config_diff_report_card` Steps in `REPORT_CARD_STEPS`; old `@report_card` wrappers kept (transitional).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_statistical_step_grades():
+    out = _run_card("statistical", _state(_PO, name="statistical", seeds=4))
+    assert out["verdict"] == "within_tol"
+    assert out["axes"]
+
+
+def test_config_step_is_ungraded_and_renders_config():
+    out = _run_card("config", _state({}, name="basal", config={"condition": "basal"}))
+    assert out["verdict"] == "ungraded" and out["axes"] == []
+    assert "basal" in out["card_html"]
+```
+
+- [ ] **Step 2: Run it — expect FAIL**
+
+Run: `.venv/bin/python -m pytest tests/test_report_card_steps.py::test_statistical_step_grades -q`
+
+- [ ] **Step 3: Rewrite `statistical.py`**
+
+```python
+"""`statistical` card — graded equivalence (violin/strip). as_step Step."""
+from __future__ import annotations
+
+from process_bigraph.composite import as_step
+
+from scripts._compare.report_cards import (
+    report_card, CardContext, Section, CARD_INPUTS, CARD_OUTPUTS, REPORT_CARD_STEPS)
+from scripts._compare.report_card_section import build_report_card
+
+
+def _statistical_html_axes(name, per_obs, variant):
+    from scripts.comparison_report_card import OBSERVABLES, CARD_KEY, EXTRA_AXES, TOL
+    left, right = {}, {}
+    for obs in OBSERVABLES:
+        ck = CARD_KEY.get(obs, obs)
+        left[ck] = [s["ve_mean"] for s in per_obs.get(obs, [])]
+        right[ck] = [s["v2_mean"] for s in per_obs.get(obs, [])]
+    vjson, html = build_report_card(left, right, extra_axes=EXTRA_AXES,
+                                    model_ref=f"v2ecoli @ {name} variant {variant}", tol_rel=TOL)
+    axes = [ax for g in (vjson.get("groups") or {}).values() for ax in (g.get("axes") or [])]
+    return html, vjson.get("overall"), axes
+
+
+@as_step(inputs=CARD_INPUTS, outputs=CARD_OUTPUTS, name="statistical_report_card",
+         aliases=["statistical"])
+def update_statistical_report_card(state):
+    html, verdict, axes = _statistical_html_axes(
+        state["name"], state["observables"], state["variant"])
+    return {"card_html": html, "verdict": verdict or "ungraded", "axes": axes}
+
+
+REPORT_CARD_STEPS["statistical_report_card"] = update_statistical_report_card
+
+
+@report_card("statistical")
+def statistical_card(ctx: CardContext) -> Section:
+    html, verdict, axes = _statistical_html_axes(ctx.config_name, ctx.per_obs, ctx.variant)
+    return {"title": f"{ctx.config_name} — statistical equivalence", "kind": "content",
+            "anchor": f"{ctx.config_name}-statistical", "html": html,
+            "verdict": verdict, "verdict_axes": axes}
+```
+
+- [ ] **Step 4: Rewrite `config.py`** — wrap the existing body in `_config_html(name, seeds, gens, config)`, then:
+
+Keep the existing rendering logic but move it into a helper `_config_html(name, seeds, gens, config) -> str` (replace every `ctx.config_name`→`name`, `ctx.seeds`→`seeds`, `ctx.gens`→`gens`, `ctx.config`→`config`). Then add:
+
+```python
+from process_bigraph.composite import as_step
+from scripts._compare.report_cards import CARD_INPUTS, CARD_OUTPUTS, REPORT_CARD_STEPS
+
+@as_step(inputs=CARD_INPUTS, outputs=CARD_OUTPUTS, name="config_report_card",
+         aliases=["config"])
+def update_config_report_card(state):
+    return {"card_html": _config_html(state["name"], state["seeds"],
+                                      state["generations"], state["config"]),
+            "verdict": "ungraded", "axes": []}
+
+REPORT_CARD_STEPS["config_report_card"] = update_config_report_card
+
+
+@report_card("config")
+def config_card(ctx: CardContext) -> Section:
+    return {"title": f"{ctx.config_name} — config", "kind": "content",
+            "anchor": f"{ctx.config_name}-config",
+            "html": _config_html(ctx.config_name, ctx.seeds, ctx.gens, ctx.config),
+            "verdict": None}
+```
+
+- [ ] **Step 5: Rewrite `config_diff.py`**
+
+```python
+"""`config_diff` card — vEcoli vs v2ecoli config comparison (S3/Nextflow). as_step Step."""
+from __future__ import annotations
+
+from process_bigraph.composite import as_step
+
+from scripts._compare.report_cards import (
+    report_card, CardContext, Section, CARD_INPUTS, CARD_OUTPUTS,
+    _sections_to_html, REPORT_CARD_STEPS)
+
+
+@as_step(inputs=CARD_INPUTS, outputs=CARD_OUTPUTS, name="config_diff_report_card",
+         aliases=["config_diff"])
+def update_config_diff_report_card(state):
+    from scripts.comparison_report_card import config_sections_for
+    secs = config_sections_for(state["name"], state["v2_dir"], state["ve_dir"])
+    return {"card_html": _sections_to_html(secs), "verdict": "ungraded", "axes": []}
+
+
+REPORT_CARD_STEPS["config_diff_report_card"] = update_config_diff_report_card
+
+
+@report_card("config_diff")
+def config_diff_card(ctx: CardContext) -> list[Section]:
+    from scripts.comparison_report_card import config_sections_for
+    return config_sections_for(ctx.config_name, ctx.v2_dir, ctx.ve_dir)
+```
+
+- [ ] **Step 6: Run the card tests**
+
+Run: `.venv/bin/python -m pytest tests/test_report_card_steps.py tests/test_card_verdicts.py -q`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add scripts/_compare/report_cards/statistical.py scripts/_compare/report_cards/config.py scripts/_compare/report_cards/config_diff.py tests/test_report_card_steps.py
+git commit -m "feat(report-cards): statistical + config + config_diff as_step Steps (dual)"
+```
+
+---
+
+### Task 4: Cutover — register in `build_core`; `assemble_from_studies` + `viz_cards` use the Steps
+
+**Files:**
+- Modify: `v2ecoli/core.py` (build_core), `scripts/comparison_report_card.py` (`assemble_from_studies`), `scripts/_compare/viz_cards.py`
+- Test: `tests/test_assemble_studies.py`, `tests/test_viz_cards.py` (adapt)
+
+**Interfaces:**
+- Consumes: `REPORT_CARD_STEPS`; `core.access`.
+- Produces: `assemble_from_studies` resolves cards via the core and calls `update(state)`; `viz_cards.write_report_cards` takes `html` per card.
+
+- [ ] **Step 1: Register the card Steps in `build_core`** — in `v2ecoli/core.py::build_core`, after the emitter `register_link` block, add:
+
+```python
+    # Report-card Steps (resolved by name in the comparison harness).
+    try:
+        from scripts._compare.report_cards import REPORT_CARD_STEPS
+        core.register_links(REPORT_CARD_STEPS)
+    except Exception:  # noqa: BLE001 — never let card registration break build_core
+        pass
+```
+
+- [ ] **Step 2: Update `viz_cards.write_report_cards`** to take pre-rendered `html`
+
+Change `_card_html` usage: the card item now carries `html` (not `sections`). Replace the body's html line:
+
+```python
+        hp.write_text(card.get("html") or "", encoding="utf-8")
+```
+and delete the now-unused `_card_html`/`_DOC` helpers and the `html as _html` import if unused. Update the existing `tests/test_viz_cards.py` to pass `{"name", "html", "verdict", "axes"}` (replace `sections` with `html`) and assert the `html` is written verbatim.
+
+- [ ] **Step 3: Update the failing test** `tests/test_assemble_studies.py::test_assemble_from_studies_writes_viz_cards` — replace the `rc.render` monkeypatch with a core-resolved stub. The new assemble resolves `core.access`; monkeypatch `build_core` to a fake core whose `access(name)` returns a stub Step class with `update` returning `{"card_html": "<b>card</b>", "verdict": "drift", "axes": [{"id": "x", "verdict": "drift"}]}`:
+
+```python
+def test_assemble_from_studies_writes_viz_cards(tmp_path, monkeypatch):
+    import scripts.comparison_report_card as crc
+    monkeypatch.setattr(crc, "overview_section",
+                        lambda cond_data: {"title": "o", "kind": "content", "html": ""})
+
+    class _Stub:
+        def __init__(self, *a, **k): pass
+        def update(self, state):
+            return {"card_html": "<b>card</b>", "verdict": "drift",
+                    "axes": [{"id": "x", "verdict": "drift"}]}
+
+    class _Core:
+        def access(self, name): return _Stub
+        def register_links(self, d): pass
+    monkeypatch.setattr(crc, "build_core", lambda: _Core())
+    spec = _spec("basal", "basal", ["standard"])
+    crc.assemble_from_studies([spec], {"basal": ({}, {}, [])},
+                              {"basal": ("v2", "ve")}, verdict_root=str(tmp_path / "vr"),
+                              studies_root=str(tmp_path / "ws/investigations"))
+    card = (tmp_path / "ws/investigations/v2ecoli-vecoli-comparison/studies/basal"
+            / "viz/report_card/standard.html")
+    assert card.is_file() and "<b>card</b>" in card.read_text(encoding="utf-8")
+    import json
+    assert json.loads(card.with_name("standard.verdict.json").read_text())["overall"] == "drift"
+```
+
+- [ ] **Step 4: Run it — expect FAIL** (assemble still calls `rc.render`)
+
+Run: `.venv/bin/python -m pytest tests/test_assemble_studies.py::test_assemble_from_studies_writes_viz_cards -q`
+
+- [ ] **Step 5: Switch `assemble_from_studies` to core invocation**
+
+In `scripts/comparison_report_card.py`: add `from v2ecoli.core import build_core` at the top of the function (lazy, mirrors existing lazy imports). Replace the per-card loop body so it resolves + updates Steps and collects `html`:
+
+```python
+def assemble_from_studies(specs, cond_data, conds, verdict_root=None,
+                          studies_root="workspace/investigations"):
+    from scripts._compare.verdict import write_condition_verdict
+    from scripts._compare.viz_cards import write_report_cards
+    from v2ecoli.core import build_core
+    core = build_core()
+    if verdict_root is None and specs:
+        verdict_root = f"docs/report_cards/{specs[0].invest_name}"
+    overview = overview_section(cond_data); overview["nav_group"] = "Overall"
+    sections = [overview]
+    for spec in specs:
+        name = spec.name
+        if name not in cond_data:
+            print(f"[assemble] skip study {name!r}: no store under --out", flush=True)
+            continue
+        per_obs, plot_trajs, v2_bounds = cond_data[name]
+        v2_dir, ve_dir = conds.get(name, ("", ""))
+        state = {"name": name, "condition": spec.condition, "seeds": spec.seeds,
+                 "generations": spec.gens, "variant": 0, "observables": per_obs,
+                 "plot_trajs": plot_trajs, "v2_bounds": v2_bounds,
+                 "config": {"condition": spec.condition, "seeds": spec.seeds,
+                            "generations": spec.gens, "cards": spec.cards},
+                 "v2_dir": v2_dir, "ve_dir": ve_dir}
+        card_verdicts, viz = {}, []
+        for card in spec.cards:
+            step = core.access(f"{card}_report_card")(config={}, core=core)
+            out = step.update(state)
+            sections.append({"title": f"{name} — {card}", "kind": "content",
+                             "html": out["card_html"], "nav_group": name})
+            card_verdicts[card] = {"verdict": out.get("verdict", "ungraded"),
+                                   "axes": out.get("axes") or []}
+            viz.append({"name": card, "html": out["card_html"],
+                        "verdict": card_verdicts[card]["verdict"],
+                        "axes": card_verdicts[card]["axes"]})
+        if verdict_root:
+            write_condition_verdict(verdict_root, name, card_verdicts)
+        if studies_root:
+            write_report_cards(Path(studies_root) / spec.invest_name / "studies" / name, viz)
+    return sections
+```
+
+- [ ] **Step 6: Run the affected tests**
+
+Run: `.venv/bin/python -m pytest tests/test_assemble_studies.py tests/test_viz_cards.py -q`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add v2ecoli/core.py scripts/comparison_report_card.py scripts/_compare/viz_cards.py tests/test_assemble_studies.py tests/test_viz_cards.py
+git commit -m "feat(report-cards): cutover assemble + build_core to as_step card Steps"
+```
+
+---
+
+### Task 5: Remove the old registry + final verification
+
+**Files:**
+- Modify: `scripts/_compare/report_cards/__init__.py` + the 5 card modules (drop the transitional wrappers)
+- Test: `tests/test_card_verdicts.py` (port to the Step interface), full suite
+
+**Interfaces:**
+- Consumes: the as_step Steps (Tasks 2–3) + the cutover (Task 4).
+
+- [ ] **Step 1: Port `tests/test_card_verdicts.py` to the Step interface** — replace the `from ... import CardContext, render` + `render(name, ctx)` usages with the `_run_card(name, state)` helper pattern from `tests/test_report_card_steps.py` (move `_run_card`/`_state` into a shared `tests/_card_helpers.py` or duplicate). Assert the same verdict vocabularies/values. Delete assertions that referenced `CardContext`/`render` directly.
+
+- [ ] **Step 2: Remove the old registry from `__init__.py`** — delete `CardContext`, `Card`, `REGISTRY`, `report_card`, `get`, `all_names`, `render`, and the bottom card-module imports' reliance on them. Keep `Section`, `CARD_INPUTS`, `CARD_OUTPUTS`, `REPORT_CARD_STEPS`, `_sections_to_html`, `_row_table`, and the card-module imports (so importing the package populates `REPORT_CARD_STEPS`):
+
+```python
+from scripts._compare.report_cards import standard, statistical  # noqa: E402,F401
+from scripts._compare.report_cards import parca, config_diff, config  # noqa: E402,F401
+```
+
+- [ ] **Step 3: Drop the transitional `@report_card` wrappers** from all 5 card modules (the second function in each), and their `report_card, CardContext, Section` imports. Each module keeps only its `_*` helper + `update_*` + the `REPORT_CARD_STEPS[...] =` line.
+
+- [ ] **Step 4: Run the FULL comparison suite**
+
+Run: `.venv/bin/python -m pytest tests/test_report_card_steps.py tests/test_card_verdicts.py tests/test_assemble_studies.py tests/test_viz_cards.py tests/test_comparison_verdict.py tests/test_study_spec.py tests/test_materialize.py tests/test_compare_cli.py tests/test_modular_tests_integration.py -q`
+Expected: all PASS, output pristine. Grep that nothing still imports the removed names:
+`grep -rn "@report_card\|CardContext\|report_cards.render\|REGISTRY" scripts/ tests/ | grep -v REPORT_CARD_STEPS` → expect no live references.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/_compare/report_cards tests/
+git commit -m "refactor(report-cards): remove the bespoke @report_card registry (as_step only)"
+```
+
+## Self-Review
+
+- **Spec coverage:** as_step Steps + typed schemas (Task 1); 5 cards converted (Tasks 2–3); `core.register_links` in build_core + harness `core.access`/`update` + viz html (Task 4); old registry removed (Task 5). Pure Steps + harness-writes preserved; dashboard/contract untouched.
+- **Placeholder scan:** none — complete code per step; the one conditional (Task 1 Step 1 pinning the type strings) is an explicit validate-and-substitute, with the fallback named.
+- **Type consistency:** `state` keys (`name`/`condition`/`seeds`/`generations`/`variant`/`observables`/`plot_trajs`/`v2_bounds`/`config`/`v2_dir`/`ve_dir`) identical across the schema (Task 1), every card's `update_*` (Tasks 2–3), and the assemble state dict (Task 4). Step output `{card_html, verdict, axes}` identical across cards, viz_cards, and assemble. Names `<card>_report_card` consistent in registration + `core.access`.

--- a/docs/superpowers/specs/2026-06-28-report-cards-as-steps-design.md
+++ b/docs/superpowers/specs/2026-06-28-report-cards-as-steps-design.md
@@ -1,0 +1,177 @@
+# Report cards as process-bigraph `as_step` types — Design
+
+**Status:** spec (approved in brainstorm 2026-06-28). v2ecoli-only. Supersedes the
+bespoke `@report_card` registry (merged in #303/#305) and the proposed
+"extract the registry to pbg-superpowers" path — both are replaced by making
+report cards first-class process-bigraph **Steps** registered in the
+bigraph-schema **core**.
+
+## Goal
+
+Make each report card a proper process-bigraph type: an `@as_step`-decorated
+Step with a typed `inputs`/`outputs` interface, registered in the core, resolved
+by name. This replaces the bespoke `@report_card`/`REGISTRY`/`render`/`CardContext`
+machinery. The shareable infrastructure becomes process-bigraph itself
+(`as_step` + the core) — any project whose `build_core` registers the card Steps
+gets them; nothing bespoke to extract.
+
+## Decisions (brainstorm 2026-06-28)
+
+1. **Execution model: typed Step, harness-invoked.** The card is an `as_step`
+   Step (typed I/O, core-registered), but the harness orchestrates: it loads the
+   v2ecoli+vEcoli zarr → builds the comparison data, resolves the card via
+   `core.access`, instantiates it, and calls `update(state)`. Not a full analysis
+   composite (can be wired into one later); not the v2ecoli `Analysis` framework.
+2. **Inputs: pragmatically typed.** Type the structural contract
+   (`condition`/`seeds`/`generations`/`variant` scalars, `observables` as a
+   tree of per-seed stat records) but leave each per-seed stat record a loose
+   `map`/`tree[float]` — meaningful, introspectable, not brittle.
+3. **Migration: full replacement.** Convert all 5 cards to `as_step`; drop
+   `REGISTRY`/`@report_card`/`render`/`get`/`all_names`/`CardContext`; the harness
+   resolves cards via the core.
+4. **Pure Step.** `update()` returns `{card_html, verdict, axes}`; the *harness*
+   writes them to `viz/report_card/<card>.{html,verdict.json}` and aggregates the
+   per-condition verdict. The dashboard + the `viz/report_card` contract are
+   unchanged.
+5. **No pbg-superpowers change.** `as_step` is in process-bigraph (already a
+   dep); registration is explicit `core.register_link` in `build_core` (the
+   mechanism v2ecoli already uses for emitters/`ShapeStep`/`KetchupEstimator`).
+   `discover_packages` is NOT used here.
+
+## The card Step
+
+Each card module (`config`, `parca`, `standard`, `statistical`, `config_diff`)
+becomes an `update_<name>_report_card(state)` function decorated with `as_step`:
+
+```python
+from process_bigraph.composite import as_step
+
+@as_step(
+    inputs={
+        "condition": "string", "seeds": "integer", "generations": "integer",
+        "variant": "integer",
+        "observables": "tree[list[map]]",   # observable -> [per-seed stat record] (loose map)
+        "plot_trajs": "tree[any]", "v2_bounds": "list[float]", "config": "tree[any]",
+    },
+    outputs={
+        "card_html": "overwrite[string]",
+        "verdict": "overwrite[string]",          # within_tol|drift|mismatch|ungraded
+        "axes": "overwrite[list[tree[any]]]",    # the verdict_axes (id/label/verdict/value/meter/detail)
+    },
+    name="standard_report_card", aliases=["standard"],
+)
+def update_standard_report_card(state):
+    # the existing standard-card logic, reading from `state` not a CardContext
+    ...
+    return {"card_html": html, "verdict": verdict, "axes": axes}
+```
+
+- The function name MUST be `update_*` (as_step requirement); `name=` gives the
+  core key (`<card>_report_card`), `aliases=["<card>"]` the short alias.
+- Existing logic is reused verbatim where possible: `standard` wraps
+  `runs_section`+`eval_section`; `statistical` wraps `build_report_card`;
+  `parca` grades `parca_section` rows; `config`/`config_diff` render the config
+  and output `verdict="ungraded"` with `axes=[]`.
+- The body reads `state["observables"]` (the former `ctx.per_obs`),
+  `state["config"]`, `state["seeds"]`, etc.
+- The exact bigraph-schema **type strings above are illustrative** — the plan's
+  first task confirms the real syntax for nested/loose types (e.g. whether it's
+  `tree[list[map]]`, `map[list[map]]`, or `tree[any]`) against the installed
+  `bigraph_schema` core and uses the validated forms verbatim thereafter.
+
+## Registration & resolution
+
+The card Step classes register into the core in `v2ecoli/core.py::build_core`,
+alongside the existing `register_link` calls:
+
+```python
+    from scripts._compare.report_cards import REPORT_CARD_STEPS  # {name: StepCls}
+    core.register_links(REPORT_CARD_STEPS)
+```
+
+`REPORT_CARD_STEPS` is assembled by the card package's `__init__` (importing each
+card module collects its `as_step` class under its `name`). Resolution:
+`core.access("standard_report_card")` returns the Step class. Any project's
+`build_core` that calls `register_links(REPORT_CARD_STEPS)` gets the cards —
+that's the infrastructure-wide sharing, via the core.
+
+## Harness invocation (replaces `render()`)
+
+`scripts/comparison_report_card.py::assemble_from_studies` — for each card the
+study declares:
+
+```python
+    core = build_core()
+    ...
+    for card in spec.cards:
+        step_cls = core.access(f"{card}_report_card")
+        step = step_cls(config={}, core=core)
+        state = {
+            "condition": spec.condition, "seeds": spec.seeds,
+            "generations": spec.gens, "variant": 0,
+            "observables": per_obs, "plot_trajs": plot_trajs,
+            "v2_bounds": v2_bounds,
+            "config": {"condition": spec.condition, "seeds": spec.seeds,
+                       "generations": spec.gens, "cards": spec.cards},
+        }
+        out = step.update(state)        # {card_html, verdict, axes}
+        # collect sections for the combined report (out["card_html"]),
+        # card_verdicts[card] = {"verdict": out["verdict"], "axes": out["axes"]}
+        viz_cards.append({"name": card, "html": out["card_html"],
+                          "verdict": out["verdict"], "axes": out["axes"]})
+    write_report_cards(study_dir, viz_cards)            # unchanged helper (signature updated)
+    write_condition_verdict(verdict_root, name, card_verdicts)  # unchanged
+```
+
+`viz_cards.write_report_cards` is adjusted to take pre-rendered `html` per card
+(it previously rebuilt HTML from `sections`); the verdict aggregation
+(`verdict.build_condition_verdict`) is unchanged.
+
+## Removed / changed
+
+- **Removed** from `scripts/_compare/report_cards/__init__.py`: `REGISTRY`,
+  `@report_card`, `render`, `get`, `all_names`, `CardContext`. Replaced by
+  `REPORT_CARD_STEPS` (the `{name: StepCls}` map) for core registration.
+- **Changed:** the 5 card modules (→ `as_step` `update_*` functions);
+  `assemble_from_studies` (→ core invocation); `viz_cards.write_report_cards`
+  (takes `html` not `sections`); the comparison tests (→ Step interface).
+- **Unchanged:** `verdict.py`, `materialize.py`, `study_spec.py`, the
+  `runner`/`scaffold`/CLI, the dashboard, and the `viz/report_card` +
+  `tests: [{kind: report_card}]` contract.
+
+## Data flow
+
+```
+v2e-compare run -> harness loads zarr -> comparison data per study
+  core = build_core()  (REPORT_CARD_STEPS registered)
+  for card in study.cards:
+     core.access("<card>_report_card") -> step.update(state) -> {card_html, verdict, axes}
+  harness writes viz/report_card/<card>.{html,verdict.json} + per-condition verdict
+Dashboard: unchanged (embeds viz/report_card by the contract)
+```
+
+## Error handling
+
+- Missing observable in `state["observables"]` → the card logic already maps to
+  `not_compared`/`ungraded`; the loose `tree`/`map` input does not reject.
+- `core.access` on an unknown card → a clear KeyError-style failure naming the
+  card (surfaced by the harness, not a silent skip).
+- A card whose `update` omits an output key → the `overwrite[...]` outputs schema
+  + a harness assertion catch it.
+- All reads/writes `encoding="utf-8"`.
+
+## Testing
+
+- **Per card Step:** `core = build_core(); step = core.access("standard_report_card")(config={}, core=core); out = step.update(synthetic_state)` → assert `out["verdict"] in {within_tol,drift,mismatch,ungraded}`, `out["axes"]` shape, and (for graded cards) at least one non-ungraded axis on a gradeable fixture. Mirrors today's `test_card_verdicts` via the Step interface.
+- **Registration:** `core.access("standard_report_card")` and the `"standard"` alias both resolve; all 5 names registered.
+- **Harness:** `assemble_from_studies` renders via core invocation and writes the viz cards + per-condition verdict (adapt the existing `test_assemble_studies`).
+- **viz_cards:** `write_report_cards` writes the supplied `html` + verdict sidecar (adapt `test_viz_cards`).
+- The 5-card conversion keeps the verdict values identical for the same input (a graded card with a 1% Δ still grades `within_tol`).
+
+## Scope (YAGNI)
+
+- v2ecoli-only. No dashboard/contract change, no pbg-superpowers change, no new
+  dependency (`as_step` ships with process-bigraph).
+- Not building a full analysis *composite* (decision 1) — the Steps are
+  harness-invoked; wiring them into a composite is a later, separate step.
+- Not converting the v2ecoli `Analysis` framework — out of scope.

--- a/scripts/_compare/report_cards/__init__.py
+++ b/scripts/_compare/report_cards/__init__.py
@@ -1,15 +1,12 @@
-"""Registry of modular comparison report cards.
+"""Registry of modular comparison report cards (as_step Steps).
 
-A card is Callable[[CardContext], Section | list[Section]]. Register with the
-@report_card("name") decorator; assign by name in the comparison manifest.
-Cards are thin wrappers over the existing section functions and Chris Long's
-on-main card library (v2ecoli.library.report_card).
+Cards are process-bigraph Steps registered in REPORT_CARD_STEPS and
+accessible via core.link_registry['<name>_report_card']. Each card's
+update function returns {card_html, verdict, axes}.
 """
 from __future__ import annotations
 
 import html as _html
-from dataclasses import dataclass, field
-from typing import Any, Callable
 
 Section = dict  # {title, kind, html, anchor, verdict?}
 
@@ -70,47 +67,6 @@ def _sections_to_html(sections: list) -> str:
     return "".join(parts)
 
 
-@dataclass
-class CardContext:
-    config_name: str
-    variant: int
-    v2_dir: str
-    ve_dir: str
-    seeds: int
-    gens: int
-    per_obs: dict = field(default_factory=dict)
-    plot_trajs: dict = field(default_factory=dict)
-    v2_bounds: dict = field(default_factory=dict)
-    config: dict = field(default_factory=dict)
-
-
-Card = Callable[[CardContext], "Section | list[Section]"]
-REGISTRY: dict[str, Card] = {}
-
-
-def report_card(name: str) -> Callable[[Card], Card]:
-    def deco(fn: Card) -> Card:
-        REGISTRY[name] = fn
-        return fn
-    return deco
-
-
-def get(name: str) -> Card:
-    if name not in REGISTRY:
-        raise KeyError(f"unknown report card {name!r}; known: {sorted(REGISTRY)}")
-    return REGISTRY[name]
-
-
-def all_names() -> list[str]:
-    return sorted(REGISTRY)
-
-
-def render(name: str, ctx: CardContext) -> list[Section]:
-    out = get(name)(ctx)
-    return out if isinstance(out, list) else [out]
-
-
-# Built-in card modules (standard/statistical/parca/config_diff) are imported
-# here once they exist (Tasks 4–5) so importing this package registers them.
+# Built-in card modules register themselves into REPORT_CARD_STEPS on import.
 from scripts._compare.report_cards import standard, statistical  # noqa: E402,F401
 from scripts._compare.report_cards import parca, config_diff, config  # noqa: E402,F401

--- a/scripts/_compare/report_cards/__init__.py
+++ b/scripts/_compare/report_cards/__init__.py
@@ -7,10 +7,67 @@ on-main card library (v2ecoli.library.report_card).
 """
 from __future__ import annotations
 
+import html as _html
 from dataclasses import dataclass, field
 from typing import Any, Callable
 
 Section = dict  # {title, kind, html, anchor, verdict?}
+
+# Typed contract for a report-card Step. Pragmatic: structural fields typed;
+# the per-seed stat records under `observables` stay loose. Strings pinned in
+# Task 1 Step 1 — substitute the validated forms if any printed BAD.
+CARD_INPUTS = {
+    "name": "string", "condition": "string",
+    "seeds": "integer", "generations": "integer", "variant": "integer",
+    "observables": "tree[list[map]]", "plot_trajs": "tree[map]",
+    "v2_bounds": "list[float]", "config": "tree[map]",
+    "v2_dir": "string", "ve_dir": "string",
+}
+CARD_OUTPUTS = {
+    "card_html": "overwrite[string]",
+    "verdict": "overwrite[string]",
+    "axes": "overwrite[list[map]]",
+}
+
+REPORT_CARD_STEPS: dict[str, type] = {}   # {name: StepCls}; populated by the card modules
+
+
+def _row_table(rows: list) -> str:
+    cells = []
+    for r in rows:
+        label = _html.escape(str(r.get("label", "")))
+        left = _html.escape(str(r.get("left", "")))
+        right = _html.escape(str(r.get("right", "")))
+        verdict = _html.escape(str(r.get("verdict", "")))
+        reason = _html.escape(str(r.get("reason", "")))
+        cells.append(
+            f'<tr><td style="padding:2px 10px">{label}</td>'
+            f'<td style="padding:2px 10px">{left}</td>'
+            f'<td style="padding:2px 10px">{right}</td>'
+            f'<td style="padding:2px 10px">{verdict}</td>'
+            f'<td style="padding:2px 10px;color:#6b7280">{reason}</td></tr>')
+    return ('<table style="border-collapse:collapse;font-size:13px">'
+            '<thead><tr style="text-align:left">'
+            '<th style="padding:2px 10px">observable</th><th>vEcoli</th>'
+            '<th>v2ecoli</th><th>verdict</th><th>note</th></tr></thead><tbody>'
+            + "".join(cells) + "</tbody></table>")
+
+
+def _sections_to_html(sections: list) -> str:
+    """Render a card's section dicts into one HTML fragment. A section with an
+    `html` field is emitted as-is; a section with `rows` is rendered as a
+    table (eval_section / parca_section produce rows)."""
+    parts = []
+    for sec in sections:
+        if sec.get("title"):
+            parts.append(f'<h3 style="margin:14px 0 6px">{_html.escape(str(sec["title"]))}</h3>')
+        if sec.get("desc"):
+            parts.append(f'<p style="color:#6b7280;font-size:12px">{_html.escape(str(sec["desc"]))}</p>')
+        if sec.get("html"):
+            parts.append(sec["html"])
+        elif sec.get("rows"):
+            parts.append(_row_table(sec["rows"]))
+    return "".join(parts)
 
 
 @dataclass

--- a/scripts/_compare/report_cards/config.py
+++ b/scripts/_compare/report_cards/config.py
@@ -7,7 +7,10 @@ from __future__ import annotations
 import html as _html
 import json as _json
 
-from scripts._compare.report_cards import report_card, CardContext, Section
+from process_bigraph.composite import as_step
+
+from scripts._compare.report_cards import (
+    report_card, CardContext, Section, CARD_INPUTS, CARD_OUTPUTS, REPORT_CARD_STEPS)
 
 # Keys surfaced first, in this order; everything else follows alphabetically.
 _PRIORITY = ["condition", "n_init_sims", "generations", "time_step",
@@ -15,14 +18,13 @@ _PRIORITY = ["condition", "n_init_sims", "generations", "time_step",
 _LABEL = {"n_init_sims": "seeds (n_init_sims)", "generations": "generations"}
 
 
-@report_card("config")
-def config_card(ctx: CardContext) -> Section:
-    cfg = dict(ctx.config or {})
-    cfg.setdefault("condition", ctx.config_name)
-    if ctx.seeds:
-        cfg.setdefault("n_init_sims", ctx.seeds)
-    if ctx.gens:
-        cfg.setdefault("generations", ctx.gens)
+def _config_html(name: str, seeds: int, gens: int, config: dict) -> str:
+    cfg = dict(config or {})
+    cfg.setdefault("condition", name)
+    if seeds:
+        cfg.setdefault("n_init_sims", seeds)
+    if gens:
+        cfg.setdefault("generations", gens)
     keys = [k for k in _PRIORITY if k in cfg] + sorted(
         k for k in cfg if k not in _PRIORITY and not k.startswith("_"))
     rows = []
@@ -36,13 +38,13 @@ def config_card(ctx: CardContext) -> Section:
             f'{vs}</td></tr>')
     table = ('<table style="border-collapse:collapse;font-size:13px">'
              + "".join(rows) + "</table>") if rows else (
-        f"<p>config for '{_html.escape(ctx.config_name)}' (no fields resolved)</p>")
-    src = ctx.config.get("_source") if isinstance(ctx.config, dict) else None
+        f"<p>config for '{_html.escape(name)}' (no fields resolved)</p>")
+    src = config.get("_source") if isinstance(config, dict) else None
     note = (f'<p style="color:#6b7280;font-size:12px">source: '
             f'{_html.escape(str(src))}</p>') if src else ""
     # Full JSON config in a browsable (collapsible, scrollable) viewer — the
     # default so every section exposes exactly what was run.
-    full = {k: v for k, v in (ctx.config or {}).items() if k != "_source"}
+    full = {k: v for k, v in (config or {}).items() if k != "_source"}
     json_viewer = (
         '<details open style="margin-top:8px"><summary style="cursor:pointer;'
         'color:#374151;font-weight:600">full JSON config</summary>'
@@ -50,10 +52,25 @@ def config_card(ctx: CardContext) -> Section:
         'padding:10px;font-size:12px;line-height:1.4;max-height:380px;overflow:auto;'
         'white-space:pre">' + _html.escape(_json.dumps(full, indent=2, sort_keys=True))
         + '</pre></details>') if full else ""
-    return {"title": f"{ctx.config_name} — config",
-            "kind": "content",
+    return (f"<p>vEcoli config driving the <b>{_html.escape(name)}</b> "
+            f"run (config = source of truth for the run shape).</p>"
+            + table + json_viewer + note)
+
+
+@as_step(inputs=CARD_INPUTS, outputs=CARD_OUTPUTS, name="config_report_card",
+         aliases=["config"])
+def update_config_report_card(state):
+    return {"card_html": _config_html(state["name"], state["seeds"],
+                                      state["generations"], state["config"]),
+            "verdict": "ungraded", "axes": []}
+
+
+REPORT_CARD_STEPS["config_report_card"] = update_config_report_card
+
+
+@report_card("config")
+def config_card(ctx: CardContext) -> Section:
+    return {"title": f"{ctx.config_name} — config", "kind": "content",
             "anchor": f"{ctx.config_name}-config",
-            "html": f"<p>vEcoli config driving the <b>{_html.escape(ctx.config_name)}</b> "
-                    f"run (config = source of truth for the run shape).</p>"
-                    + table + json_viewer + note,
+            "html": _config_html(ctx.config_name, ctx.seeds, ctx.gens, ctx.config),
             "verdict": None}

--- a/scripts/_compare/report_cards/config.py
+++ b/scripts/_compare/report_cards/config.py
@@ -10,7 +10,7 @@ import json as _json
 from process_bigraph.composite import as_step
 
 from scripts._compare.report_cards import (
-    report_card, CardContext, Section, CARD_INPUTS, CARD_OUTPUTS, REPORT_CARD_STEPS)
+    CARD_INPUTS, CARD_OUTPUTS, REPORT_CARD_STEPS)
 
 # Keys surfaced first, in this order; everything else follows alphabetically.
 _PRIORITY = ["condition", "n_init_sims", "generations", "time_step",
@@ -66,11 +66,3 @@ def update_config_report_card(state):
 
 
 REPORT_CARD_STEPS["config_report_card"] = update_config_report_card
-
-
-@report_card("config")
-def config_card(ctx: CardContext) -> Section:
-    return {"title": f"{ctx.config_name} — config", "kind": "content",
-            "anchor": f"{ctx.config_name}-config",
-            "html": _config_html(ctx.config_name, ctx.seeds, ctx.gens, ctx.config),
-            "verdict": None}

--- a/scripts/_compare/report_cards/config_diff.py
+++ b/scripts/_compare/report_cards/config_diff.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 from process_bigraph.composite import as_step
 
 from scripts._compare.report_cards import (
-    report_card, CardContext, Section, CARD_INPUTS, CARD_OUTPUTS,
-    _sections_to_html, REPORT_CARD_STEPS)
+    CARD_INPUTS, CARD_OUTPUTS, _sections_to_html, REPORT_CARD_STEPS)
 
 
 @as_step(inputs=CARD_INPUTS, outputs=CARD_OUTPUTS, name="config_diff_report_card",
@@ -17,9 +16,3 @@ def update_config_diff_report_card(state):
 
 
 REPORT_CARD_STEPS["config_diff_report_card"] = update_config_diff_report_card
-
-
-@report_card("config_diff")
-def config_diff_card(ctx: CardContext) -> list[Section]:
-    from scripts.comparison_report_card import config_sections_for
-    return config_sections_for(ctx.config_name, ctx.v2_dir, ctx.ve_dir)

--- a/scripts/_compare/report_cards/config_diff.py
+++ b/scripts/_compare/report_cards/config_diff.py
@@ -1,7 +1,22 @@
-"""`config_diff` card — vEcoli vs v2ecoli config comparison for one config."""
+"""`config_diff` card — vEcoli vs v2ecoli config comparison (S3/Nextflow). as_step Step."""
 from __future__ import annotations
 
-from scripts._compare.report_cards import report_card, CardContext, Section
+from process_bigraph.composite import as_step
+
+from scripts._compare.report_cards import (
+    report_card, CardContext, Section, CARD_INPUTS, CARD_OUTPUTS,
+    _sections_to_html, REPORT_CARD_STEPS)
+
+
+@as_step(inputs=CARD_INPUTS, outputs=CARD_OUTPUTS, name="config_diff_report_card",
+         aliases=["config_diff"])
+def update_config_diff_report_card(state):
+    from scripts.comparison_report_card import config_sections_for
+    secs = config_sections_for(state["name"], state["v2_dir"], state["ve_dir"])
+    return {"card_html": _sections_to_html(secs), "verdict": "ungraded", "axes": []}
+
+
+REPORT_CARD_STEPS["config_diff_report_card"] = update_config_diff_report_card
 
 
 @report_card("config_diff")

--- a/scripts/_compare/report_cards/parca.py
+++ b/scripts/_compare/report_cards/parca.py
@@ -1,28 +1,20 @@
-"""`parca` card — ParCa / initial-state match for one config.
-
-Graded: the t~0 (first matched emit) initial masses must agree between v2ecoli
-and vEcoli — both sims start from their engine's ParCa fit, so this is the
-same-initial-state evidence the per-condition dynamics build on. Each mass
-observable's initial |Δ| is graded (5% within / 10% drift); the worst is the
-card verdict, so a ParCa study can gate its follow-ups.
-"""
+"""`parca` card — ParCa / initial-state match, graded on per-mass t~0 |Δ|.
+as_step Step invoked via core.access('parca_report_card')."""
 from __future__ import annotations
 
-from scripts._compare.report_cards import report_card, CardContext, Section
+from process_bigraph.composite import as_step
+
+from scripts._compare.report_cards import (
+    report_card, CardContext, Section, CARD_INPUTS, CARD_OUTPUTS,
+    _sections_to_html, REPORT_CARD_STEPS)
 from scripts._compare.verdict import worst
 
 
-@report_card("parca")
-def parca_card(ctx: CardContext) -> Section:
+def _parca_section_and_axes(name, per_obs, plot_trajs, v2_bounds):
     from scripts.comparison_report_card import parca_section
-    # parca_section takes the cond_data map; build a single-cond slice.
-    sec = parca_section({ctx.config_name: (ctx.per_obs, ctx.plot_trajs, ctx.v2_bounds)})
-    sec["anchor"] = f"{ctx.config_name}-parca"
-    sec["title"] = f"{ctx.config_name} — ParCa / initial-state match"
-    # Grade the per-mass initial-state agreement. parca_section already grades
-    # each mass row (_grade over the init |Δ|); expose those as verdict_axes so
-    # the card produces a verdict the framework can gate on. Rows without a
-    # graded value (condition headers, missing observables) are skipped.
+    sec = parca_section({name: (per_obs, plot_trajs, v2_bounds)})
+    sec["anchor"] = f"{name}-parca"
+    sec["title"] = f"{name} — ParCa / initial-state match"
     axes = []
     for row in sec.get("rows", []):
         if "median_rel" not in row:
@@ -30,14 +22,28 @@ def parca_card(ctx: CardContext) -> Section:
         v = row.get("verdict", "ungraded")
         if v == "not_compared":
             v = "ungraded"
-        axes.append({
-            "id": f"parca.{row['label']}",
-            "label": row["label"],
-            "verdict": v,
-            "value": row.get("median_rel"),
-            "meter": row.get("reason", ""),
-            "detail": {"init_rel": row.get("median_rel")},
-        })
+        axes.append({"id": f"parca.{row['label']}", "label": row["label"], "verdict": v,
+                     "value": row.get("median_rel"), "meter": row.get("reason", ""),
+                     "detail": {"init_rel": row.get("median_rel")}})
+    return sec, axes
+
+
+@as_step(inputs=CARD_INPUTS, outputs=CARD_OUTPUTS, name="parca_report_card",
+         aliases=["parca"])
+def update_parca_report_card(state):
+    sec, axes = _parca_section_and_axes(
+        state["name"], state["observables"], state["plot_trajs"], state["v2_bounds"])
+    return {"card_html": _sections_to_html([sec]),
+            "verdict": worst(a["verdict"] for a in axes), "axes": axes}
+
+
+REPORT_CARD_STEPS["parca_report_card"] = update_parca_report_card
+
+
+@report_card("parca")
+def parca_card(ctx: CardContext) -> Section:
+    sec, axes = _parca_section_and_axes(
+        ctx.config_name, ctx.per_obs, ctx.plot_trajs, ctx.v2_bounds)
     sec["verdict"] = worst(a["verdict"] for a in axes)
     sec["verdict_axes"] = axes
     return sec

--- a/scripts/_compare/report_cards/parca.py
+++ b/scripts/_compare/report_cards/parca.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 from process_bigraph.composite import as_step
 
 from scripts._compare.report_cards import (
-    report_card, CardContext, Section, CARD_INPUTS, CARD_OUTPUTS,
-    _sections_to_html, REPORT_CARD_STEPS)
+    CARD_INPUTS, CARD_OUTPUTS, _sections_to_html, REPORT_CARD_STEPS)
 from scripts._compare.verdict import worst
 
 
@@ -38,12 +37,3 @@ def update_parca_report_card(state):
 
 
 REPORT_CARD_STEPS["parca_report_card"] = update_parca_report_card
-
-
-@report_card("parca")
-def parca_card(ctx: CardContext) -> Section:
-    sec, axes = _parca_section_and_axes(
-        ctx.config_name, ctx.per_obs, ctx.plot_trajs, ctx.v2_bounds)
-    sec["verdict"] = worst(a["verdict"] for a in axes)
-    sec["verdict_axes"] = axes
-    return sec

--- a/scripts/_compare/report_cards/parca.py
+++ b/scripts/_compare/report_cards/parca.py
@@ -1,5 +1,5 @@
 """`parca` card — ParCa / initial-state match, graded on per-mass t~0 |Δ|.
-as_step Step invoked via core.access('parca_report_card')."""
+as_step Step invoked via core.link_registry['parca_report_card']."""
 from __future__ import annotations
 
 from process_bigraph.composite import as_step

--- a/scripts/_compare/report_cards/standard.py
+++ b/scripts/_compare/report_cards/standard.py
@@ -1,5 +1,5 @@
 """`standard` card — matched-time runs + per-observable evaluation. as_step Step;
-the harness invokes it via core.access('standard_report_card')."""
+the harness invokes it via core.link_registry['standard_report_card']."""
 from __future__ import annotations
 
 from process_bigraph.composite import as_step

--- a/scripts/_compare/report_cards/standard.py
+++ b/scripts/_compare/report_cards/standard.py
@@ -1,34 +1,50 @@
-"""`standard` card — matched-time run trajectories + evaluation (the lighter
-card). Thin wrapper over comparison_report_card.runs_section / eval_section.
-The evaluation section also carries a card-level verdict + axes (one per
-observable) so the comparison can gate on it via report_card_axis."""
+"""`standard` card — matched-time runs + per-observable evaluation. as_step Step;
+the harness invokes it via core.access('standard_report_card')."""
 from __future__ import annotations
 
-from scripts._compare.report_cards import report_card, CardContext, Section
+from process_bigraph.composite import as_step
+
+from scripts._compare.report_cards import (
+    report_card, CardContext, Section, CARD_INPUTS, CARD_OUTPUTS,
+    _sections_to_html, REPORT_CARD_STEPS)
 from scripts._compare.verdict import worst
 
 
-@report_card("standard")
-def standard_card(ctx: CardContext) -> list[Section]:
-    # Imported lazily: comparison_report_card imports heavy deps; importing it at
-    # module load would slow registry import and risk a cycle.
+def _standard_sections_and_axes(name, per_obs, plot_trajs, v2_bounds):
     from scripts.comparison_report_card import runs_section, eval_section
-    runs = runs_section(ctx.config_name, ctx.per_obs, ctx.plot_trajs, ctx.v2_bounds)
-    ev = eval_section(ctx.config_name, ctx.per_obs)
+    runs = runs_section(name, per_obs, plot_trajs, v2_bounds)
+    ev = eval_section(name, per_obs)
     axes = []
     for row in ev.get("rows", []):
         v = row.get("verdict", "ungraded")
         if v == "not_compared":
             v = "ungraded"
-        axes.append({
-            "id": f"standard.{row.get('label', '')}",
-            "label": row.get("label", ""),
-            "verdict": v,
-            "value": row.get("median_rel"),
-            "meter": row.get("reason", ""),
-            "detail": {"median_rel": row.get("median_rel"),
-                       "max_rel": row.get("max_rel")},
-        })
+        axes.append({"id": f"standard.{row.get('label', '')}", "label": row.get("label", ""),
+                     "verdict": v, "value": row.get("median_rel"),
+                     "meter": row.get("reason", ""),
+                     "detail": {"median_rel": row.get("median_rel"),
+                                "max_rel": row.get("max_rel")}})
+    return [runs, ev], axes
+
+
+@as_step(inputs=CARD_INPUTS, outputs=CARD_OUTPUTS, name="standard_report_card",
+         aliases=["standard"])
+def update_standard_report_card(state):
+    sections, axes = _standard_sections_and_axes(
+        state["name"], state["observables"], state["plot_trajs"], state["v2_bounds"])
+    return {"card_html": _sections_to_html(sections),
+            "verdict": worst(a["verdict"] for a in axes), "axes": axes}
+
+
+REPORT_CARD_STEPS["standard_report_card"] = update_standard_report_card
+
+
+# --- transitional: keep the old registry wrapper until the Task 5 cutover ---
+@report_card("standard")
+def standard_card(ctx: CardContext) -> list[Section]:
+    sections, axes = _standard_sections_and_axes(
+        ctx.config_name, ctx.per_obs, ctx.plot_trajs, ctx.v2_bounds)
+    ev = sections[1]
     ev["verdict"] = worst(a["verdict"] for a in axes)
     ev["verdict_axes"] = axes
-    return [runs, ev]
+    return sections

--- a/scripts/_compare/report_cards/standard.py
+++ b/scripts/_compare/report_cards/standard.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 from process_bigraph.composite import as_step
 
 from scripts._compare.report_cards import (
-    report_card, CardContext, Section, CARD_INPUTS, CARD_OUTPUTS,
-    _sections_to_html, REPORT_CARD_STEPS)
+    CARD_INPUTS, CARD_OUTPUTS, _sections_to_html, REPORT_CARD_STEPS)
 from scripts._compare.verdict import worst
 
 
@@ -37,14 +36,3 @@ def update_standard_report_card(state):
 
 
 REPORT_CARD_STEPS["standard_report_card"] = update_standard_report_card
-
-
-# --- transitional: keep the old registry wrapper until the Task 5 cutover ---
-@report_card("standard")
-def standard_card(ctx: CardContext) -> list[Section]:
-    sections, axes = _standard_sections_and_axes(
-        ctx.config_name, ctx.per_obs, ctx.plot_trajs, ctx.v2_bounds)
-    ev = sections[1]
-    ev["verdict"] = worst(a["verdict"] for a in axes)
-    ev["verdict_axes"] = axes
-    return sections

--- a/scripts/_compare/report_cards/statistical.py
+++ b/scripts/_compare/report_cards/statistical.py
@@ -1,27 +1,40 @@
-"""`statistical` card — Chris Long's graded equivalence card (violin/strip +
-<details> dropdown viz bars + within_tol/drift/mismatch pills). Mirrors the
-per_obs -> build_report_card mapping in comparison_report_card.report_card()."""
+"""`statistical` card — graded equivalence (violin/strip). as_step Step."""
 from __future__ import annotations
 
-from scripts._compare.report_cards import report_card, CardContext, Section
+from process_bigraph.composite import as_step
+
+from scripts._compare.report_cards import (
+    report_card, CardContext, Section, CARD_INPUTS, CARD_OUTPUTS, REPORT_CARD_STEPS)
 from scripts._compare.report_card_section import build_report_card
+
+
+def _statistical_html_axes(name, per_obs, variant):
+    from scripts.comparison_report_card import OBSERVABLES, CARD_KEY, EXTRA_AXES, TOL
+    left, right = {}, {}
+    for obs in OBSERVABLES:
+        ck = CARD_KEY.get(obs, obs)
+        left[ck] = [s["ve_mean"] for s in per_obs.get(obs, [])]
+        right[ck] = [s["v2_mean"] for s in per_obs.get(obs, [])]
+    vjson, html = build_report_card(left, right, extra_axes=EXTRA_AXES,
+                                    model_ref=f"v2ecoli @ {name} variant {variant}", tol_rel=TOL)
+    axes = [ax for g in (vjson.get("groups") or {}).values() for ax in (g.get("axes") or [])]
+    return html, vjson.get("overall"), axes
+
+
+@as_step(inputs=CARD_INPUTS, outputs=CARD_OUTPUTS, name="statistical_report_card",
+         aliases=["statistical"])
+def update_statistical_report_card(state):
+    html, verdict, axes = _statistical_html_axes(
+        state["name"], state["observables"], state["variant"])
+    return {"card_html": html, "verdict": verdict or "ungraded", "axes": axes}
+
+
+REPORT_CARD_STEPS["statistical_report_card"] = update_statistical_report_card
 
 
 @report_card("statistical")
 def statistical_card(ctx: CardContext) -> Section:
-    from scripts.comparison_report_card import OBSERVABLES, CARD_KEY, EXTRA_AXES, TOL
-    left: dict = {}   # vEcoli (reference)
-    right: dict = {}  # v2ecoli (measured)
-    for obs in OBSERVABLES:
-        ck = CARD_KEY.get(obs, obs)
-        left[ck] = [s["ve_mean"] for s in ctx.per_obs.get(obs, [])]
-        right[ck] = [s["v2_mean"] for s in ctx.per_obs.get(obs, [])]
-    vjson, html = build_report_card(
-        left, right, extra_axes=EXTRA_AXES,
-        model_ref=f"v2ecoli @ {ctx.config_name} variant {ctx.variant}", tol_rel=TOL)
-    axes = [ax for g in (vjson.get("groups") or {}).values()
-            for ax in (g.get("axes") or [])]
-    return {"title": f"{ctx.config_name} — statistical equivalence",
-            "kind": "content", "anchor": f"{ctx.config_name}-statistical",
-            "html": html, "verdict": vjson.get("overall"),
-            "verdict_axes": axes}
+    html, verdict, axes = _statistical_html_axes(ctx.config_name, ctx.per_obs, ctx.variant)
+    return {"title": f"{ctx.config_name} — statistical equivalence", "kind": "content",
+            "anchor": f"{ctx.config_name}-statistical", "html": html,
+            "verdict": verdict, "verdict_axes": axes}

--- a/scripts/_compare/report_cards/statistical.py
+++ b/scripts/_compare/report_cards/statistical.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from process_bigraph.composite import as_step
 
 from scripts._compare.report_cards import (
-    report_card, CardContext, Section, CARD_INPUTS, CARD_OUTPUTS, REPORT_CARD_STEPS)
+    CARD_INPUTS, CARD_OUTPUTS, REPORT_CARD_STEPS)
 from scripts._compare.report_card_section import build_report_card
 
 
@@ -30,11 +30,3 @@ def update_statistical_report_card(state):
 
 
 REPORT_CARD_STEPS["statistical_report_card"] = update_statistical_report_card
-
-
-@report_card("statistical")
-def statistical_card(ctx: CardContext) -> Section:
-    html, verdict, axes = _statistical_html_axes(ctx.config_name, ctx.per_obs, ctx.variant)
-    return {"title": f"{ctx.config_name} — statistical equivalence", "kind": "content",
-            "anchor": f"{ctx.config_name}-statistical", "html": html,
-            "verdict": verdict, "verdict_axes": axes}

--- a/scripts/_compare/viz_cards.py
+++ b/scripts/_compare/viz_cards.py
@@ -4,23 +4,7 @@ studies/<study>/viz/report_card/, the convention the dashboard auto-discovers
 from __future__ import annotations
 
 import json
-import html as _html
 from pathlib import Path
-
-_DOC = ("<!DOCTYPE html><html lang=\"en\"><head><meta charset=\"utf-8\">"
-        "<title>{title}</title><style>body{{font-family:-apple-system,Segoe UI,"
-        "Roboto,sans-serif;margin:14px;color:#0f172a}}h3{{margin:14px 0 6px}}"
-        "table{{border-collapse:collapse}}td,th{{padding:4px 8px}}</style></head>"
-        "<body>{body}</body></html>")
-
-
-def _card_html(name: str, sections: list) -> str:
-    parts = []
-    for sec in sections:
-        if sec.get("title"):
-            parts.append(f"<h3>{_html.escape(str(sec['title']))}</h3>")
-        parts.append(sec.get("html", ""))
-    return _DOC.format(title=_html.escape(name), body="".join(parts))
 
 
 def write_report_cards(study_dir, cards: list) -> list[Path]:
@@ -31,7 +15,7 @@ def write_report_cards(study_dir, cards: list) -> list[Path]:
     for card in cards:
         name = card["name"]
         hp = out / f"{name}.html"
-        hp.write_text(_card_html(name, card.get("sections") or []), encoding="utf-8")
+        hp.write_text(card.get("html") or "", encoding="utf-8")
         written.append(hp)
         verdict = card.get("verdict") or "ungraded"
         vp = out / f"{name}.verdict.json"

--- a/scripts/comparison_report_card.py
+++ b/scripts/comparison_report_card.py
@@ -61,6 +61,7 @@ sys.path.insert(0, str(REPO_ROOT))
 
 from scripts._compare import report
 from scripts._compare.report_card_section import build_report_card
+from v2ecoli.core import build_core
 from scripts._compare.vecoli_parquet_reader import read_vecoli_trajectory
 from scripts.compare_matched_trajectories import (
     BUCKET, PREFIX, REGION, OBS_LABEL, _legend_html, overlay_svg_multi,
@@ -695,9 +696,9 @@ def assemble_from_studies(specs, cond_data, conds, verdict_root=None,
     condition, seeds/gens and cards; the `config` card renders the study's run
     spec. Writes one report_card_verdict.json per study (each card a group). When
     verdict_root is None it is derived from the studies' investigation."""
-    from scripts._compare import report_cards as rc
     from scripts._compare.verdict import write_condition_verdict
-
+    from scripts._compare.viz_cards import write_report_cards
+    core = build_core()
     if verdict_root is None and specs:
         verdict_root = f"docs/report_cards/{specs[0].invest_name}"
     overview = overview_section(cond_data); overview["nav_group"] = "Overall"
@@ -709,33 +710,27 @@ def assemble_from_studies(specs, cond_data, conds, verdict_root=None,
             continue
         per_obs, plot_trajs, v2_bounds = cond_data[name]
         v2_dir, ve_dir = conds.get(name, ("", ""))
-        ctx = rc.CardContext(
-            config_name=name, variant=0, v2_dir=v2_dir, ve_dir=ve_dir,
-            seeds=spec.seeds, gens=spec.gens, per_obs=per_obs,
-            plot_trajs=plot_trajs, v2_bounds=v2_bounds,
-            config={"condition": spec.condition, "seeds": spec.seeds,
-                    "generations": spec.gens, "cards": spec.cards})
-        card_verdicts = {}
-        viz_cards = []
+        state = {"name": name, "condition": spec.condition, "seeds": spec.seeds,
+                 "generations": spec.gens, "variant": 0, "observables": per_obs,
+                 "plot_trajs": plot_trajs, "v2_bounds": v2_bounds,
+                 "config": {"condition": spec.condition, "seeds": spec.seeds,
+                            "generations": spec.gens, "cards": spec.cards},
+                 "v2_dir": v2_dir, "ve_dir": ve_dir}
+        card_verdicts, viz = {}, []
         for card in spec.cards:
-            cardv, secs = None, []
-            for sec in rc.render(card, ctx):
-                sec["nav_group"] = name
-                sections.append(sec)
-                secs.append(sec)
-                if "verdict_axes" in sec:
-                    cardv = {"verdict": sec.get("verdict", "ungraded"),
-                             "axes": sec["verdict_axes"]}
-            card_verdicts[card] = cardv or {"verdict": "ungraded", "axes": []}
-            viz_cards.append({"name": card, "sections": secs,
-                              "verdict": card_verdicts[card]["verdict"],
-                              "axes": card_verdicts[card]["axes"]})
+            step = core.link_registry[f"{card}_report_card"](config={}, core=core)
+            out = step.update(state)
+            sections.append({"title": f"{name} — {card}", "kind": "content",
+                             "html": out["card_html"], "nav_group": name})
+            card_verdicts[card] = {"verdict": out.get("verdict", "ungraded"),
+                                   "axes": out.get("axes") or []}
+            viz.append({"name": card, "html": out["card_html"],
+                        "verdict": card_verdicts[card]["verdict"],
+                        "axes": card_verdicts[card]["axes"]})
         if verdict_root:
             write_condition_verdict(verdict_root, name, card_verdicts)
         if studies_root:
-            from scripts._compare.viz_cards import write_report_cards
-            study_dir = Path(studies_root) / spec.invest_name / "studies" / name
-            write_report_cards(study_dir, viz_cards)
+            write_report_cards(Path(studies_root) / spec.invest_name / "studies" / name, viz)
     return sections
 
 

--- a/tests/_card_helpers.py
+++ b/tests/_card_helpers.py
@@ -1,0 +1,13 @@
+def _state(per_obs, name="basal", seeds=1, gens=4, variant=0, config=None):
+    return {"name": name, "condition": "basal", "seeds": seeds, "generations": gens,
+            "variant": variant, "observables": per_obs, "plot_trajs": {},
+            "v2_bounds": [], "config": config or {}, "v2_dir": "", "ve_dir": ""}
+
+
+def _run_card(name, state):
+    from v2ecoli.core import build_core
+    from scripts._compare.report_cards import REPORT_CARD_STEPS
+    core = build_core()
+    core.register_links(REPORT_CARD_STEPS)
+    step = core.link_registry[f"{name}_report_card"](config={}, core=core)
+    return step.update(state)

--- a/tests/test_assemble_studies.py
+++ b/tests/test_assemble_studies.py
@@ -9,14 +9,30 @@ def _spec(name, condition, cards):
                      fork="", study_path="/x")
 
 
+def _stub_core(monkeypatch, crc, captured=None):
+    """Monkeypatch build_core with a fake core whose link_registry resolves any
+    '<card>_report_card' key to a stub Step that returns drift verdict + card html."""
+    class _Stub:
+        def __init__(self, *a, **k): pass
+        def update(self, state):
+            if captured is not None:
+                captured["state"] = state
+            return {"card_html": "<b>card</b>", "verdict": "drift",
+                    "axes": [{"id": "x", "verdict": "drift"}]}
+
+    class _Reg(dict):
+        def __getitem__(self, k): return _Stub
+    class _Core:
+        link_registry = _Reg()
+        def register_links(self, d): pass
+    monkeypatch.setattr(crc, "build_core", lambda: _Core())
+
+
 def test_assemble_from_studies_writes_per_study_verdict(tmp_path, monkeypatch):
     import scripts.comparison_report_card as crc
-    from scripts._compare import report_cards as rc
     monkeypatch.setattr(crc, "overview_section",
                         lambda cond_data: {"title": "o", "kind": "content", "html": ""})
-    monkeypatch.setattr(rc, "render", lambda name, ctx: [
-        {"title": name, "kind": "content", "html": "",
-         "verdict": "drift", "verdict_axes": [{"id": "x", "verdict": "drift"}]}])
+    _stub_core(monkeypatch, crc)
     specs = [_spec("basal", "basal", ["config", "parca", "standard"]),
              _spec("basal_4x4", "basal", ["config", "parca", "statistical"])]
     cond_data = {"basal": ({}, {}, []), "basal_4x4": ({}, {}, [])}
@@ -24,7 +40,7 @@ def test_assemble_from_studies_writes_per_study_verdict(tmp_path, monkeypatch):
     crc.assemble_from_studies(specs, cond_data, conds, verdict_root=str(tmp_path))
     for name, graded in (("basal", "standard"), ("basal_4x4", "statistical")):
         doc = json.loads((tmp_path / name / "report_card_verdict.json").read_text(encoding="utf-8"))
-        # config + parca render (ungraded via stub returning verdict_axes -> drift here),
+        # config + parca + graded card all get verdict "drift" from stub;
         # the graded card group is present and the overall is worst-of.
         assert graded in doc["groups"]
         assert doc["overall"] == "drift"
@@ -32,31 +48,35 @@ def test_assemble_from_studies_writes_per_study_verdict(tmp_path, monkeypatch):
 
 def test_assemble_from_studies_config_card_sees_study_spec(tmp_path, monkeypatch):
     import scripts.comparison_report_card as crc
-    from scripts._compare import report_cards as rc
-    seen = {}
+    captured = {}
     monkeypatch.setattr(crc, "overview_section",
                         lambda cond_data: {"title": "o", "kind": "content", "html": ""})
-
-    def _capture(name, ctx):
-        seen["config"] = ctx.config
-        return [{"title": name, "kind": "content", "html": ""}]
-    monkeypatch.setattr(rc, "render", _capture)
+    _stub_core(monkeypatch, crc, captured=captured)
     specs = [_spec("basal_4x4", "basal", ["config"])]
     crc.assemble_from_studies(specs, {"basal_4x4": ({}, {}, [])},
                               {"basal_4x4": ("v2", "ve")}, verdict_root=str(tmp_path))
-    # the config card receives the study's run spec (no manifest config file)
-    assert seen["config"] == {"condition": "basal", "seeds": 1,
-                              "generations": 4, "cards": ["config"]}
+    # the config card receives the study's run spec via state["config"]
+    assert captured["state"]["config"] == {"condition": "basal", "seeds": 1,
+                                           "generations": 4, "cards": ["config"]}
 
 
 def test_assemble_from_studies_writes_viz_cards(tmp_path, monkeypatch):
     import scripts.comparison_report_card as crc
-    from scripts._compare import report_cards as rc
     monkeypatch.setattr(crc, "overview_section",
                         lambda cond_data: {"title": "o", "kind": "content", "html": ""})
-    monkeypatch.setattr(rc, "render", lambda name, ctx: [
-        {"title": f"{ctx.config_name}-{name}", "kind": "content", "html": "<b>card</b>",
-         "verdict": "drift", "verdict_axes": [{"id": "x", "verdict": "drift"}]}])
+
+    class _Stub:
+        def __init__(self, *a, **k): pass
+        def update(self, state):
+            return {"card_html": "<b>card</b>", "verdict": "drift",
+                    "axes": [{"id": "x", "verdict": "drift"}]}
+
+    class _Reg(dict):
+        def __getitem__(self, k): return _Stub
+    class _Core:
+        link_registry = _Reg()
+        def register_links(self, d): pass
+    monkeypatch.setattr(crc, "build_core", lambda: _Core())
     spec = _spec("basal", "basal", ["standard"])
     crc.assemble_from_studies([spec], {"basal": ({}, {}, [])},
                               {"basal": ("v2", "ve")}, verdict_root=str(tmp_path / "vr"),
@@ -65,5 +85,4 @@ def test_assemble_from_studies_writes_viz_cards(tmp_path, monkeypatch):
             / "viz/report_card/standard.html")
     assert card.is_file() and "<b>card</b>" in card.read_text(encoding="utf-8")
     import json
-    vd = json.loads(card.with_name("standard.verdict.json").read_text(encoding="utf-8"))
-    assert vd["overall"] == "drift"
+    assert json.loads(card.with_name("standard.verdict.json").read_text())["overall"] == "drift"

--- a/tests/test_card_verdicts.py
+++ b/tests/test_card_verdicts.py
@@ -1,4 +1,4 @@
-from scripts._compare.report_cards import CardContext, render
+from _card_helpers import _state, _run_card
 
 # One within-tol observable; the rest are absent -> 'not_compared' -> 'ungraded'.
 _PER_OBS = {"rna_mass": [
@@ -15,45 +15,33 @@ _PER_OBS = {"rna_mass": [
 ]}
 
 
-def _ctx():
-    return CardContext(config_name="basal", variant=0, v2_dir="", ve_dir="",
-                       seeds=1, gens=1, per_obs=_PER_OBS)
-
-
-def _verdict_section(sections):
-    hits = [s for s in sections if "verdict_axes" in s]
-    assert len(hits) == 1, "exactly one section must carry the verdict"
-    return hits[0]
-
-
 def test_parca_card_emits_verdict_and_axes():
-    sec = render("parca", _ctx())[0]
-    assert "verdict_axes" in sec
+    out = _run_card("parca", _state(_PER_OBS))
     # the t~0 rna_mass init (~1%) is graded -> a parca.* axis, within tolerance
-    assert any(a["id"].startswith("parca.") for a in sec["verdict_axes"])
-    assert sec["verdict"] == "within_tol"
+    assert any(a["id"].startswith("parca.") for a in out["axes"])
+    assert out["verdict"] == "within_tol"
 
 
 def test_standard_card_emits_verdict_and_axes():
-    sec = _verdict_section(render("standard", _ctx()))
-    assert sec["verdict"] in {"within_tol", "drift", "mismatch", "ungraded"}
-    ids = {a["id"] for a in sec["verdict_axes"]}
+    out = _run_card("standard", _state(_PER_OBS))
+    assert out["verdict"] in {"within_tol", "drift", "mismatch", "ungraded"}
+    ids = {a["id"] for a in out["axes"]}
     assert any(i.startswith("standard.") for i in ids)
     # not_compared rows map to 'ungraded', never the literal 'not_compared'.
-    assert all(a["verdict"] != "not_compared" for a in sec["verdict_axes"])
+    assert all(a["verdict"] != "not_compared" for a in out["axes"])
     # the one matched observable is within_tol -> card overall within_tol.
-    assert sec["verdict"] == "within_tol"
+    assert out["verdict"] == "within_tol"
 
 
 def test_statistical_card_emits_verdict_and_axes():
-    sec = render("statistical", _ctx())[0]
-    assert "verdict_axes" in sec and isinstance(sec["verdict_axes"], list)
-    assert sec["verdict"] in {"within_tol", "drift", "mismatch", "ungraded"}
+    out = _run_card("statistical", _state(_PER_OBS))
+    assert isinstance(out["axes"], list)
+    assert out["verdict"] in {"within_tol", "drift", "mismatch", "ungraded"}
     # Fixture has 5 rna_mass seeds -> at least one graded axis.
-    assert len(sec["verdict_axes"]) > 0
-    assert any(a["verdict"] != "ungraded" for a in sec["verdict_axes"])
+    assert len(out["axes"]) > 0
+    assert any(a["verdict"] != "ungraded" for a in out["axes"])
     # ~1% rna_mass difference (100 vs 101 mean) -> within_tol.
-    assert sec["verdict"] == "within_tol"
+    assert out["verdict"] == "within_tol"
     # Every verdict axis must carry exactly the required 6 keys.
     assert all({"id", "label", "verdict", "value", "meter", "detail"} <= set(a)
-               for a in sec["verdict_axes"])
+               for a in out["axes"])

--- a/tests/test_report_card_steps.py
+++ b/tests/test_report_card_steps.py
@@ -28,3 +28,36 @@ def test_as_step_card_round_trips_through_core():
                        "plot_trajs": {}, "v2_bounds": [], "config": {},
                        "v2_dir": "", "ve_dir": ""})
     assert out["verdict"] == "within_tol" and "basal" in out["card_html"]
+
+
+def _state(per_obs, name="basal", seeds=1, gens=4, variant=0, config=None):
+    return {"name": name, "condition": "basal", "seeds": seeds, "generations": gens,
+            "variant": variant, "observables": per_obs, "plot_trajs": {},
+            "v2_bounds": [], "config": config or {}, "v2_dir": "", "ve_dir": ""}
+
+
+# 5 seeds so the t-test / median have data; one within-tol observable.
+_PO = {"rna_mass": [{"median_rel": 0.02, "max_rel": 0.05, "init_ve": 100.0,
+                     "init_v2": 101.0, "init_t": 60.0, "ve_mean": 100.0, "v2_mean": 101.0}
+                    for _ in range(5)]}
+
+
+def _run_card(name, state):
+    from v2ecoli.core import build_core
+    from scripts._compare.report_cards import REPORT_CARD_STEPS
+    core = build_core(); core.register_links(REPORT_CARD_STEPS)
+    step = core.link_registry[f"{name}_report_card"](config={}, core=core)
+    return step.update(state)
+
+
+def test_standard_step_grades_and_renders():
+    out = _run_card("standard", _state(_PO))
+    assert out["verdict"] in {"within_tol", "drift", "mismatch", "ungraded"}
+    assert any(a["id"].startswith("standard.") for a in out["axes"])
+    assert "<" in out["card_html"]
+
+
+def test_parca_step_grades_initial_state():
+    out = _run_card("parca", _state(_PO))
+    assert out["verdict"] == "within_tol"
+    assert any(a["id"].startswith("parca.") for a in out["axes"])

--- a/tests/test_report_card_steps.py
+++ b/tests/test_report_card_steps.py
@@ -61,3 +61,15 @@ def test_parca_step_grades_initial_state():
     out = _run_card("parca", _state(_PO))
     assert out["verdict"] == "within_tol"
     assert any(a["id"].startswith("parca.") for a in out["axes"])
+
+
+def test_statistical_step_grades():
+    out = _run_card("statistical", _state(_PO, name="statistical", seeds=4))
+    assert out["verdict"] == "within_tol"
+    assert out["axes"]
+
+
+def test_config_step_is_ungraded_and_renders_config():
+    out = _run_card("config", _state({}, name="basal", config={"condition": "basal"}))
+    assert out["verdict"] == "ungraded" and out["axes"] == []
+    assert "basal" in out["card_html"]

--- a/tests/test_report_card_steps.py
+++ b/tests/test_report_card_steps.py
@@ -1,0 +1,30 @@
+from process_bigraph.composite import as_step
+from v2ecoli.core import build_core
+from scripts._compare.report_cards import _sections_to_html, CARD_INPUTS, CARD_OUTPUTS
+
+
+def test_sections_to_html_renders_html_and_rows():
+    html = _sections_to_html([
+        {"title": "A", "html": "<b>hi</b>"},
+        {"title": "B", "rows": [{"label": "x", "left": "1", "right": "2",
+                                 "verdict": "within_tol", "reason": "ok"}]},
+    ])
+    assert html.lstrip().startswith("<")
+    assert "<b>hi</b>" in html and "A" in html
+    assert "x" in html and "within_tol" in html        # rows rendered as a table
+
+
+def test_as_step_card_round_trips_through_core():
+    @as_step(inputs=CARD_INPUTS, outputs=CARD_OUTPUTS, name="probe_report_card",
+             aliases=["probe"])
+    def update_probe_report_card(state):
+        return {"card_html": f"<p>{state['name']}</p>", "verdict": "within_tol", "axes": []}
+    core = build_core()
+    core.register_link("probe_report_card", update_probe_report_card)
+    StepCls = core.link_registry["probe_report_card"]
+    step = StepCls(config={}, core=core)
+    out = step.update({"name": "basal", "condition": "basal", "seeds": 1,
+                       "generations": 4, "variant": 0, "observables": {},
+                       "plot_trajs": {}, "v2_bounds": [], "config": {},
+                       "v2_dir": "", "ve_dir": ""})
+    assert out["verdict"] == "within_tol" and "basal" in out["card_html"]

--- a/tests/test_report_card_steps.py
+++ b/tests/test_report_card_steps.py
@@ -1,6 +1,7 @@
 from process_bigraph.composite import as_step
 from v2ecoli.core import build_core
 from scripts._compare.report_cards import _sections_to_html, CARD_INPUTS, CARD_OUTPUTS
+from _card_helpers import _state, _run_card
 
 
 def test_sections_to_html_renders_html_and_rows():
@@ -30,24 +31,10 @@ def test_as_step_card_round_trips_through_core():
     assert out["verdict"] == "within_tol" and "basal" in out["card_html"]
 
 
-def _state(per_obs, name="basal", seeds=1, gens=4, variant=0, config=None):
-    return {"name": name, "condition": "basal", "seeds": seeds, "generations": gens,
-            "variant": variant, "observables": per_obs, "plot_trajs": {},
-            "v2_bounds": [], "config": config or {}, "v2_dir": "", "ve_dir": ""}
-
-
 # 5 seeds so the t-test / median have data; one within-tol observable.
 _PO = {"rna_mass": [{"median_rel": 0.02, "max_rel": 0.05, "init_ve": 100.0,
                      "init_v2": 101.0, "init_t": 60.0, "ve_mean": 100.0, "v2_mean": 101.0}
                     for _ in range(5)]}
-
-
-def _run_card(name, state):
-    from v2ecoli.core import build_core
-    from scripts._compare.report_cards import REPORT_CARD_STEPS
-    core = build_core(); core.register_links(REPORT_CARD_STEPS)
-    step = core.link_registry[f"{name}_report_card"](config={}, core=core)
-    return step.update(state)
 
 
 def test_standard_step_grades_and_renders():

--- a/tests/test_report_cards.py
+++ b/tests/test_report_cards.py
@@ -3,7 +3,7 @@ from _card_helpers import _state, _run_card
 
 
 def test_builtin_cards_registered():
-    for name in ("standard", "statistical", "parca", "config_diff"):
+    for name in ("standard", "statistical", "parca", "config_diff", "config"):
         assert f"{name}_report_card" in REPORT_CARD_STEPS
 
 

--- a/tests/test_report_cards.py
+++ b/tests/test_report_cards.py
@@ -1,43 +1,23 @@
-import pytest
-from scripts._compare import report_cards as rc
-
-
-def test_register_and_get():
-    @rc.report_card("dummy_card_xyz")
-    def _c(ctx):
-        return {"title": "T", "kind": "content", "html": "<p>x</p>", "anchor": "a"}
-    assert "dummy_card_xyz" in rc.all_names()
-    fn = rc.get("dummy_card_xyz")
-    out = rc.render("dummy_card_xyz", _ctx())
-    assert out[0]["title"] == "T" and out[0]["html"]
-
-
-def test_get_unknown_raises():
-    with pytest.raises(KeyError):
-        rc.get("does_not_exist")
-
-
-def _ctx():
-    return rc.CardContext(config_name="basal", variant=0, v2_dir="", ve_dir="",
-                          seeds=1, gens=1, per_obs={}, plot_trajs={}, v2_bounds={},
-                          config={})
+from scripts._compare.report_cards import REPORT_CARD_STEPS
+from _card_helpers import _state, _run_card
 
 
 def test_builtin_cards_registered():
     for name in ("standard", "statistical", "parca", "config_diff"):
-        assert name in rc.all_names()
+        assert f"{name}_report_card" in REPORT_CARD_STEPS
 
 
 def test_statistical_card_returns_graded_section():
-    ctx = rc.CardContext(config_name="basal", variant=0, v2_dir="", ve_dir="",
-                         seeds=2, gens=1,
-                         per_obs={"cell_mass": [{"ve_mean": 1.0, "v2_mean": 1.0},
-                                                {"ve_mean": 1.1, "v2_mean": 1.05}],
-                                  "growth_rate": [{"ve_mean": 2e-4, "v2_mean": 2e-4},
-                                                  {"ve_mean": 2.1e-4, "v2_mean": 2.05e-4}]},
-                         plot_trajs={}, v2_bounds={}, config={})
-    secs = rc.render("statistical", ctx)
-    assert secs[0]["html"] and secs[0]["verdict"] in (
+    per_obs = {"cell_mass": [{"ve_mean": 1.0, "v2_mean": 1.0, "median_rel": 0.0,
+                               "max_rel": 0.0, "init_ve": 1.0, "init_v2": 1.0, "init_t": 0.0},
+                              {"ve_mean": 1.1, "v2_mean": 1.05, "median_rel": 0.05,
+                               "max_rel": 0.05, "init_ve": 1.1, "init_v2": 1.05, "init_t": 0.0}],
+               "growth_rate": [{"ve_mean": 2e-4, "v2_mean": 2e-4, "median_rel": 0.0,
+                                 "max_rel": 0.0, "init_ve": 2e-4, "init_v2": 2e-4, "init_t": 0.0},
+                                {"ve_mean": 2.1e-4, "v2_mean": 2.05e-4, "median_rel": 0.05,
+                                 "max_rel": 0.05, "init_ve": 2.1e-4, "init_v2": 2.05e-4, "init_t": 0.0}]}
+    out = _run_card("statistical", _state(per_obs, name="basal", seeds=2))
+    assert out["card_html"] and out["verdict"] in (
         "within_tol", "drift", "mismatch", "ungraded")
 
 

--- a/tests/test_viz_cards.py
+++ b/tests/test_viz_cards.py
@@ -6,17 +6,16 @@ def test_writes_html_and_verdict_per_card(tmp_path):
     cards = [
         {"name": "standard", "verdict": "drift",
          "axes": [{"id": "standard.rna", "verdict": "drift"}],
-         "sections": [{"title": "basal — evaluation", "html": "<table>rows</table>"}]},
+         "html": "<!DOCTYPE html><b>standard card</b>"},
         {"name": "config", "verdict": "ungraded", "axes": [],
-         "sections": [{"title": "basal — config", "html": "<pre>cfg</pre>"}]},
+         "html": "<b>config card</b>"},
     ]
     paths = write_report_cards(tmp_path, cards)
     rc = tmp_path / "viz" / "report_card"
     assert (rc / "standard.html").is_file() and (rc / "standard.verdict.json").is_file()
     assert (rc / "config.html").is_file()
     html = (rc / "standard.html").read_text(encoding="utf-8")
-    assert "<table>rows</table>" in html and "basal — evaluation" in html
-    assert html.lstrip().startswith("<!DOCTYPE html>")
+    assert html == "<!DOCTYPE html><b>standard card</b>"
     vd = json.loads((rc / "standard.verdict.json").read_text(encoding="utf-8"))
     assert vd["overall"] == "drift"
     assert vd["groups"]["standard"]["verdict"] == "drift"

--- a/v2ecoli/core.py
+++ b/v2ecoli/core.py
@@ -96,6 +96,12 @@ def build_core():
         core.register_link("BiRDTransportHours", BiRDTransportHours)
     except Exception:
         pass
+    # Report-card Steps (resolved by name in the comparison harness).
+    try:
+        from scripts._compare.report_cards import REPORT_CARD_STEPS
+        core.register_links(REPORT_CARD_STEPS)
+    except Exception:  # noqa: BLE001 — never let card registration break build_core
+        pass
     return core
 
 


### PR DESCRIPTION
Converts the comparison harness's report cards from a bespoke `@report_card`/`REGISTRY`/`CardContext`/`render` registry into first-class process-bigraph **`as_step` Steps** registered in the bigraph-schema **core**, resolved by name and invoked by the harness. The shareable infrastructure becomes process-bigraph itself (`as_step` + the core) — any project whose `build_core` calls `register_links(REPORT_CARD_STEPS)` gets the cards.

## What changed
- **Typed Step contract** (`CARD_INPUTS`/`CARD_OUTPUTS`) — all bigraph type strings validated against `build_core()` (`tree[list[map]]`, `tree[map]`, `list[float]`, `overwrite[string]`, `overwrite[list[map]]`).
- **5 cards → `@as_step` Steps**: `standard`, `parca`, `statistical`, `config`, `config_diff`. Each `update_*(state)` returns `{card_html, verdict, axes}`.
- **Registration**: `v2ecoli/core.py::build_core` does `core.register_links(REPORT_CARD_STEPS)` (guarded). Resolution via `core.link_registry["<card>_report_card"]`.
- **Harness cutover**: `assemble_from_studies` resolves + `update`s each Step; `viz_cards.write_report_cards` takes pre-rendered `html`.
- **Removed** the bespoke registry entirely; tests ported to the Step interface via shared `tests/_card_helpers.py`.

## Unchanged (by design)
Pure Steps — the harness still writes `viz/report_card/<card>.{html,verdict.json}` and aggregates the per-condition verdict. `materialize.py`, `study_spec.py`, `verdict.py`, the dashboard, and the `viz/report_card` + `tests:[{kind: report_card}]` contract are untouched. Grading logic is behaviorally identical (Step bodies call the same `_*_sections_and_axes`/`build_report_card` functions).

## Verification
- 42 tests green across the comparison suite (`test_report_card_steps`, `test_card_verdicts`, `test_report_cards`, `test_assemble_studies`, `test_viz_cards`, `test_comparison_verdict`, `test_study_spec`, `test_materialize`, `test_compare_cli`, `test_modular_tests_integration`).
- Built via subagent-driven development: fresh implementer + task reviewer per task (5 tasks), plus a final whole-branch review (verdict: ready to merge, no Critical/Important defects).

🤖 Generated with [Claude Code](https://claude.com/claude-code)