### PR TITLE
feat(inject): support process swaps — convert+config+type-defer for fork processes

### DIFF
--- a/scripts/_compare/inject.py
+++ b/scripts/_compare/inject.py
@@ -266,6 +266,24 @@ def apply_injected_processes(cell_state: dict, flow_order: list, core,
     return added
 
 
+def remove_processes(cell_state: dict, flow_order: list, names) -> list[str]:
+    """Remove named processes/steps from a cell-state tree + flow order in place.
+
+    The 'remove' half of a swap: a ``swap_processes`` mapping {old: new} adds the
+    converted ``new`` (via :func:`apply_injected_processes`) and removes ``old``
+    here; a config's ``exclude_processes`` list is removed the same way. Names not
+    present are ignored (returns only the names actually removed from cell_state).
+    """
+    removed: list[str] = []
+    for name in names:
+        if name in cell_state:
+            del cell_state[name]
+            removed.append(name)
+        while name in flow_order:
+            flow_order.remove(name)
+    return removed
+
+
 if __name__ == "__main__":
     # argv: <fork_repo> <config_json_path>  -> prints specs JSON to stdout
     fork_repo, cfg_path = sys.argv[1], sys.argv[2]

--- a/scripts/_compare/inject.py
+++ b/scripts/_compare/inject.py
@@ -295,9 +295,16 @@ def apply_injected_processes(cell_state: dict, flow_order: list, core,
     for spec in specs:
         cls = _import_class(spec["module"], spec["qualname"])
         if spec["kind"] == "vivarium_1":
+            # Defer ports wiring to stores the composite already owns: use their
+            # existing types instead of this process's inferred ones (avoids the
+            # unitless-float vs quantity[fg] subtype conflict on shared stores
+            # like listeners.mass that the v2 mass deriver owns).
+            defer_ports = [p for p, path in spec["topology"].items()
+                           if path and path[0] in cell_state]
             wrapped = wrap_vivarium_process(cls, name=spec["name"],
                                             as_step=spec["as_step"],
-                                            output_ports=spec.get("output_ports"))
+                                            output_ports=spec.get("output_ports"),
+                                            defer_ports=defer_ports)
         else:  # pbg_native
             wrapped = cls
         core.register_link(spec["name"], wrapped)

--- a/scripts/_compare/inject.py
+++ b/scripts/_compare/inject.py
@@ -144,6 +144,27 @@ def _restore_ecoli(saved_real: dict, fork_repo: str) -> None:
         pass
 
 
+def translate_vivarium_topology(topo: dict) -> dict[str, list]:
+    """Translate a vivarium-1.0 topology to process-bigraph port→store paths.
+
+    A flat entry ``port: (a, b)`` becomes ``port: [a, b]``. A *nested* vivarium
+    entry ``port: {"_path": base, sub: relpath, ...}`` wires the port to its
+    ``_path`` base store (the subports live under it, matching the bridged
+    process's typed sub-ports) — so a metabolism ``environment`` port declared as
+    ``{"_path": ("environment",), "exchange": ("exchange",)}`` auto-wires to
+    ``["environment"]`` instead of the corrupt ``["_path", "exchange"]`` a plain
+    ``list()`` produced. Ports with no ``_path`` fall back to the port name.
+    """
+    out: dict[str, list] = {}
+    for port, path in dict(topo).items():
+        if isinstance(path, dict):
+            base = path.get("_path", (port,))
+            out[port] = list(base)
+        else:
+            out[port] = list(path)
+    return out
+
+
 def resolve_injections(fork_repo: str, config: dict) -> list[dict[str, Any]]:
     """Resolve add_processes/swap_processes -> a list of InjectionSpec dicts.
 
@@ -162,7 +183,9 @@ def resolve_injections(fork_repo: str, config: dict) -> list[dict[str, Any]]:
         "process_configs": config.get("process_configs") or {},
         "topology": config.get("topology") or {},
         "time_step": config.get("time_step", 1.0),
-    }, sort_keys=True)
+    }, sort_keys=True, default=str)  # default=str: process_configs may hold
+    # sim_data-derived numpy arrays (e.g. a swapped metabolism config) that are
+    # not natively JSON-serializable; stringifying them keeps the memo key stable.
     if key in _RESOLVE_CACHE:
         return [dict(s) for s in _RESOLVE_CACHE[key]]
 
@@ -197,7 +220,7 @@ def resolve_injections(fork_repo: str, config: dict) -> list[dict[str, Any]]:
         topo = topologies.get(name)
         if topo is None:
             topo = getattr(cls, "topology", getattr(cls, "TOPOLOGY", {}))
-        topo = {k: list(v) for k, v in dict(topo).items()}
+        topo = translate_vivarium_topology(topo)
 
         # Cache class for apply step (survives sys.modules restore in _fork_registry).
         _fork_class_cache[(cls.__module__, cls.__qualname__)] = cls

--- a/scripts/_compare/inject.py
+++ b/scripts/_compare/inject.py
@@ -261,6 +261,11 @@ def resolve_injections(fork_repo: str, config: dict) -> list[dict[str, Any]]:
             "config": config_dict,
             "topology": topo,
             "interval": interval,
+            # Restrict the bridge's write surface to these ports (the bridge
+            # over-declares every port as both input AND output by default; a
+            # swapped process must not re-type stores another process owns, e.g.
+            # the mass deriver's listeners.mass). None = default (all ports).
+            "output_ports": (config.get("output_ports") or {}).get(name),
         })
     _RESOLVE_CACHE[key] = specs
     return [dict(s) for s in specs]
@@ -291,7 +296,8 @@ def apply_injected_processes(cell_state: dict, flow_order: list, core,
         cls = _import_class(spec["module"], spec["qualname"])
         if spec["kind"] == "vivarium_1":
             wrapped = wrap_vivarium_process(cls, name=spec["name"],
-                                            as_step=spec["as_step"])
+                                            as_step=spec["as_step"],
+                                            output_ports=spec.get("output_ports"))
         else:  # pbg_native
             wrapped = cls
         core.register_link(spec["name"], wrapped)

--- a/scripts/_compare/inject.py
+++ b/scripts/_compare/inject.py
@@ -144,6 +144,21 @@ def _restore_ecoli(saved_real: dict, fork_repo: str) -> None:
         pass
 
 
+def build_fork_config(fork_repo: str, sim_data_path: str, name: str) -> dict:
+    """Build a fork process's config from the FORK's own ``LoadSimData``.
+
+    The faithful, complete config source for a converted/swapped vEcoli process:
+    vEcoli's ``ecoli.library.sim_data.LoadSimData(sim_data_path).get_config_by_name``
+    supplies every parameter the real process needs (where v2ecoli's reimplemented
+    getter can drift). Runs in the resolve subprocess, where the fork's ``ecoli``
+    package is importable. Raises if the fork has no config-getter for ``name``.
+    """
+    import importlib
+    sim_data_mod = importlib.import_module("ecoli.library.sim_data")
+    loader = sim_data_mod.LoadSimData(sim_data_path=sim_data_path)
+    return dict(loader.get_config_by_name(name))
+
+
 def translate_vivarium_topology(topo: dict) -> dict[str, list]:
     """Translate a vivarium-1.0 topology to process-bigraph port→store paths.
 
@@ -216,6 +231,18 @@ def resolve_injections(fork_repo: str, config: dict) -> list[dict[str, Any]]:
                 f"{name!r}: process_configs 'sim_data' is unsupported for new "
                 "processes (no ParCa entry). Provide an explicit dict or 'default'.")
         config_dict = None if pcfg in ("default", None) else dict(pcfg)
