### PR TITLE
chore(deps): bump vivarium-dashboard pin for report-card staging

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -4582,7 +4582,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/3e/87/794e0b4c5dccbca30
 [[package]]
 name = "vivarium-dashboard"
 version = "0.1.0"
-source = { git = "https://github.com/vivarium-collective/vivarium-dashboard.git?branch=main#0041657e01d7d81707f296787806dec28eb77edb" }
+source = { git = "https://github.com/vivarium-collective/vivarium-dashboard.git?branch=main#a54ada21f0da824a2dfd8187d6009cb46f74d7d7" }
 dependencies = [
     { name = "bigraph-loom" },
     { name = "bigraph-schema" },
@@ -4592,6 +4592,7 @@ dependencies = [
     { name = "jsonschema", extra = ["format-nongpl"] },
     { name = "numpy" },
     { name = "pbg-basic-processes" },
+    { name = "pbg-emitters" },
     { name = "pbg-superpowers" },
     { name = "process-bigraph" },
     { name = "pydantic" },


### PR DESCRIPTION
Bumps the `vivarium-dashboard` git pin to current main (a54ada21), which includes vivarium-dashboard#425 (`_stage_report_cards`). This stages the comparison studies' rendered report cards into the published static bundle so they stop 404-ing on the read-only dashboard — the *visualizations* half of the comparison-graph fix (graph fields landed in #312).

uv.lock-only; verified `uv lock` resolves cleanly (330 packages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)