### PR TITLE
feat(compare): ensemble fork-injection + full per-engine config & converted-process schema in report

### DIFF
--- a/scripts/comparison_report_card.py
+++ b/scripts/comparison_report_card.py
@@ -49,6 +49,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import shutil
 import sys
 from datetime import datetime, timezone
@@ -472,6 +473,15 @@ def _read_v2ecoli_build_config(v2_dir: str) -> dict | None:
     options) straight from the built Composite document. Returns None if absent
     (older runs that predate the sidecar — the caller falls back to zarr attrs).
     """
+    # Local run dir first (pbg-vs-pbg / local-pbg modes write the sidecar
+    # straight to <v2_dir>); fall back to S3 for cloud runs.
+    local = os.path.join(v2_dir, "v2ecoli_build_config.json")
+    if os.path.exists(local):
+        try:
+            with open(local) as fh:
+                return json.load(fh)
+        except Exception:  # noqa: BLE001
+            return None
     import boto3
     s3 = boto3.client("s3", region_name=REGION)
     key = f"{PREFIX}/{v2_dir}/v2ecoli_build_config.json"
@@ -633,6 +643,46 @@ def config_sections_for(cond: str, v2_dir: str, ve_dir: str) -> list[dict]:
     diff["title"] = f"{cond} — config diff"
     sections.append(diff)
     return sections
+
+
+def converted_processes_section(cond: str, v2_build: dict | None) -> dict | None:
+    """Surface the fork processes converted + injected into the v2ecoli composite.
+
+    Sourced from the build-config sidecar's ``options.overrides.injected_processes``
+    (written by run_comparison_ensemble): the add_processes + swap_processes that
+    the bridge auto-converted from vivarium-1.0 to process-bigraph and wired into
+    baseline. Returns None when the run injected nothing.
+    """
+    inj = (((v2_build or {}).get("options") or {}).get("overrides") or {}).get(
+        "injected_processes")
+    if not inj:
+        return None
+    adds = list(inj.get("add_processes") or [])
+    swaps = dict(inj.get("swap_processes") or {})
+    if not adds and not swaps:
+        return None
+    fork = inj.get("fork_repo", "?")
+    rows = []
+    for name in adds:
+        rows.append(f"<tr><td><code>{name}</code></td><td>add</td>"
+                    f"<td>—</td><td>vivarium-1.0 → process-bigraph</td></tr>")
+    for old, new in swaps.items():
+        rows.append(f"<tr><td><code>{new}</code></td><td>swap</td>"
+                    f"<td>replaces <code>{old}</code></td>"
+                    f"<td>vivarium-1.0 → process-bigraph</td></tr>")
+    table = ("<table><thead><tr><th>process</th><th>mode</th><th>note</th>"
+             "<th>conversion</th></tr></thead><tbody>"
+             + "".join(rows) + "</tbody></table>")
+    return {
+        "title": f"{cond} — converted processes",
+        "kind": "content",
+        "nav_group": "Config",
+        "desc": (f"Fork (vEcoli) processes auto-converted by the v2ecoli bridge "
+                 f"(<code>wrap_vivarium_process</code>) and injected into the "
+                 f"v2ecoli composite for '{cond}', from fork <code>{fork}</code>. "
+                 f"Each ran in the v2ecoli engine of this comparison."),
+        "html": table,
+    }
 
 
 def runs_section(cond: str, per_obs: dict, plot_trajs: dict,
@@ -892,6 +942,12 @@ def main(argv=None):
             per_obs, plot_trajs, v2_bounds = cond_data[cond]
             cond_sections = [runs_section(cond, per_obs, plot_trajs, v2_bounds),
                              eval_section(cond, per_obs)]
+            # Converted-processes panel renders in EVERY mode (incl. local pbg) —
+            # it reads the v2ecoli build-config sidecar, not any Nextflow config.
+            conv = converted_processes_section(
+                cond, _read_v2ecoli_build_config(v2_dir))
+            if conv is not None:
+                cond_sections = [conv] + cond_sections
             if not skip_nextflow:
                 cond_sections = (config_sections_for(cond, v2_dir, ve_dir)
                                  + cond_sections)

--- a/scripts/comparison_report_card.py
+++ b/scripts/comparison_report_card.py
@@ -603,40 +603,14 @@ def config_sections_for(cond: str, v2_dir: str, ve_dir: str) -> list[dict]:
             "html": f"<p style='color:#6b7280'>config not found for {cond} "
                     f"(no workflow_config.json under {ve_dir}/cond_{cond}).</p>"})
 
-    # Prefer the new build-config sidecar (full resolved process set +
-    # topology straight from the Composite); fall back to the zarr-attrs run
-    # config for older runs that predate it. Label which one is shown.
+    # The v2ecoli config panel itself is rendered by v2_config_section (every
+    # mode); here we only resolve v2_cfg/source for the config-DIFF below.
     v2_build = _read_v2ecoli_build_config(v2_dir)
     if v2_build is not None:
         v2_cfg, v2_source = v2_build, "build-config sidecar"
-        sec = report.config_panel_section(v2_cfg)
-        sec["title"] = f"{cond} — config (v2ecoli)"
-        sec["desc"] = (
-            f"v2ecoli RESOLVED build config for condition '{cond}', from the "
-            f"v2ecoli_build_config.json sidecar the run emitted straight off the "
-            f"built Composite (process set, per-process config keys, topology, "
-            f"time_step, condition, seed, options).")
-        sections.append(sec)
     else:
         v2_cfg = _read_v2ecoli_config(v2_dir)
         v2_source = "zarr-attrs run config (sidecar absent)"
-        if v2_cfg is not None:
-            sec = report.config_panel_section(v2_cfg)
-            sec["title"] = f"{cond} — config (v2ecoli)"
-            sec["desc"] = (
-                f"v2ecoli RUN config for condition '{cond}', recovered from the "
-                f"compact zarr's lineage-node attrs (the build-config sidecar was "
-                f"absent — this is the run config: condition, seed, time_step, "
-                f"max_duration, variant, generation).")
-            sections.append(sec)
-        else:
-            v2_cfg = None
-            sections.append({
-                "title": f"{cond} — config (v2ecoli)", "kind": "content",
-                "desc": f"v2ecoli run config for condition '{cond}'.",
-                "html": f"<p style='color:#6b7280'>config not found for {cond} "
-                        f"(no sidecar and no recoverable run config in "
-                        f"{v2_dir} zarr attrs).</p>"})
 
     # CONFIG DIFF panel — vEcoli resolved vs v2ecoli build config.
     diff = config_diff_section(cond, ve_cfg, v2_cfg, v2_source)
@@ -645,13 +619,59 @@ def config_sections_for(cond: str, v2_dir: str, ve_dir: str) -> list[dict]:
     return sections
 
 
+def _process_interfaces(v2_build: dict | None) -> dict[str, dict]:
+    """Map process name AND address → its resolved interface ({inputs,outputs})
+    from the build-config sidecar, so a converted process can be looked up by
+    whichever identifier the injection spec used."""
+    out: dict[str, dict] = {}
+    for p in (v2_build or {}).get("processes") or []:
+        iface = p.get("interface")
+        if not iface:
+            continue
+        for k in (p.get("name"), p.get("address")):
+            if k:
+                out[k] = iface
+    return out
+
+
+def _schema_table(iface: dict | None) -> str:
+    """Render a converted process's RESULTING process-bigraph schema: each
+    input/output port → its resolved type. Returns '' when unavailable."""
+    from scripts._compare.report import _e
+    if not iface:
+        return ("<div style='color:#6b7280;font-size:12px;padding:2px 0 6px'>"
+                "resulting schema unavailable (process instance not captured).</div>")
+
+    def _rows(ports: dict, kind: str) -> str:
+        if not ports:
+            return (f"<tr><td style='color:#6b7280'>{kind}</td>"
+                    f"<td style='color:#6b7280' colspan='2'>(none)</td></tr>")
+        rs = []
+        for i, (port, typ) in enumerate(ports.items()):
+            tstr = typ if isinstance(typ, str) else json.dumps(typ, default=str)
+            rs.append(f"<tr><td style='color:#6b7280'>{kind if i == 0 else ''}</td>"
+                      f"<td style='padding:2px 10px'><code>{_e(port)}</code></td>"
+                      f"<td style='padding:2px 10px;color:#334155'>"
+                      f"<code>{_e(tstr if len(tstr) <= 80 else tstr[:77] + '…')}</code>"
+                      f"</td></tr>")
+        return "".join(rs)
+    return ("<table style='border-collapse:collapse;font-size:12px;margin:2px 0 8px'>"
+            "<tbody>"
+            + _rows(iface.get("inputs") or {}, "inputs")
+            + _rows(iface.get("outputs") or {}, "outputs")
+            + "</tbody></table>")
+
+
 def converted_processes_section(cond: str, v2_build: dict | None) -> dict | None:
-    """Surface the fork processes converted + injected into the v2ecoli composite.
+    """Surface the fork processes converted + injected into the v2ecoli composite,
+    with each one's RESULTING process-bigraph schema (resolved port types).
 
     Sourced from the build-config sidecar's ``options.overrides.injected_processes``
     (written by run_comparison_ensemble): the add_processes + swap_processes that
     the bridge auto-converted from vivarium-1.0 to process-bigraph and wired into
-    baseline. Returns None when the run injected nothing.
+    baseline. The resulting schema comes from each process's captured
+    ``interface`` (inputs()/outputs()) in the sidecar's ``processes`` list.
+    Returns None when the run injected nothing.
     """
     inj = (((v2_build or {}).get("options") or {}).get("overrides") or {}).get(
         "injected_processes")