+        # A 'default' config + a fork_sim_data path → auto-build the FULL, faithful
+        # config from the FORK's own LoadSimData (vEcoli configures its own
+        # process), instead of an empty config. Falls back to default if the fork
+        # has no config-getter for this process (e.g. a brand-new add_process).
+        if config_dict is None and config.get("fork_sim_data"):
+            try:
+                config_dict = build_fork_config(
+                    fork_repo, config["fork_sim_data"], name)
+            except Exception as e:  # noqa: BLE001 — not fork-configurable; use default
+                print(f"[inject] fork config for {name!r} unavailable "
+                      f"({type(e).__name__}); using default. {e}")
+                config_dict = None
 
         topo = topologies.get(name)
         if topo is None:

--- a/tests/test_inject_swap.py
+++ b/tests/test_inject_swap.py
@@ -1,0 +1,64 @@
+"""Swap semantics for fork process injection: removing the swapped-out process
+and any excluded processes from the composite (the converter/add path already
+exists in inject.py; this is the missing 'remove' half of a true swap)."""
+import os
+
+import pytest
+
+from scripts._compare import inject
+
+FORK = os.path.join(os.path.dirname(__file__), "fixtures", "fork_example")
+
+
+def test_remove_processes_drops_from_state_and_flow():
+    cell_state = {
+        "ecoli-metabolism": {"_type": "process"},
+        "keep-me": {"_type": "process"},
+        "exchange_data": {"_type": "step"},
+    }
+    flow_order = ["ecoli-metabolism", "keep-me", "exchange_data"]
+
+    removed = inject.remove_processes(
+        cell_state, flow_order, ["ecoli-metabolism", "exchange_data"])
+
+    assert "ecoli-metabolism" not in cell_state
+    assert "exchange_data" not in cell_state
+    assert "keep-me" in cell_state
+    assert flow_order == ["keep-me"]
+    assert set(removed) == {"ecoli-metabolism", "exchange_data"}
+
+
+def test_remove_processes_ignores_absent_names():
+    cell_state = {"keep-me": {"_type": "process"}}
+    flow_order = ["keep-me"]
+
+    removed = inject.remove_processes(cell_state, flow_order, ["not-here"])
+
+    assert flow_order == ["keep-me"]
+    assert removed == []
+
+
+@pytest.mark.sim
+def test_baseline_swaps_and_excludes_processes():
+    """A swap-only injection (no add_processes) must still convert+add the swap
+    target, remove the swapped-out process, and drop exclude_processes."""
+    from v2ecoli.core import build_core
+    from v2ecoli.composites.baseline import baseline
+    core = build_core()
+    inj = {
+        "fork_repo": FORK,
+        "add_processes": [],
+        "swap_processes": {"ecoli-mass-listener": "example-secretion"},
+        "exclude_processes": ["exchange_data"],
+        "process_configs": {"example-secretion": {"rate": 2.0}},
+        "topology": {"example-secretion": {"counts": ["bulk"]}},
+        "time_step": 1.0,
+    }
+    doc = baseline(core=core, seed=0, cache_dir="out/cache",
+                   injected_processes=inj)
+    cell = doc["state"]["agents"]["0"]
+    assert "example-secretion" in cell            # swap target converted + added
+    assert "ecoli-mass-listener" not in cell      # swapped-out removed
+    assert "exchange_data" not in cell            # excluded removed
+    assert "ecoli-mass-listener" not in doc["flow_order"]
+    assert "exchange_data" not in doc["flow_order"]

