### PR TITLE
Analysis flush — Plan 3: allowlist, worker flush de-dup, re-flush CLI

### DIFF
--- a/tests/test_flush_plan3.py
+++ b/tests/test_flush_plan3.py
@@ -1,0 +1,82 @@
+"""Flush Plan 3 hardening: report_cards allowlist in run_flush, worker flush
+de-dup (sequential path only flushes on the driver), and a re-flush CLI."""
+import sys
+from pathlib import Path
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+
+def _study(tmp_path, slug="demo", spec=None):
+    sd = tmp_path / "workspace" / "studies" / slug
+    sd.mkdir(parents=True)
+    (sd / "study.yaml").write_text(yaml.safe_dump(spec or {"name": slug}))
+    return sd
+
+
+# --- Change 1: run_flush honors a study's report_cards: allowlist ---------------
+
+def test_run_flush_honors_report_cards_allowlist(core, tmp_path):
+    from v2ecoli.workflow.flush import run_flush
+    # study has tests AND a vs_vecoli ref, but declares report_cards: [tests]
+    ref = tmp_path / "rc" / "v.json"
+    ref.parent.mkdir(parents=True)
+    ref.write_text('{"schema":"report_card_verdict/v1","overall":"drift",'
+                   '"groups":{"standard":{"verdict":"drift","axes":[]}}}')
+    _study(tmp_path, "demo", {
+        "name": "demo",
+        "report_cards": ["tests"],                       # allowlist: tests only
+        "tests": [{"name": "t1", "status": "passed",
+                   "pass_if": {"op": "in_range", "low": 1, "high": 2}}],
+        "report_card_refs": {"vs_vecoli": "rc/v.json"},   # would apply but excluded
+    })
+    res = run_flush(str(tmp_path / "out"), {"study": "demo"}, tmp_path,
+                    core=core, kinds=("report_card",))
+    names = {p["name"] for p in res["placed"]}
+    assert "tests" in names
+    assert "vs_vecoli" not in names   # excluded by the allowlist despite a valid ref
+
+
+def test_run_flush_no_allowlist_runs_all_applicable(core, tmp_path):
+    from v2ecoli.workflow.flush import run_flush
+    _study(tmp_path, "demo", {
+        "name": "demo",
+        "tests": [{"name": "t1", "status": "passed",
+                   "pass_if": {"op": "in_range", "low": 1, "high": 2}}],
+    })
+    res = run_flush(str(tmp_path / "out"), {"study": "demo"}, tmp_path,
+                    core=core, kinds=("report_card",))
+    assert "tests" in {p["name"] for p in res["placed"]}
+
+
+# --- Change 2: workers (run_analysis=False) do NOT flush -------------------------
+
+def test_sequential_worker_does_not_flush(monkeypatch):
+    import v2ecoli.workflow.run as run_mod
+    calls = {"n": 0}
+    monkeypatch.setattr(run_mod, "_maybe_flush",
+                        lambda *a, **k: calls.__setitem__("n", calls["n"] + 1) or (a[2] if len(a) > 2 else {}))
+    # call the sequential path's flush gate directly via a tiny stand-in:
+    # the production gate is `if run_analysis: result = _maybe_flush(...)`.
+    # Verify the helper that decides it.
+    assert run_mod._should_flush(run_analysis=False) is False
+    assert run_mod._should_flush(run_analysis=True) is True
+
+
+# --- Change 3: a standalone re-flush CLI ---------------------------------------
+
+def test_reflush_cli_runs_flush(core, tmp_path, monkeypatch, capsys):
+    import v2ecoli.workflow.flush as flush_mod
+    seen = {}
+    def _fake(out_dir, config, ws_root, **kw):
+        seen.update(out_dir=out_dir, study=config.get("study"), kinds=kw.get("kinds"))
+        return {"placed": [{"kind": "report_card", "name": "tests", "path": "p"}],
+                "skipped": [], "study": config.get("study")}
+    monkeypatch.setattr(flush_mod, "run_flush", _fake)
+    rc = flush_mod.main(["out/x", "--study", "demo", "--ws-root", str(tmp_path),
+                         "--kinds", "report_card"])
+    assert rc == 0
+    assert seen["out_dir"] == "out/x" and seen["study"] == "demo"
+    assert seen["kinds"] == ("report_card",)
+    assert "placed 1" in capsys.readouterr().out

--- a/v2ecoli/workflow/flush.py
+++ b/v2ecoli/workflow/flush.py
@@ -135,7 +135,15 @@ def _run_one_step(cls, kind, extract, core):
     # report cards: skip when applies() is False; build() returns (verdict, html)
     if kind == "report_card":
         ctx = bag.get("study")
