### PR TITLE
chore: bump vivarium-dashboard pin to main (pillar streamline)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -4582,7 +4582,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/3e/87/794e0b4c5dccbca30
 [[package]]
 name = "vivarium-dashboard"
 version = "0.1.0"
-source = { git = "https://github.com/vivarium-collective/vivarium-dashboard.git?branch=main#a54ada21f0da824a2dfd8187d6009cb46f74d7d7" }
+source = { git = "https://github.com/vivarium-collective/vivarium-dashboard.git?branch=main#bf3c108107fc7a372cf74e02695b6888165120f4" }
 dependencies = [
     { name = "bigraph-loom" },
     { name = "bigraph-schema" },


### PR DESCRIPTION
Bumps the pinned `vivarium-dashboard` commit in `uv.lock` from `a54ada2` → `bf3c108` so the **read-only v2ecoli dashboard** reflects the 5-pillar streamline:

- Compose pillar unified (#423) — *was already in the old pin*
- Simulate + Visualize pillars unified (#424)
- Single investigation detail page declutter (#427)
- All-investigations landing list declutter + Investigations-tab reset (#431)
- (+ the test-only fix #428 and unrelated #425/#430 that landed on dashboard main)

`uv.lock`-only change (dashboard is a frontend/viewing dependency; the streamline is template + JS, no Python API change). Generated via `uv lock --upgrade-package vivarium-dashboard`.

After merge, the "Publish read-only dashboard" workflow is triggered manually (a uv.lock-only change doesn't auto-trigger it) so `vivarium-collective.github.io/v2ecoli/dashboard` picks up the streamline.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>