--- a/tests/test_inject_swap.py
+++ b/tests/test_inject_swap.py
@@ -38,6 +38,20 @@ def test_remove_processes_ignores_absent_names():
     assert removed == []
 
 
+def test_translate_vivarium_topology_resolves_nested_path():
+    """vivarium nested topology ({_path: base, sub: relpath}) auto-translates to
+    a process-bigraph store path (the _path base) — not the dict's keys."""
+    topo = {
+        "bulk": ("bulk",),
+        "environment": {"_path": ("environment",), "exchange": ("exchange",)},
+        "next_update_time": ("next_update_time", "metabolism"),
+    }
+    out = inject.translate_vivarium_topology(topo)
+    assert out["bulk"] == ["bulk"]
+    assert out["environment"] == ["environment"]   # _path base, NOT ['_path','exchange']
+    assert out["next_update_time"] == ["next_update_time", "metabolism"]
+
+
 @pytest.mark.sim
 def test_baseline_swaps_and_excludes_processes():
     """A swap-only injection (no add_processes) must still convert+add the swap

--- a/tests/test_inject_swap.py
+++ b/tests/test_inject_swap.py
@@ -38,6 +38,30 @@ def test_remove_processes_ignores_absent_names():
     assert removed == []
 
 
+def test_resolve_builds_default_config_from_fork_sim_data(monkeypatch):
+    """When fork_sim_data is provided, a process with a 'default' config gets its
+    full, faithful config auto-built from the FORK's own LoadSimData (not v2's
+    reimplementation), so a swapped vEcoli process is configured by vEcoli."""
+    captured = {}
+
+    def fake_build(fork_repo, sim_data_path, name):
+        captured["args"] = (fork_repo, sim_data_path, name)
+        return {"rate": 99.0}
+
+    monkeypatch.setattr(inject, "build_fork_config", fake_build)
+    cfg = {
+        "add_processes": ["example-secretion"],
+        "swap_processes": {},
+        "process_configs": {},  # 'default' → should auto-build from the fork
+        "topology": {"example-secretion": {"counts": ["bulk"]}},
+        "fork_sim_data": "/unique/test/path/simData.cPickle",
+        "time_step": 1.0,
+    }
+    specs = inject.resolve_injections(FORK, cfg)
+    assert captured["args"][2] == "example-secretion"
+    assert specs[0]["config"] == {"rate": 99.0}
+
+
 def test_translate_vivarium_topology_resolves_nested_path():
     """vivarium nested topology ({_path: base, sub: relpath}) auto-translates to
     a process-bigraph store path (the _path base) — not the dict's keys."""

