### PR TITLE
Run the last generation to its division in the xarray multigen runner

### DIFF
--- a/scripts/run_comparison_ensemble.py
+++ b/scripts/run_comparison_ensemble.py
@@ -565,6 +565,12 @@ def make_run_one(*, composite_kind: str, condition: str, cache_dir: str,
             max_steps=max_steps,
             max_generations=max_generations,
             chunk=chunk,
+            # Follow a single lineage (prune non-followed daughters each
+            # division) so EVERY generation — including the last — runs to its
+            # own division, matching genuine vEcoli. Without this, kept siblings
+            # trigger spurious division signals that truncate the final
+            # generation (v2ecoli would stop one generation short of vEcoli).
+            single_daughters=True,
         )
         return {"seed": seed, "wall_seconds": round(time.time() - t0, 1),
                 "store": str(store_path), **{k: result.get(k) for k in

--- a/tests/test_multigen_last_generation.py
+++ b/tests/test_multigen_last_generation.py
@@ -105,6 +105,43 @@ def _gens_in_partitions(out_dir: str, experiment_id: str) -> dict[int, dict]:
     return out
 
 
+def test_xarray_runner_every_generation_ends_at_its_division(tmp_path):
+    """The XArray runner (used by the comparison harness) must also run the
+    LAST generation to its division, not truncate it.
+
+    Regression for the "v2ecoli runs one generation fewer than vEcoli" artifact:
+    without sibling pruning the kept daughters keep dividing and surface new
+    agent ids that the division detector reads as a division — which, once
+    ``gen == max_generations``, breaks the loop and truncates the final
+    generation to a few ticks. With ``single_daughters=True`` only the followed
+    lineage survives, so every generation (incl. the last) runs to its own
+    division.
+    """
+    from v2ecoli.library.xarray_run import (
+        run_multigen_xarray, view_from_emit_paths)
+    from v2ecoli.core import build_core
+    comp = _FakeComposite(divide_period=200, dry0=350.0)
+    comp.core = build_core()      # the xarray runner reads core from composite.core
+    res = run_multigen_xarray(
+        comp,
+        store_path=str(tmp_path / "regress-xr.zarr"),
+        view=view_from_emit_paths(["listeners.mass.dry_mass"]),
+        metadata_base={"experiment_id": "regress-xr", "engine": "fake",
+                       "condition": "test", "variant": 0, "lineage_seed": 0,
+                       "time_step": 1.0, "max_duration": 900.0, "agent_id": "0"},
+        max_steps=900,            # crosses 4 divisions (at 200/400/600/800)
+        max_generations=4,
+        chunk=20,
+        single_daughters=True,
+    )
+    # All four generations reached, and the run advanced to the 4th division
+    # (~800 ticks) rather than breaking at the start of gen 4 (~620 ticks).
+    assert res["generations"] == [1, 2, 3, 4], res["generations"]
+    assert res["steps"] >= 800, (
+        f"final generation truncated: ran only {res['steps']} ticks "
+        f"(expected ~800 = 4 divisions)")
+
+
 def test_every_generation_ends_at_its_division(tmp_path):
     """PASS criteria: each generation partition holds exactly ONE cell — a
     monotonic dry_mass ramp with NO mid-partition fold-change reset — and the

--- a/v2ecoli/library/xarray_run.py
+++ b/v2ecoli/library/xarray_run.py
@@ -448,6 +448,7 @@ def run_multigen_xarray(
     initial_agent_id: str = "0",
     overwrite: bool = True,
     buffer_size: int = 3,
+    single_daughters: bool = False,
     division_detector: Callable[[set[str], set[str]], tuple[bool, str | None]] | None = None,
 ) -> dict:
     """Run a v2ecoli composite past divisions, swapping XArrayEmitters per generation.
@@ -658,6 +659,22 @@ def run_multigen_xarray(
             print(f"[multigen_xarray] gen-{gen} close hit pbg-emitters final-flush "
                   "assert (buffer full at division); flushed data retained.")
         followed = inner_next
+        # Prune the non-followed daughters so ONLY the followed lineage survives
+        # in the inner composite. Kept siblings keep growing and dividing, each
+        # surfacing a NEW agent id that the division detector reads as a division
+        # — and once gen == max_generations the very next such signal hits the
+        # `gen >= max_generations` break below, TRUNCATING the last generation to
+        # a few ticks (the "v2ecoli runs one generation fewer than vEcoli"
+        # artifact). With pruning, only the followed cell's own division ends a
+        # generation, so the last generation runs to completion like vEcoli.
+        # Mirrors run_multigen_parquet / sqlite_run's single_daughters prune.
+        if single_daughters:
+            import gc
+            from v2ecoli.library.sqlite_run import prune_to_followed_lineage
+            dropped = prune_to_followed_lineage(composite, followed)
+            gc.collect()
+            print(f"[multigen_xarray] gen {gen + 1} → following {followed!r} at "
+                  f"tick {done} (single_daughters: dropped {dropped} sibling(s))")
         partition_agent_id = daughter_phylogeny_id(partition_agent_id)[0]
         gen += 1
         gens_seen.append(gen)


### PR DESCRIPTION
## Problem
In the v2ecoli↔vEcoli comparison, **v2ecoli rendered one generation fewer than vEcoli**. For basal/seed0, v2ecoli stopped 3 ticks into generation 4 (8221→8341s) while vEcoli ran gen 4 to completion (→10920s):

| | gen1 | gen2 | gen3 | gen4 |
|---|---|---|---|---|
| vEcoli | full | full | full | **full (44 pts, →10920s)** |
| v2ecoli | full | full | full | **stub (3 pts, →8341s)** |

## Root cause
The two engines use different multigen runners. vEcoli runs via vivarium's internal engine (4 full divisions). v2ecoli runs via `run_multigen_xarray`, which kept **all** daughters at each division ("keep everything" semantics — the sqlite/parquet runners' `single_daughters` prune is off by default precisely to mirror this).

Kept siblings keep growing and dividing, each surfacing a **new agent id** that the division detector (`len(curr) > len(prev)` / any new id) reads as a division. By generation 4 enough accumulated siblings are dividing that a spurious division fires ~240s in — and since `gen >= max_generations`, the `gen-cap break` ends the generation immediately. The step caps were non-binding (`PER_GEN_STEPS=15000` ≫ ~2500 ticks/division), so steps weren't the limiter.

## Fix
Port the proven `single_daughters` prune (`prune_to_followed_lineage`) from `run_multigen_parquet`/`sqlite_run` to `run_multigen_xarray`, and enable it in the comparison ensemble. With only the followed lineage alive, a generation ends **only on the followed cell's own division**, so the last generation runs to completion like genuine vEcoli.

## Verification
- New regression test `test_xarray_runner_every_generation_ends_at_its_division` (mirrors the existing parquet-runner test) — asserts all 4 generations reached and the run advances to the 4th division (~800 ticks), not the gen-4 start.
- 43 runner tests pass (`test_multigen_last_generation`, `test_prune_to_followed_lineage`, `test_output_metadata`, `test_workflow_xarray`, `test_upstream_division`).
- A real basal v2ecoli 4-gen run is in progress to confirm gen 4 completes end-to-end; will note the result on the PR.

## Notes
Independent of #306 (as_step report cards) and #307 (verdict refresh). Once merged, re-running the comparison will render matched generation counts; the verdicts grade the overlapping window so they're unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)