-        if ctx is None or not step.applies(ctx):
+        if ctx is None:
+            return "", {}
+        # honor a study's optional report_cards: allowlist (parity with the
+        # standalone runner's report_cards.applicable) — a declared list narrows
+        # which cards run; an absent key = every applicable card.
+        declared = (getattr(ctx, "spec", None) or {}).get("report_cards")
+        if declared is not None and step.name not in declared:
+            return "", {}
+        if not step.applies(ctx):
             return "", {}
         res = step.build(ctx)
         if not res:
@@ -229,3 +237,35 @@ def place_analysis_outputs(extract: "RunExtract") -> list:
         for tsv in sorted(src_ptools.glob("*.tsv")):
             shutil.copyfile(tsv, study_ptools / tsv.name)
     return placed
+
+
+def main(argv=None) -> int:
+    """Re-run the post-sim flush over an EXISTING run dir (parity with
+    analysis_runner.main). Useful to regenerate a study's report cards /
+    visualizations / analyses without re-simulating.
+
+    Usage: python -m v2ecoli.workflow.flush <out_dir> [--study SLUG]
+           [--ws-root DIR] [--kinds report_card,visualization,analysis]
+    """
+    import argparse
+    import os
+
+    ap = argparse.ArgumentParser(description=main.__doc__)
+    ap.add_argument("out_dir", help="the finished run's output dir")
+    ap.add_argument("--study", default=None, help="owning study slug (else inferred from out_dir)")
+    ap.add_argument("--ws-root", default=None, help="workspace root (default: cwd)")
+    ap.add_argument("--kinds", default="report_card,visualization,analysis",
+                    help="comma-separated post-sim kinds to run")
+    args = ap.parse_args(argv)
+
+    ws_root = args.ws_root or os.getcwd()
+    config = {"study": args.study} if args.study else {}
+    kinds = tuple(k.strip() for k in args.kinds.split(",") if k.strip())
+    res = run_flush(args.out_dir, config, ws_root, kinds=kinds)
+    print(f"placed {len(res['placed'])}, skipped {len(res['skipped'])}, "
+          f"study={res.get('study')}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/v2ecoli/workflow/run.py
+++ b/v2ecoli/workflow/run.py
@@ -22,6 +22,16 @@ from v2ecoli.workflow.meta_composite import (
 from v2ecoli.workflow.variants import expand_branches
 
 
+def _should_flush(run_analysis: bool) -> bool:
+    """Whether the sequential sweep path should run the post-sim flush. Parallel
+    workers invoke that path with ``run_analysis=False`` and must NOT flush — the
+    flush (report cards + visualizations + analyses) runs ONCE on the driver,
+    over the shared out_dir. The driver-sequential path passes ``run_analysis=True``.
+    Without this gate the flush ran once per worker (redundant writes / a race on
+    the shared study report dir)."""
+    return bool(run_analysis)
+
+
 def _maybe_flush(config: dict, out_dir: str, result: dict) -> dict:
     """Run the post-sim flush. Never raises. Runs when an owning study is
     resolvable OR when analysis_options are present (ad-hoc analyses place into
@@ -224,7 +234,8 @@ def _run_sweep_sequential(config: dict[str, Any], *, max_sim_time: float = 1e9,
         # kind), which runs run_analyses once and places outputs into the study
         # report dir. We only record where analysis.json will be written.
         result["analysis"] = os.path.join(out_dir, "analysis.json")
-    result = _maybe_flush(config, out_dir, result)
+    if _should_flush(run_analysis):
+        result = _maybe_flush(config, out_dir, result)
     return result
 
 


### PR DESCRIPTION
## What

Final hardening of the post-simulation flush — three clean changes flagged by the Plan-1/2 reviews:

1. **`report_cards:` allowlist in `run_flush`.** The report-card dispatch now honors a study's optional `report_cards:` list (parity with the standalone runner's `report_cards.applicable`): a declared list narrows which cards run; an absent key = every applicable card. (Today 0 studies declare it, so no behavior change — but a future allowlist study no longer silently gets the wrong cards.)
2. **Worker flush de-dup.** The sequential sweep path only flushes on the **driver** (`run_analysis=True`); parallel **workers** (`run_analysis=False`) no longer re-run the report-card/visualization flush once per worker (was redundant writes + a race on the shared study report dir). Gated via a small `_should_flush(run_analysis)` helper.
3. **Re-flush CLI.** `python -m v2ecoli.workflow.flush <out_dir> [--study SLUG] [--ws-root DIR] [--kinds report_card,visualization,analysis]` re-runs the flush over an existing run dir — regenerate cards/viz/analyses without re-simulating (parity with `analysis_runner.main`).

## Deferred (cosmetic)

Unifying `scripts/study_report_cards.py` onto `run_flush(kinds=("report_card",))`. It adds `--card`/`--prune` friction, and after change #1 both paths honor the allowlist identically — so the dedup is purely cosmetic. Left as-is.

## Tests

4 new tests (allowlist narrows + absent-key runs all; worker gate; CLI drives run_flush) + **36 existing flush tests green** (40 total). No regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)