--- a/tests/test_inject_swap.py
+++ b/tests/test_inject_swap.py
@@ -62,6 +62,35 @@ def test_resolve_builds_default_config_from_fork_sim_data(monkeypatch):
     assert specs[0]["config"] == {"rate": 99.0}
 
 
+def test_wrap_defer_ports_declares_any():
+    """defer_ports makes the bridge declare those ports as the top type 'any', so
+    a swapped process defers to the composite's existing store types (e.g. v2's
+    quantity[fg] mass store) instead of imposing its unitless inferred float."""
+    from v2ecoli.core import build_core
+    from v2ecoli.library.ecoli_step import set_current_core
+    from v2ecoli.library.vivarium_bridge import wrap_vivarium_process
+    core = build_core()
+    set_current_core(core)
+
+    class P:
+        name = "p"
+
+        def __init__(self, parameters=None):
+            self.parameters = parameters or {}
+
+        def ports_schema(self):
+            return {"a": {"_default": 0.0}, "b": {"_default": 0}}
+
+        def next_update(self, timestep, states):
+            return {}
+
+    W = wrap_vivarium_process(P, defer_ports=["a"])
+    inst = W({}, core=core)
+    assert inst.inputs()["a"] == {"_type": "node"}   # defers to the store's type
+    assert inst.inputs()["b"] != {"_type": "node"}
+    assert inst.outputs()["a"] == {"_type": "node"}
+
+
 def test_translate_vivarium_topology_resolves_nested_path():
     """vivarium nested topology ({_path: base, sub: relpath}) auto-translates to
     a process-bigraph store path (the _path base) — not the dict's keys."""

--- a/v2ecoli/composites/baseline.py
+++ b/v2ecoli/composites/baseline.py
@@ -913,15 +913,29 @@ def baseline(
         }
         flow_order.append('shape_step')
 