@@ -662,14 +682,19 @@ def converted_processes_section(cond: str, v2_build: dict | None) -> dict | None
     if not adds and not swaps:
         return None
     fork = inj.get("fork_repo", "?")
+    ifaces = _process_interfaces(v2_build)
     rows = []
+
+    def _card(name: str, mode: str, note: str) -> str:
+        return (f"<tr><td><code>{name}</code></td><td>{mode}</td><td>{note}</td>"
+                f"<td>vivarium-1.0 → process-bigraph</td></tr>"
+                f"<tr><td colspan='4' style='padding:0 0 6px 18px'>"
+                f"<div style='font-size:12px;color:#6b7280;margin:2px 0'>"
+                f"resulting schema:</div>{_schema_table(ifaces.get(name))}</td></tr>")
     for name in adds:
-        rows.append(f"<tr><td><code>{name}</code></td><td>add</td>"
-                    f"<td>—</td><td>vivarium-1.0 → process-bigraph</td></tr>")
+        rows.append(_card(name, "add", "—"))
     for old, new in swaps.items():
-        rows.append(f"<tr><td><code>{new}</code></td><td>swap</td>"
-                    f"<td>replaces <code>{old}</code></td>"
-                    f"<td>vivarium-1.0 → process-bigraph</td></tr>")
+        rows.append(_card(new, "swap", f"replaces <code>{old}</code>"))
     table = ("<table><thead><tr><th>process</th><th>mode</th><th>note</th>"
              "<th>conversion</th></tr></thead><tbody>"
              + "".join(rows) + "</tbody></table>")
