### PR TITLE
deps: bump pbg-emitters to short-generation flush fix (#13); fix parity test for 0.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,17 +45,21 @@ jobs:
         run: uv sync --extra dev --no-install-package vivarium-dashboard || uv sync --no-install-package vivarium-dashboard
 
       - name: Run fast tests (no .run() calls)
-        # -n auto: pytest-xdist parallelism (~4 workers on ubuntu-latest).
-        # --dist=loadfile keeps tests from the same file on one worker —
-        # any module-level fixtures (caches, registry setup) only pay
-        # the build cost once per file, not once per worker.
+        # -n 2: pytest-xdist parallelism, capped at 2 workers. ``-n auto`` (~4
+        # workers on ubuntu-latest) OOM-kills a worker on the 7GB runner since
+        # the pbg-emitters 0.2.0 framework — each worker holds sim_data + built
+        # composites — so 4× peak memory exceeds the runner and a worker dies
+        # ("node down: Not properly terminated"), hanging the job to timeout.
+        # 2 workers keeps peak memory in budget; the full set still runs in a
+        # few minutes. --dist=loadfile keeps tests from the same file on one
+        # worker so module-level fixtures pay the build cost once per file.
         run: >-
           uv run pytest
           -m "not slow and not sim"
           --ignore=tests/test_initialize.py
           --ignore=tests/test_kinetics_units.py
           --ignore=tests/test_unit_bridge.py
-          -n auto --dist=loadfile
+          -n 2 --dist=loadfile
           -v --tb=short
 
   behavior-tests:

--- a/tests/test_emitter_vecoli_parity.py
+++ b/tests/test_emitter_vecoli_parity.py
@@ -121,6 +121,10 @@ def test_xarray_parity_against_golden(tmp_path, core):
     cfg = {
         "emit": {"global_time": "node"},
         "out_uri": out_uri,
+        # pbg-emitters >=0.2.0: colony/lineage envelope is opt-in (flat default).
+        # This test emits the agents/<id> envelope, so select the colony strategy.
+        "strategy": "colony",
+        "emit_root": ["agents", "1"],
         "transducer": {
             "predicate": [[{"subsample": {"interval": 1}}]],
             "buffer": {"size": 3},

--- a/uv.lock
+++ b/uv.lock
@@ -2858,7 +2858,7 @@ dependencies = [
 [[package]]
 name = "pbg-emitters"
 version = "0.2.0"
-source = { git = "https://github.com/vivarium-collective/pbg-emitters.git?branch=main#358974e693cf24164ca023af07adf1f28f6341fc" }
+source = { git = "https://github.com/vivarium-collective/pbg-emitters.git?branch=main#00c91b2800fe684ac09bb490dfd65a8107c85b17" }
 dependencies = [
     { name = "bigraph-schema" },
     { name = "numpy" },


### PR DESCRIPTION
## What

Pull in the merged pbg-emitters fix and fix a latent 0.2.0 test breakage.

- **`uv.lock`**: bump `pbg-emitters` to [vivarium-collective/pbg-emitters#13](https://github.com/vivarium-collective/pbg-emitters/pull/13). That fix makes a generation emitting **fewer rows than `buffer_size`** write its zarr partition instead of silently producing an **empty store** — which was the root cause of comparison runs reading every observable as `not_compared` (both engines' stores had only group metadata, no `generation=` data partition, because short/coarse runs produced ≤ buffer_size emits per generation).
- **`test_emitter_vecoli_parity`**: select `strategy="colony"` + `emit_root`. pbg-emitters 0.2.0 made the generic flat Step the default (the `agents/<id>` envelope is now opt-in); this test builds its own emitter config and emits the colony envelope, so on 0.2.0 it raised `Unexpected emit path` until the strategy was selected. (`build_emitter_config` was already migrated on main; this test was missed.)

## Verified

Both engines now write data on the upgraded framework; the v2ecoli↔vEcoli comparison populates (cell/dry/protein/RNA mass within tolerance, growth rate drift). Even a degenerate 1-emit generation now writes a readable partition. Focused emitter/xarray/compare/report/baseline suite: **312 passed, 11 skipped**.