-    if injected_processes and injected_processes.get("add_processes"):
+    if injected_processes and (
+            injected_processes.get("add_processes")
+            or injected_processes.get("swap_processes")
+            or injected_processes.get("exclude_processes")):
         import sys, os
         sys.path.insert(0, os.path.join(os.path.dirname(__file__),
                                         "..", "..", "scripts"))
         from scripts._compare.inject import (
-            resolve_injections, apply_injected_processes)
-        specs = resolve_injections(injected_processes["fork_repo"],
-                                   injected_processes)
-        apply_injected_processes(cell_state, flow_order, core, specs)
+            resolve_injections, apply_injected_processes, remove_processes)
+        # Add half: convert + inject the new processes (add_processes plus the
+        # TARGETS of swap_processes). resolve_injections needs the fork repo only
+        # when there is something to add.
+        if (injected_processes.get("add_processes")
+                or injected_processes.get("swap_processes")):
+            specs = resolve_injections(injected_processes["fork_repo"],
+                                       injected_processes)
+            apply_injected_processes(cell_state, flow_order, core, specs)
+        # Remove half: drop the swapped-out SOURCES and any exclude_processes, so
+        # a swap is a true replace (not a co-existing add).
+        remove_processes(cell_state, flow_order,
+                         list((injected_processes.get("swap_processes") or {}).keys()))
+        remove_processes(cell_state, flow_order,
+                         list(injected_processes.get("exclude_processes") or []))
 
     state = {
         'agents': {'0': cell_state},

--- a/v2ecoli/library/vivarium_bridge.py
+++ b/v2ecoli/library/vivarium_bridge.py
@@ -184,6 +184,7 @@ def wrap_vivarium_process(
     name=None,
     as_step=False,
     output_ports=None,
+    defer_ports=None,
 ):
     """Build an ``EcoliProcess`` / ``EcoliStep`` subclass from a vivarium-1.0 class.
 
@@ -215,6 +216,12 @@ def wrap_vivarium_process(
     base = EcoliStep if as_step else EcoliProcess
     proc_name = name or getattr(v1_cls, 'name', v1_cls.__name__)
     write_ports = set(output_ports) if output_ports is not None else None
+    # defer_ports: declare these top-level ports as the top type ``any`` so the
+    # composite's EXISTING store type governs. Needed when a swapped/injected
+    # process shares a store another process already types (e.g. v2's mass deriver
+    # owns listeners.mass as quantity[fg]; the bridged vEcoli process infers a
+    # bare unitless float and the two won't subtype-resolve). ``any`` defers.
+    defer = set(defer_ports) if defer_ports is not None else set()
 
     class _VivariumBridge(base):
         name = proc_name
@@ -227,12 +234,14 @@ def wrap_vivarium_process(
             self._typed_ports = translate_ports(self.core, self._v1.ports_schema())
 
         def inputs(self):
-            return dict(self._typed_ports)
+            return {k: ({'_type': 'node'} if k in defer else v)
+                    for k, v in self._typed_ports.items()}
 
         def outputs(self):
-            if write_ports is None:
-                return dict(self._typed_ports)
-            return {k: v for k, v in self._typed_ports.items() if k in write_ports}
+            ports = (self._typed_ports if write_ports is None
+                     else {k: v for k, v in self._typed_ports.items()
+                           if k in write_ports})
+            return {k: ({'_type': 'node'} if k in defer else v) for k, v in ports.items()}
 
         def update(self, state, interval=None):
             v1 = self._v1


### PR DESCRIPTION
Extends the existing fork-process injection (`scripts/_compare/inject.py` + `wrap_vivarium_process`) so a vEcoli (vivarium-1.0) process can be **swapped into** the v2ecoli baseline — converted, configured, topology-wired, and type-reconciled — not just added alongside. All built on the existing converter; no new converter.

## What's added
- **True swap** (`8bd0a1ac`): `inject.remove_processes()` drops the swapped-out source + `exclude_processes`; `baseline()` triggers injection on `swap_processes`/`exclude_processes` (not just `add_processes`) and removes after adding the converted target.
- **Auto vivarium-topology translation** (`10569ca6`): `translate_vivarium_topology()` resolves vivarium's nested `{_path: base, sub: rel}` topology to the process-bigraph store path (a swapped process reuses its source's topology); plus a sim_data-tolerant resolve memo key.
- **Config from the fork's own LoadSimData** (`7f09106a`): a `fork_sim_data` path sources the converted process's full, faithful config from vEcoli's `ecoli.library.sim_data.LoadSimData.get_config_by_name` (v2's reimplemented getter had drifted).
- **`output_ports`** (`d588327b`): restrict the bridge's write surface.
- **Type-defer** (`84117cf1`): ports wiring to stores the composite already owns are declared `{'_type':'node'}` so the existing store type governs (fixes the unitless-float vs `quantity[fg]` subtype clash on shared stores like `listeners.mass`).

With these, swapping vEcoli's `metabolism_redux` into baseline **converts, configures, type-checks, and the composite builds + runs into the process's computation**. 25 tests pass (`tests/test_inject_swap.py` + existing inject/bridge/baseline tests), no regressions.

## Follow-up (not in this PR)
The `metabolism_redux` end-to-end run still needs **pint↔unum boundary bridging** (the `docs/converting_vivarium_processes.md` "Units" caveat) — the process does unum unit math on v2's pint-typed store values. Tracked as a follow-up; this PR is the reusable framework.

🤖 Generated with [Claude Code](https://claude.com/claude-code)