@@ -680,9 +705,82 @@ def converted_processes_section(cond: str, v2_build: dict | None) -> dict | None
         "desc": (f"Fork (vEcoli) processes auto-converted by the v2ecoli bridge "
                  f"(<code>wrap_vivarium_process</code>) and injected into the "
                  f"v2ecoli composite for '{cond}', from fork <code>{fork}</code>. "
-                 f"Each ran in the v2ecoli engine of this comparison."),
+                 f"Each row shows the conversion plus the RESULTING process-bigraph "
+                 f"schema (resolved input/output port types). Each ran in the "
+                 f"v2ecoli engine of this comparison."),
         "html": table,
     }
+
+
+def v2_config_section(cond: str, v2_build: dict | None) -> dict | None:
+    """The FULL resolved v2ecoli build config for ONE condition, rendered from a
+    build-config dict — process set, per-process config keys, topology wiring,
+    time_step, and the build options. Renders in EVERY mode (it needs no
+    Nextflow config), so a run that injected processes shows its real config
+    instead of reading as a bare condition label. Returns None without a build."""
+    if not v2_build:
+        return None
+    sec = report.config_panel_section(v2_build)
+    sec["title"] = f"{cond} — config (v2ecoli)"
+    sec["nav_group"] = cond
+    procs = v2_build.get("processes") or []
+    inj = (((v2_build.get("options") or {}).get("overrides") or {})
+           .get("injected_processes") or {})
+    injected = list(inj.get("add_processes") or []) + \
+        list((inj.get("swap_processes") or {}).values())
+    note = (f" Includes {len(injected)} injected process"
+            f"{'es' if len(injected) != 1 else ''}: "
+            f"{', '.join(injected)}." if injected else "")
+    sec["desc"] = (
+        f"v2ecoli RESOLVED build config for '{cond}' — {len(procs)} processes "
+        f"actually built into the composite (with per-process config keys + "
+        f"topology), time_step {v2_build.get('time_step')}, from the "
+        f"v2ecoli_build_config.json sidecar emitted off the built Composite.{note}")
+    return sec
+
+
+def vecoli_config_section(cond: str, ve_build: dict | None) -> dict | None:
+    """The FULL resolved vEcoli config for ONE condition, rendered from the
+    vecoli_build_config.json sidecar (the EcoliSim.config the genuine-vEcoli pbg
+    run actually used — its real process set, exclude list, media, time_step).
+    Renders in EVERY mode, so the report shows what vEcoli truly ran (e.g. its
+    default baseline, when the v2 side injected a v2-only process). Returns None
+    without a build."""
+    if not ve_build:
+        return None
+    sec = report.config_panel_section(ve_build)
+    sec["title"] = f"{cond} — config (vEcoli)"
+    sec["nav_group"] = cond
+    n = len(ve_build.get("processes") or []) + len(ve_build.get("steps") or [])
+    sec["desc"] = (
+        f"vEcoli RESOLVED config for '{cond}' — {n} processes+steps the "
+        f"genuine-vEcoli engine actually ran (from EcoliSim.config; vEcoli runs "
+        f"most mechanism as partitioned requester/evolver steps), time_step "
+        f"{ve_build.get('time_step')}, media {ve_build.get('media_id')}, captured "
+        f"into the vecoli_build_config.json sidecar. This is vEcoli's OWN config; "
+        f"compare it against the v2ecoli config panel to see any divergence.")
+    return sec
+
+
+def _read_vecoli_build_config(ve_dir: str) -> dict | None:
+    """The resolved vEcoli config sidecar (vecoli_build_config.json) the
+    genuine-vEcoli pbg run emits next to its zarr. Local dir first, then S3.
+    Returns None when absent (older runs that predate the sidecar)."""
+    local = os.path.join(ve_dir, "vecoli_build_config.json")
+    if os.path.exists(local):
+        try:
+            with open(local) as fh:
+                return json.load(fh)
+        except Exception:  # noqa: BLE001
+            return None
+    import boto3
+    s3 = boto3.client("s3", region_name=REGION)
+    key = f"{PREFIX}/{ve_dir}/vecoli_build_config.json"
+    try:
+        obj = s3.get_object(Bucket=BUCKET, Key=key)
+        return json.loads(obj["Body"].read())
+    except Exception:  # noqa: BLE001
+        return None
 
 
 def runs_section(cond: str, per_obs: dict, plot_trajs: dict,
@@ -940,14 +1038,28 @@ def main(argv=None):
         for cond in conds:
             v2_dir, ve_dir = conds[cond]
             per_obs, plot_trajs, v2_bounds = cond_data[cond]
+            v2_build = _read_v2ecoli_build_config(v2_dir)
             cond_sections = [runs_section(cond, per_obs, plot_trajs, v2_bounds),
                              eval_section(cond, per_obs)]
-            # Converted-processes panel renders in EVERY mode (incl. local pbg) —
-            # it reads the v2ecoli build-config sidecar, not any Nextflow config.
-            conv = converted_processes_section(
-                cond, _read_v2ecoli_build_config(v2_dir))
+            # Converted-processes panel (with each converted process's RESULTING
+            # schema) AND the full v2ecoli config panel render in EVERY mode —
+            # both read the v2ecoli build-config sidecar, not any Nextflow config.
+            # So a 'basal' run that injected processes shows its real process set
+            # and the conversions, not just the bare condition label.
+            conv = converted_processes_section(cond, v2_build)
             if conv is not None:
                 cond_sections = [conv] + cond_sections
+            v2cfg = v2_config_section(cond, v2_build)
+            if v2cfg is not None:
+                cond_sections = [v2cfg] + cond_sections
+            # vEcoli config panel — every mode, from the vecoli sidecar (what
+            # genuine vEcoli actually ran). So both engines show full config.
+            ve_build = _read_vecoli_build_config(ve_dir)
+            vecfg = vecoli_config_section(cond, ve_build)
+            if vecfg is not None:
+                cond_sections = [vecfg] + cond_sections
+            # vEcoli Nextflow config panel + config diff — only when the
+            # workflow_config.json is available (genuine S3/Nextflow runs).
             if not skip_nextflow:
                 cond_sections = (config_sections_for(cond, v2_dir, ve_dir)
                                  + cond_sections)

--- a/scripts/run_comparison_ensemble.py
+++ b/scripts/run_comparison_ensemble.py
@@ -316,10 +316,23 @@ def extract_v2_build_config(composite, *, seed: int, condition: str,
         if ntype not in ("process", "step"):
             continue
         cfg = node.get("config")
+        # The RESULTING process-bigraph schema: the resolved port types the
+        # built process declares (inputs()/outputs()). For converted vEcoli
+        # processes this is what the bridge produced — surfaced in the report's
+        # converted-processes panel. Best-effort: never crash the sidecar.
+        interface = None
+        inst = node.get("instance")
+        if inst is not None:
+            try:
+                interface = {"inputs": dict(inst.inputs()),
+                             "outputs": dict(inst.outputs())}
+            except Exception:  # noqa: BLE001
+                interface = None
         processes.append({
             "name": name, "type": ntype, "address": node.get("address"),
             "interval": node.get("interval"),
             "config_keys": sorted(cfg.keys()) if isinstance(cfg, dict) else [],
+            "interface": interface,
         })
         topology[name] = {"inputs": node.get("inputs") or {},
                           "outputs": node.get("outputs") or {}}
@@ -527,6 +540,19 @@ def make_run_one(*, composite_kind: str, condition: str, cache_dir: str,
                 fork_dir=os.environ.get("V2E_VECOLI_DIR"),
                 experiment_id=f"cmp-vecoli-{condition}-seed{seed:02d}",
                 variant=0, lineage_seed=seed)
+            # Emit vEcoli's OWN resolved config sidecar ONCE (lowest seed) next to
+            # the stores, so the report shows the full vEcoli config too. Best-effort.
+            if seed == seed_start and res.get("build_config"):
+                try:
+                    _write_json_sidecar(
+                        f"{out_root.rstrip('/')}/vecoli_build_config.json",
+                        res["build_config"])
+                    print(f"[config] wrote vecoli_build_config.json "
+                          f"({res['build_config'].get('n_processes')} processes) "
+                          f"under {out_root}")
+                except Exception as e:  # noqa: BLE001
+                    print(f"[warn] vecoli build-config sidecar emit failed: "
+                          f"{type(e).__name__} {e}")
             return {"seed": seed, "wall_seconds": round(time.time() - t0, 1),
                     "store": str(store_path), "steps": None,
                     "generations": list(range(1, res.get("generations", 0) + 1))}

--- a/scripts/run_comparison_ensemble.py
+++ b/scripts/run_comparison_ensemble.py
@@ -407,6 +407,37 @@ def _overrides_from_resolved(resolved: dict) -> tuple[dict, dict]:
     return overrides, translated
 
 
+def _injected_from_resolved(resolved: dict, fork_repo: str,
+                            fork_sim_data: str | None) -> dict | None:
+    """Assemble a baseline ``injected_processes`` block from a resolved vEcoli
+    config, so the v2 side converts+injects the fork's add/swap processes.
+
+    Returns None when the config declares no injection. Carries every per-port
+    knob the bridge understands (output/defer/strip/attach), so a swap is fully
+    config-described; ``fork_sim_data`` lets a swapped process pull its full
+    config from the fork's own LoadSimData.
+    """
+    if not (resolved.get("add_processes") or resolved.get("swap_processes")
+            or resolved.get("exclude_processes")):
+        return None
+    inj = {
+        "fork_repo": fork_repo,
+        "add_processes": resolved.get("add_processes") or [],
+        "swap_processes": resolved.get("swap_processes") or {},
+        "exclude_processes": resolved.get("exclude_processes") or [],
+        "process_configs": resolved.get("process_configs") or {},
+        "topology": resolved.get("topology") or {},
+        "time_step": float(resolved.get("time_step", 1.0)),
+        "output_ports": resolved.get("output_ports") or {},
+        "defer_ports": resolved.get("defer_ports") or {},
+        "strip_pint_ports": resolved.get("strip_pint_ports") or {},
+        "attach_pint_ports": resolved.get("attach_pint_ports") or {},
+    }
+    if fork_sim_data:
+        inj["fork_sim_data"] = fork_sim_data
+    return inj
+
+
 def _translated_v2_overrides(vecoli_config_path: str) -> tuple[dict, dict]:
     """Resolve+translate a vEcoli config; return (overrides, translated_full).
 
@@ -445,8 +476,18 @@ def make_run_one(*, composite_kind: str, condition: str, cache_dir: str,
                 "V2E_VECOLI_DIR", str(REPO_ROOT.parent / "vEcoli"))
             resolved = resolve_vecoli_config_local(from_vecoli_config, fork_dir)
             v2_overrides, v2_translated = _overrides_from_resolved(resolved)
+            # Build the injected_processes block so the v2 side actually
+            # converts+injects the fork's add/swap processes (translate alone
+            # passes the raw keys through but never assembles the block).
+            inj = _injected_from_resolved(
+                resolved, fork_dir,
+                os.path.abspath(match_vecoli_simdata) if match_vecoli_simdata else None)
+            if inj:
+                v2_overrides = dict(v2_overrides or {})
+                v2_overrides["injected_processes"] = inj
             print(f"[from-vecoli-config] {from_vecoli_config} → v2 overrides "
-                  f"{sorted(v2_overrides)} ({len(v2_translated)} translated keys)")
+                  f"{sorted(v2_overrides)} ({len(v2_translated)} translated keys"
+                  f"{'; +injected '+str(inj.get('add_processes') or list(inj.get('swap_processes') or {})) if inj else ''})")
         except Exception as e:  # noqa: BLE001
             print(f"[warn] from-vecoli-config resolve failed: {type(e).__name__} {e}")
 

--- a/tests/test_comparison_report_card_panels.py
+++ b/tests/test_comparison_report_card_panels.py
@@ -1,0 +1,82 @@
+"""Panels in the ensemble/gov-cloud report (scripts/comparison_report_card.py):
+the converted-process panel must show each converted process's RESULTING
+process-bigraph schema (port types), and the v2ecoli full-config panel must
+render from a build-config dict in EVERY mode (so a 'basal' run that injected
+processes no longer reads as bare 'basal')."""
+from scripts.comparison_report_card import (
+    converted_processes_section, v2_config_section, vecoli_config_section)
+
+
+def _build_with_injection():
+    return {
+        "engine": "v2ecoli", "condition": "basal", "seed": 0,
+        "time_step": 1.0, "n_processes": 2,
+        "options": {"overrides": {"injected_processes": {
+            "fork_repo": "/abs/vEcoli",
+            "add_processes": ["ecoli-mock-secretion"],
+            "swap_processes": {},
+        }}},
+        "processes": [
+            {"name": "ecoli-metabolism", "address": "local:ecoli-metabolism",
+             "type": "process", "config_keys": ["media_id"], "interface": None},
+            {"name": "ecoli-mock-secretion",
+             "address": "local:ecoli-mock-secretion", "type": "process",
+             "config_keys": ["rate"],
+             "interface": {
+                 "inputs": {"bulk": "bulk_array", "timestep": "float"},
+                 "outputs": {"bulk": "bulk_array"}}},
+        ],
+        "topology": {
+            "ecoli-metabolism": {"inputs": {}, "outputs": {}},
+            "ecoli-mock-secretion": {"inputs": {"bulk": ["bulk"]},
+                                     "outputs": {"bulk": ["bulk"]}}},
+    }
+
+
+def test_converted_panel_shows_resulting_schema():
+    sec = converted_processes_section("basal", _build_with_injection())
+    assert sec is not None and sec["kind"] == "content"
+    html = sec["html"]
+    assert "ecoli-mock-secretion" in html
+    assert "vivarium-1.0" in html
+    # the RESULTING process-bigraph schema (port names + types) is rendered
+    assert "bulk" in html and "bulk_array" in html
+    assert "timestep" in html and "float" in html
+
+
+def test_converted_panel_none_without_injection():
+    assert converted_processes_section("basal", {"processes": []}) is None
+
+
+def test_v2_config_panel_renders_full_process_set():
+    sec = v2_config_section("basal", _build_with_injection())
+    assert sec is not None and sec["kind"] == "content"
+    html = sec["html"]
+    # the FULL config — not just the bare 'basal' label — lists the real
+    # process set including the injected process
+    assert "ecoli-metabolism" in html
+    assert "ecoli-mock-secretion" in html
+
+
+def test_v2_config_panel_none_without_build():
+    assert v2_config_section("basal", None) is None
+
+
+def test_vecoli_config_panel_renders_actual_process_set():
+    ve_build = {
+        "engine": "vecoli", "source": "EcoliSim.config",
+        "condition": "basal", "seed": 0, "time_step": 1.0,
+        "media_id": "minimal", "n_processes": 2,
+        "processes": ["ecoli-metabolism", "ecoli-transcript-initiation"],
+        "exclude_processes": ["monomer_counts_listener"]}
+    sec = vecoli_config_section("basal", ve_build)
+    assert sec is not None and sec["kind"] == "content"
+    html = sec["html"]
+    assert "ecoli-metabolism" in html
+    # vEcoli ran its own (default) process set — the mock is NOT here
+    assert "mock-secretion" not in html
+    assert "vEcoli" in sec["title"]
+
+
+def test_vecoli_config_panel_none_without_build():
+    assert vecoli_config_section("basal", None) is None

--- a/v2ecoli/library/vivarium_ecoli_engine.py
+++ b/v2ecoli/library/vivarium_ecoli_engine.py
@@ -21,6 +21,7 @@ one-knob change: point ``V2E_VECOLI_DIR`` at a different checkout + its matching
 """
 from __future__ import annotations
 
+import json
 import os
 import sys
 from dataclasses import dataclass, field
@@ -378,6 +379,47 @@ def _dperiod_should_divide(handle) -> tuple[bool, int]:
     return bool(gt >= float(untriggered.min())), nchrom
 
 
+def _vecoli_config_summary(handle, *, condition: str, seed: int,
+                           time_step: float, exclude_processes) -> dict:
+    """JSON-able summary of the resolved vEcoli config the run actually used.
+
+    Pulls the process/step NAMES the genuine-vEcoli Engine built plus a sanitized
+    copy of ``EcoliSim.config`` (scalars/lists/small dicts only — the ~300MB
+    ``sim_data`` object and other non-serializable values are dropped). Written
+    next to the vEcoli zarr as ``vecoli_build_config.json`` so the comparison
+    report shows vEcoli's OWN full config alongside v2ecoli's. Best-effort."""
+    sim = getattr(handle, "sim", None)
+    ecoli = getattr(sim, "ecoli", None) if sim is not None else None
+    processes = sorted((getattr(ecoli, "processes", {}) or {}).keys()) if ecoli else []
+    steps = sorted((getattr(ecoli, "steps", {}) or {}).keys()) if ecoli else []
+    safe: dict = {}
+    for k, v in (getattr(sim, "config", {}) or {}).items():
+        if k in ("sim_data",):                 # huge object — never serialize
+            continue
+        if isinstance(v, (str, int, float, bool, type(None))):
+            safe[k] = v
+        elif isinstance(v, (list, tuple)) and len(v) <= 64:
+            try:
+                json.dumps(list(v))
+                safe[k] = list(v)
+            except Exception:  # noqa: BLE001
+                safe[k] = f"<{type(v).__name__}[{len(v)}]>"
+        elif isinstance(v, dict) and len(v) <= 32:
+            try:
+                json.dumps(v)
+                safe[k] = v
+            except Exception:  # noqa: BLE001
+                safe[k] = f"<dict[{len(v)} keys]>"
+    return {
+        "engine": "vecoli", "source": "EcoliSim.config",
+        "condition": condition, "seed": int(seed), "time_step": float(time_step),
+        "media_id": getattr(handle, "media_id", None),
+        "n_processes": len(processes), "processes": processes, "steps": steps,
+        "exclude_processes": list(exclude_processes or []),
+        "config": safe,
+    }
+
+
 def run_vivarium_ecoli_pbg_multigen(
     *,
     store_path,
@@ -436,6 +478,7 @@ def run_vivarium_ecoli_pbg_multigen(
     divisions = 0
     gens_done = 0
     final_cell_mass = None
+    build_config = None
 
     for gen in range(max_generations):
         # gen 0 is a fresh founder (overlay=None); later generations seed the inner
@@ -447,6 +490,14 @@ def run_vivarium_ecoli_pbg_multigen(
             initial_overlay=overlay)
         proc = info["process"]
         comp.run(1)  # warm-up tick so listeners materialise
+        if gen == 0:                       # capture vEcoli's OWN resolved config once
+            try:
+                build_config = _vecoli_config_summary(
+                    proc._handle, condition=condition, seed=seed,
+                    time_step=time_step, exclude_processes=exclude_processes)
+            except Exception as _cfgerr:  # noqa: BLE001 — never block the run
+                print(f"[vecoli-config] summary skipped: "
+                      f"{type(_cfgerr).__name__} {_cfgerr}")
         em = _build_emitter(
             core=core, store_path=store_path, view=view, metadata_base=metadata_base,
             generation=gen + 1,  # 1-indexed to match run_multigen_xarray (v2ecoli side)
@@ -488,7 +539,8 @@ def run_vivarium_ecoli_pbg_multigen(
         divisions += 1
 
     return {"generations": gens_done, "divisions": divisions,
-            "store": store_path, "final_cell_mass": final_cell_mass}
+            "store": store_path, "final_cell_mass": final_cell_mass,
+            "build_config": build_config}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Two things, both cooked into the comparison report so they appear on every run:

1. **Ensemble injects fork processes from `--from-vecoli-config`** — the v2 side now builds the `injected_processes` block (convert + inject the vEcoli config's add/swap processes) instead of only translating scalar keys.

2. **Report shows more, every mode:**
   - **Full config per engine** — both the v2ecoli and vEcoli config panels render in *every* mode (previously the config panels were Nextflow-only). An injected-process run now shows its real process set instead of reading as a bare `basal` label.
   - **Converted-process resulting schema** — the converted-processes panel now shows each process's resulting process-bigraph schema (resolved input/output port types), captured from the built Composite.
   - **vEcoli's own config** — the genuine-vEcoli pbg runner emits `vecoli_build_config.json` (its resolved process+step set, exclude list, media), so the report shows what vEcoli actually ran alongside v2ecoli — making any config divergence visible.

## Tests

New `tests/test_comparison_report_card_panels.py` (6 tests) covers the resulting-schema rendering and the always-on per-engine config panels. Full compare suite green except the 3 pre-existing `test_parca_drift` failures (unrelated).