### PR TITLE
Refresh v2ecoli↔vEcoli comparison verdicts (latest 7-study run)

### DIFF
--- a/docs/report_cards/v2ecoli-vecoli-comparison/acetate/report_card_verdict.json
+++ b/docs/report_cards/v2ecoli-vecoli-comparison/acetate/report_card_verdict.json
@@ -3,72 +3,68 @@
   "model_ref": "v2ecoli @ acetate",
   "reference_model": "vEcoli @ acetate",
   "generated": "",
-  "overall": "mismatch",
+  "overall": "drift",
   "groups": {
     "config": {
       "verdict": "ungraded",
       "axes": []
     },
-    "parca": {
-      "verdict": "ungraded",
-      "axes": []
-    },
     "standard": {
-      "verdict": "mismatch",
+      "verdict": "drift",
       "axes": [
         {
           "id": "standard.cell mass (fg)",
           "label": "cell mass (fg)",
           "verdict": "within_tol",
-          "value": 0.028056597012994372,
-          "meter": "t~60s init Δ=+0.56%; gen-1 matched median |Δ|=2.81% (median of 1 seed)",
+          "value": 0.006738335067586629,
+          "meter": "t~60s init Δ=+0.26%; gen-1 matched median |Δ|=0.67% (median of 1 seed)",
           "detail": {
-            "median_rel": 0.028056597012994372,
-            "max_rel": 0.08947475109192696
+            "median_rel": 0.006738335067586629,
+            "max_rel": 0.07396070737712762
           }
         },
         {
           "id": "standard.dry mass (fg)",
           "label": "dry mass (fg)",
           "verdict": "within_tol",
-          "value": 0.027852840953131026,
-          "meter": "t~60s init Δ=+0.56%; gen-1 matched median |Δ|=2.79% (median of 1 seed)",
+          "value": 0.006763391294215052,
+          "meter": "t~60s init Δ=+0.26%; gen-1 matched median |Δ|=0.68% (median of 1 seed)",
           "detail": {
-            "median_rel": 0.027852840953131026,
-            "max_rel": 0.08934537593773241
+            "median_rel": 0.006763391294215052,
+            "max_rel": 0.0742025653983969
           }
         },
         {
           "id": "standard.protein mass (fg)",
           "label": "protein mass (fg)",
           "verdict": "within_tol",
-          "value": 0.01303898996128371,
-          "meter": "t~60s init Δ=+0.28%; gen-1 matched median |Δ|=1.30% (median of 1 seed)",
+          "value": 0.006801273247126157,
+          "meter": "t~60s init Δ=+0.11%; gen-1 matched median |Δ|=0.68% (median of 1 seed)",
           "detail": {
-            "median_rel": 0.01303898996128371,
-            "max_rel": 0.043575197863774125
+            "median_rel": 0.006801273247126157,
+            "max_rel": 0.03920087078860991
           }
         },
         {
           "id": "standard.RNA mass (fg)",
           "label": "RNA mass (fg)",
-          "verdict": "drift",
-          "value": 0.07575516056351667,
-          "meter": "t~60s init Δ=+2.78%; gen-1 matched median |Δ|=7.58% (median of 1 seed)",
+          "verdict": "within_tol",
+          "value": 0.01230258576014922,
+          "meter": "t~60s init Δ=+1.11%; gen-1 matched median |Δ|=1.23% (median of 1 seed)",
           "detail": {
-            "median_rel": 0.07575516056351667,
-            "max_rel": 0.15286781391121446
+            "median_rel": 0.01230258576014922,
+            "max_rel": 0.07582537027143481
           }
         },
         {
           "id": "standard.growth rate (1/s)",
           "label": "growth rate (1/s)",
-          "verdict": "mismatch",
-          "value": 0.16980511002186022,
-          "meter": "t~60s init Δ=+16.84%; gen-1 matched median |Δ|=16.98% (median of 1 seed)",
+          "verdict": "drift",
+          "value": 0.06943642515601448,
+          "meter": "t~60s init Δ=-13.05%; gen-1 matched median |Δ|=6.94% (median of 1 seed)",
           "detail": {
-            "median_rel": 0.16980511002186022,
-            "max_rel": 0.9816832561984723
+            "median_rel": 0.06943642515601448,
+            "max_rel": 0.8612057619618421
           }
         },
         {

--- a/docs/report_cards/v2ecoli-vecoli-comparison/basal/report_card_verdict.json
+++ b/docs/report_cards/v2ecoli-vecoli-comparison/basal/report_card_verdict.json
@@ -9,10 +9,6 @@
       "verdict": "ungraded",
       "axes": []
     },
-    "parca": {
-      "verdict": "ungraded",
-      "axes": []
-    },
     "standard": {
       "verdict": "drift",
       "axes": [
@@ -20,55 +16,55 @@
           "id": "standard.cell mass (fg)",
           "label": "cell mass (fg)",
           "verdict": "within_tol",
-          "value": 0.018387893497392255,
-          "meter": "t~60s init Δ=-0.10%; gen-1 matched median |Δ|=1.84% (median of 1 seed)",
+          "value": 0.027776400420454907,
+          "meter": "t~60s init Δ=+0.05%; gen-1 matched median |Δ|=2.78% (median of 1 seed)",
           "detail": {
-            "median_rel": 0.018387893497392255,
-            "max_rel": 0.03277006091161624
+            "median_rel": 0.027776400420454907,
+            "max_rel": 0.05421907791052483
           }
         },
         {
           "id": "standard.dry mass (fg)",
           "label": "dry mass (fg)",
           "verdict": "within_tol",
-          "value": 0.018382204379082598,
-          "meter": "t~60s init Δ=-0.10%; gen-1 matched median |Δ|=1.84% (median of 1 seed)",
+          "value": 0.02784764305195052,
+          "meter": "t~60s init Δ=+0.06%; gen-1 matched median |Δ|=2.78% (median of 1 seed)",
           "detail": {
-            "median_rel": 0.018382204379082598,
-            "max_rel": 0.032788723621133255
+            "median_rel": 0.02784764305195052,
+            "max_rel": 0.0542375665761026
           }
         },
         {
           "id": "standard.protein mass (fg)",
           "label": "protein mass (fg)",
           "verdict": "within_tol",
-          "value": 0.024560298443208776,
-          "meter": "t~60s init Δ=-0.09%; gen-1 matched median |Δ|=2.46% (median of 1 seed)",
+          "value": 0.023310620078258303,
+          "meter": "t~60s init Δ=-0.02%; gen-1 matched median |Δ|=2.33% (median of 1 seed)",
           "detail": {
-            "median_rel": 0.024560298443208776,
-            "max_rel": 0.06431502305183485
+            "median_rel": 0.023310620078258303,
+            "max_rel": 0.045750424220644154
           }
         },
         {
           "id": "standard.RNA mass (fg)",
           "label": "RNA mass (fg)",
           "verdict": "within_tol",
-          "value": 0.008680016290896962,
-          "meter": "t~60s init Δ=-0.49%; gen-1 matched median |Δ|=0.87% (median of 1 seed)",
+          "value": 0.02379196948041154,
+          "meter": "t~60s init Δ=+0.15%; gen-1 matched median |Δ|=2.38% (median of 1 seed)",
           "detail": {
-            "median_rel": 0.008680016290896962,
-            "max_rel": 0.023746796398417546
+            "median_rel": 0.02379196948041154,
+            "max_rel": 0.05186722331606915
           }
         },
         {
           "id": "standard.growth rate (1/s)",
           "label": "growth rate (1/s)",
           "verdict": "drift",
-          "value": 0.06676479930713267,
-          "meter": "t~60s init Δ=+5.71%; gen-1 matched median |Δ|=6.68% (median of 1 seed)",
+          "value": 0.07710558104539517,
+          "meter": "t~60s init Δ=+11.95%; gen-1 matched median |Δ|=7.71% (median of 1 seed)",
           "detail": {
-            "median_rel": 0.06676479930713267,
-            "max_rel": 0.4178977810269291
+            "median_rel": 0.07710558104539517,
+            "max_rel": 0.5395168804048324
           }
         },
         {

--- a/docs/report_cards/v2ecoli-vecoli-comparison/no_oxygen/report_card_verdict.json
+++ b/docs/report_cards/v2ecoli-vecoli-comparison/no_oxygen/report_card_verdict.json
@@ -9,10 +9,6 @@
       "verdict": "ungraded",
       "axes": []
     },
-    "parca": {
-      "verdict": "ungraded",
-      "axes": []
-    },
     "standard": {
       "verdict": "drift",
       "axes": [
@@ -20,55 +16,55 @@
           "id": "standard.cell mass (fg)",
           "label": "cell mass (fg)",
           "verdict": "within_tol",
-          "value": 0.02428140600002983,
-          "meter": "t~60s init Δ=+0.20%; gen-1 matched median |Δ|=2.43% (median of 1 seed)",
+          "value": 0.01097222154855857,
+          "meter": "t~60s init Δ=-0.06%; gen-1 matched median |Δ|=1.10% (median of 1 seed)",
           "detail": {
-            "median_rel": 0.02428140600002983,
-            "max_rel": 0.06453167925391141
+            "median_rel": 0.01097222154855857,
+            "max_rel": 0.03610581423148213
           }
         },
         {
           "id": "standard.dry mass (fg)",
           "label": "dry mass (fg)",
           "verdict": "within_tol",
-          "value": 0.02430646819308814,
-          "meter": "t~60s init Δ=+0.21%; gen-1 matched median |Δ|=2.43% (median of 1 seed)",
+          "value": 0.01100088944579295,
+          "meter": "t~60s init Δ=-0.06%; gen-1 matched median |Δ|=1.10% (median of 1 seed)",
           "detail": {
-            "median_rel": 0.02430646819308814,
-            "max_rel": 0.06450449675590875
+            "median_rel": 0.01100088944579295,
+            "max_rel": 0.03604162680448985
           }
         },
         {
           "id": "standard.protein mass (fg)",
           "label": "protein mass (fg)",
           "verdict": "within_tol",
-          "value": 0.005152989813191519,
-          "meter": "t~60s init Δ=+0.00%; gen-1 matched median |Δ|=0.52% (median of 1 seed)",
+          "value": 0.0140529094873271,
+          "meter": "t~60s init Δ=-0.05%; gen-1 matched median |Δ|=1.41% (median of 1 seed)",
           "detail": {
-            "median_rel": 0.005152989813191519,
-            "max_rel": 0.021166683196430086
+            "median_rel": 0.0140529094873271,
+            "max_rel": 0.06760516366865185
           }
         },
         {
           "id": "standard.RNA mass (fg)",
           "label": "RNA mass (fg)",
-          "verdict": "within_tol",
-          "value": 0.041034004833742935,
-          "meter": "t~60s init Δ=+0.02%; gen-1 matched median |Δ|=4.10% (median of 1 seed)",
+          "verdict": "drift",
+          "value": 0.07143351256612963,
+          "meter": "t~60s init Δ=-0.95%; gen-1 matched median |Δ|=7.14% (median of 1 seed)",
           "detail": {
-            "median_rel": 0.041034004833742935,
-            "max_rel": 0.07494186808090224
+            "median_rel": 0.07143351256612963,
+            "max_rel": 0.09763179037060907
           }
         },
         {
           "id": "standard.growth rate (1/s)",
           "label": "growth rate (1/s)",
           "verdict": "drift",
-          "value": 0.07832415078032935,
-          "meter": "t~60s init Δ=+17.55%; gen-1 matched median |Δ|=7.83% (median of 1 seed)",
+          "value": 0.06837703773723518,
+          "meter": "t~60s init Δ=+6.86%; gen-1 matched median |Δ|=6.84% (median of 1 seed)",
           "detail": {
-            "median_rel": 0.07832415078032935,
-            "max_rel": 0.8653892543304893
+            "median_rel": 0.06837703773723518,
+            "max_rel": 0.8232119060558148
           }
         },
         {

--- a/docs/report_cards/v2ecoli-vecoli-comparison/succinate/report_card_verdict.json
+++ b/docs/report_cards/v2ecoli-vecoli-comparison/succinate/report_card_verdict.json
@@ -9,10 +9,6 @@
       "verdict": "ungraded",
       "axes": []
     },
-    "parca": {
-      "verdict": "ungraded",
-      "axes": []
-    },
     "standard": {
       "verdict": "mismatch",
       "axes": [
@@ -20,55 +16,55 @@
           "id": "standard.cell mass (fg)",
           "label": "cell mass (fg)",
           "verdict": "within_tol",
-          "value": 0.04054176738033932,
-          "meter": "t~60s init Δ=+0.36%; gen-1 matched median |Δ|=4.05% (median of 1 seed)",
+          "value": 0.015096400605499983,
+          "meter": "t~60s init Δ=-0.09%; gen-1 matched median |Δ|=1.51% (median of 1 seed)",
           "detail": {
-            "median_rel": 0.04054176738033932,
-            "max_rel": 0.10516054534007165
+            "median_rel": 0.015096400605499983,
+            "max_rel": 0.07548791731179019
           }
         },
         {
           "id": "standard.dry mass (fg)",
           "label": "dry mass (fg)",
           "verdict": "within_tol",
-          "value": 0.04059076567286418,
-          "meter": "t~60s init Δ=+0.36%; gen-1 matched median |Δ|=4.06% (median of 1 seed)",
+          "value": 0.015082120591729704,
+          "meter": "t~60s init Δ=-0.08%; gen-1 matched median |Δ|=1.51% (median of 1 seed)",
           "detail": {
-            "median_rel": 0.04059076567286418,
-            "max_rel": 0.10517342226198273
+            "median_rel": 0.015082120591729704,
+            "max_rel": 0.07551746804650447
           }
         },
         {
           "id": "standard.protein mass (fg)",
           "label": "protein mass (fg)",
           "verdict": "within_tol",
-          "value": 0.019389953430041053,
-          "meter": "t~60s init Δ=+0.15%; gen-1 matched median |Δ|=1.94% (median of 1 seed)",
+          "value": 0.005743479068580663,
+          "meter": "t~60s init Δ=-0.08%; gen-1 matched median |Δ|=0.57% (median of 1 seed)",
           "detail": {
-            "median_rel": 0.019389953430041053,
-            "max_rel": 0.06746595153818258
+            "median_rel": 0.005743479068580663,
+            "max_rel": 0.10347695881560481
           }
         },
         {
           "id": "standard.RNA mass (fg)",
           "label": "RNA mass (fg)",
-          "verdict": "drift",
-          "value": 0.0636431471291697,
-          "meter": "t~60s init Δ=+1.74%; gen-1 matched median |Δ|=6.36% (median of 1 seed)",
+          "verdict": "within_tol",
+          "value": 0.026097488601379393,
+          "meter": "t~60s init Δ=-0.49%; gen-1 matched median |Δ|=2.61% (median of 1 seed)",
           "detail": {
-            "median_rel": 0.0636431471291697,
-            "max_rel": 0.13556710083534068
+            "median_rel": 0.026097488601379393,
+            "max_rel": 0.059290300329077505
           }
         },
         {
           "id": "standard.growth rate (1/s)",
           "label": "growth rate (1/s)",
           "verdict": "mismatch",
-          "value": 0.10150308173105242,
-          "meter": "t~60s init Δ=+0.56%; gen-1 matched median |Δ|=10.15% (median of 1 seed)",
+          "value": 0.12046132285628307,
+          "meter": "t~60s init Δ=-0.85%; gen-1 matched median |Δ|=12.05% (median of 1 seed)",
           "detail": {
-            "median_rel": 0.10150308173105242,
-            "max_rel": 0.4396743198775074
+            "median_rel": 0.12046132285628307,
+            "max_rel": 0.9375676953660699
           }
         },
         {

--- a/docs/report_cards/v2ecoli-vecoli-comparison/with_aa/report_card_verdict.json
+++ b/docs/report_cards/v2ecoli-vecoli-comparison/with_aa/report_card_verdict.json
@@ -3,72 +3,68 @@
   "model_ref": "v2ecoli @ with_aa",
   "reference_model": "vEcoli @ with_aa",
   "generated": "",
-  "overall": "drift",
+  "overall": "mismatch",
   "groups": {
     "config": {
       "verdict": "ungraded",
       "axes": []
     },
-    "parca": {
-      "verdict": "ungraded",
-      "axes": []
-    },
     "standard": {
-      "verdict": "drift",
+      "verdict": "mismatch",
       "axes": [
         {
           "id": "standard.cell mass (fg)",
           "label": "cell mass (fg)",
           "verdict": "within_tol",
-          "value": 0.01273885463443923,
-          "meter": "t~60s init Δ=-1.18%; gen-1 matched median |Δ|=1.27% (median of 1 seed)",
+          "value": 0.021441575557716953,
+          "meter": "t~60s init Δ=+0.83%; gen-1 matched median |Δ|=2.14% (median of 1 seed)",
           "detail": {
-            "median_rel": 0.01273885463443923,
-            "max_rel": 0.023183459759760723
+            "median_rel": 0.021441575557716953,
+            "max_rel": 0.05065115941334701
           }
         },
         {
           "id": "standard.dry mass (fg)",
           "label": "dry mass (fg)",
           "verdict": "within_tol",
-          "value": 0.012774349669920162,
-          "meter": "t~60s init Δ=-1.19%; gen-1 matched median |Δ|=1.28% (median of 1 seed)",
+          "value": 0.0215437606829538,
+          "meter": "t~60s init Δ=+0.84%; gen-1 matched median |Δ|=2.15% (median of 1 seed)",
           "detail": {
-            "median_rel": 0.012774349669920162,
-            "max_rel": 0.023282121841869355
+            "median_rel": 0.0215437606829538,
+            "max_rel": 0.05075788043477805
           }
         },
         {
           "id": "standard.protein mass (fg)",
           "label": "protein mass (fg)",
           "verdict": "within_tol",
-          "value": 0.015086967997875546,
-          "meter": "t~60s init Δ=-0.44%; gen-1 matched median |Δ|=1.51% (median of 1 seed)",
+          "value": 0.01691998378294464,
+          "meter": "t~60s init Δ=+0.59%; gen-1 matched median |Δ|=1.69% (median of 1 seed)",
           "detail": {
-            "median_rel": 0.015086967997875546,
-            "max_rel": 0.043617373962016724
+            "median_rel": 0.01691998378294464,
+            "max_rel": 0.03723899591297472
           }
         },
         {
           "id": "standard.RNA mass (fg)",
           "label": "RNA mass (fg)",
-          "verdict": "drift",
-          "value": 0.07491714383367788,
-          "meter": "t~60s init Δ=-3.30%; gen-1 matched median |Δ|=7.49% (median of 1 seed)",
+          "verdict": "mismatch",
+          "value": 0.12402496789493633,
+          "meter": "t~60s init Δ=+3.80%; gen-1 matched median |Δ|=12.40% (median of 1 seed)",
           "detail": {
-            "median_rel": 0.07491714383367788,
-            "max_rel": 0.16550652392916726
+            "median_rel": 0.12402496789493633,
+            "max_rel": 0.20293219881563573
           }
         },
         {
           "id": "standard.growth rate (1/s)",
           "label": "growth rate (1/s)",
-          "verdict": "within_tol",
-          "value": 0.026793065897298986,
-          "meter": "t~60s init Δ=-1.78%; gen-1 matched median |Δ|=2.68% (median of 1 seed)",
+          "verdict": "drift",
+          "value": 0.07547634095518133,
+          "meter": "t~60s init Δ=+4.32%; gen-1 matched median |Δ|=7.55% (median of 1 seed)",
           "detail": {
-            "median_rel": 0.026793065897298986,
-            "max_rel": 0.11217376547178211
+            "median_rel": 0.07547634095518133,
+            "max_rel": 0.25779049175079954
           }
         },
         {

--- a/workspace/investigations/v2ecoli-vecoli-comparison/studies/acetate/study.yaml
+++ b/workspace/investigations/v2ecoli-vecoli-comparison/studies/acetate/study.yaml
@@ -20,11 +20,11 @@ runs:
   canonical: true
   description: v2e-compare study acetate
   status: completed
-  result: FAIL
+  result: PARTIAL
   outcomes:
     standard-vs-vecoli:
-      result: FAIL
-      detail: 'report card ''standard'': mismatch'
+      result: PARTIAL
+      detail: 'report card ''standard'': drift'
 status: evaluated
 tests:
 - name: config-vs-vecoli

--- a/workspace/investigations/v2ecoli-vecoli-comparison/studies/with_aa/study.yaml
+++ b/workspace/investigations/v2ecoli-vecoli-comparison/studies/with_aa/study.yaml
@@ -20,11 +20,11 @@ runs:
   canonical: true
   description: v2e-compare study with_aa
   status: completed
-  result: PARTIAL
+  result: FAIL
   outcomes:
     standard-vs-vecoli:
-      result: PARTIAL
-      detail: 'report card ''standard'': drift'
+      result: FAIL
+      detail: 'report card ''standard'': mismatch'
 status: evaluated
 tests:
 - name: config-vs-vecoli


### PR DESCRIPTION
Refreshes the committed verdict artifacts for the **v2ecoli-vecoli-comparison** investigation from the latest full 7-study run.

## Evaluated verdicts
| Study | Verdict |
|---|---|
| parca | within_tol (PASS) — initial states match, Δ~0.05% |
| basal | drift (PARTIAL) |
| no_oxygen | drift (PARTIAL) |
| acetate | drift (PARTIAL) |
| with_aa | mismatch (FAIL) |
| succinate | mismatch (FAIL) |

ParCa/initial-state agreement is excellent; dynamic trajectories diverge under richer and alternate carbon/oxygen conditions.

## What changed
- Per-condition `docs/report_cards/v2ecoli-vecoli-comparison/<study>/report_card_verdict.json` aggregates refreshed.
- `acetate`/`with_aa` `study.yaml` run outcomes updated to the current results.
- Stale empty `parca` groups dropped from conditions that don't run the parca card.

Data only — no code. Grading logic is unchanged under the `as_step` report-card refactor (PR #306); these verdicts are identical to what that path produces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)