### PR TITLE
feat(inject): honor config initial_state + backfill sentinel-None leaves

### DIFF
--- a/scripts/_compare/inject.py
+++ b/scripts/_compare/inject.py
@@ -180,6 +180,52 @@ def translate_vivarium_topology(topo: dict) -> dict[str, list]:
     return out
 
 
+def _deep_merge(base: dict, over: dict) -> dict:
+    """Recursive dict merge; ``over`` wins. Returns a new dict."""
+    out = dict(base)
+    for k, v in over.items():
+        if isinstance(v, dict) and isinstance(out.get(k), dict):
+            out[k] = _deep_merge(out[k], v)
+        else:
+            out[k] = v
+    return out
+
+
+def resolve_config_initial_state(fork_repo: str, config: dict) -> dict:
+    """Resolve a vEcoli config's initial state for INJECTED stores.
+
+    Honors the same two knobs ``EcoliSim`` does — ``initial_state`` (inline) and
+    ``initial_state_overrides`` (names of JSON files under the fork's
+    ``data/``) — merged in the same order (overrides on top of inline). This is
+    what gives an injected subsystem its real starting values (e.g. the
+    cell-wall model's ``murein_state`` counts) instead of bare schema defaults,
+    so the subsystem's own first-update logic can build the rest (e.g. PBPBinding
+    samples the murein lattice when ``wall_state.lattice`` is None). The big
+    ``initial_state_file`` (bulk/unique) is NOT loaded here — matched bulk is
+    handled by --match-initial-state; this resolves only the small,
+    subsystem-specific stores the config declares. Best-effort: a missing
+    override file is logged and skipped, never fatal."""
+    merged: dict = dict(config.get("initial_state") or {})
+    for name in (config.get("initial_state_overrides") or []):
+        rel = name if name.endswith(".json") else f"{name}.json"
+        candidates = [
+            os.path.join(fork_repo, "data", rel),
+            os.path.join(fork_repo, "data", "overrides", os.path.basename(rel)),
+        ]
+        path = next((p for p in candidates if os.path.exists(p)), None)
+        if path is None:
+            print(f"[inject] initial_state override {name!r} not found under "
+                  f"{fork_repo}/data — skipping")
+            continue
+        try:
+            with open(path) as fh:
+                merged = _deep_merge(merged, json.load(fh))
+        except Exception as e:  # noqa: BLE001
+            print(f"[inject] initial_state override {name!r} unreadable "
+                  f"({type(e).__name__}: {e}) — skipping")
+    return merged
+
+
 def resolve_injections(fork_repo: str, config: dict) -> list[dict[str, Any]]:
     """Resolve add_processes/swap_processes -> a list of InjectionSpec dicts.
 
@@ -202,6 +248,8 @@ def resolve_injections(fork_repo: str, config: dict) -> list[dict[str, Any]]:
         "strip_pint_ports": config.get("strip_pint_ports") or {},
         "defer_ports": config.get("defer_ports") or {},
         "attach_pint_ports": config.get("attach_pint_ports") or {},
+        "initial_state": config.get("initial_state") or {},
+        "initial_state_overrides": config.get("initial_state_overrides") or [],
     }, sort_keys=True, default=str)  # default=str: process_configs may hold
     # sim_data-derived numpy arrays (e.g. a swapped metabolism config) that are
     # not natively JSON-serializable; stringifying them keeps the memo key stable.
@@ -212,6 +260,9 @@ def resolve_injections(fork_repo: str, config: dict) -> list[dict[str, Any]]:
     interval = float(config.get("time_step", 1.0))
     process_configs = config.get("process_configs") or {}
     topologies = config.get("topology") or {}
+    # Resolve the config's initial_state + initial_state_overrides ONCE; each
+    # spec carries the slice for its own topology roots (below).
+    config_initial_state = resolve_config_initial_state(fork_repo, config)
 
     names = list(config.get("add_processes") or [])
     names += list((config.get("swap_processes") or {}).values())
@@ -256,6 +307,12 @@ def resolve_injections(fork_repo: str, config: dict) -> list[dict[str, Any]]:
         # Cache class for apply step (survives sys.modules restore in _fork_registry).
         _fork_class_cache[(cls.__module__, cls.__qualname__)] = cls
 
+        # Slice the config's resolved initial_state to THIS process's topology
+        # roots, so each process seeds only the stores it actually wires.
+        roots = {path[0] for path in topo.values() if path}
+        proc_initial = {r: config_initial_state[r]
+                        for r in roots if r in config_initial_state}
+
         specs.append({
             "name": name,
             "module": cls.__module__,
@@ -280,6 +337,9 @@ def resolve_injections(fork_repo: str, config: dict) -> list[dict[str, Any]]:
             "defer_ports": (config.get("defer_ports") or {}).get(name),
             # {port: unit} to wrap raw magnitudes as pint for pint-reading ports.
             "attach_pint_ports": (config.get("attach_pint_ports") or {}).get(name),
+            # Config-resolved initial values for this process's stores
+            # (initial_state + initial_state_overrides), applied at injection.
+            "initial_state": proc_initial,
         })
     _RESOLVE_CACHE[key] = specs
     return [dict(s) for s in specs]
@@ -328,13 +388,20 @@ def _merge_missing(dst: dict, src: dict) -> None:
 
 
 def _materialize_declared_state(cell_state: dict, cls, config: dict | None,
-                                topology: dict, name: str) -> None:
+                                topology: dict, name: str,
+                                initial_state: dict | None = None,
+                                protected_roots: set | None = None) -> None:
     """Fill the state a vivarium-1.0 process declares (ports_schema defaults)
-    into ``cell_state`` along its topology, creating missing stores/fields only.
+    into ``cell_state`` along its topology, creating missing stores/fields only,
+    then overlay the config's resolved ``initial_state`` for this process's roots.
 
     This is what lets a SURPRISE fork process/subsystem inject + run unattended:
-    its private stores get created with sensible defaults and any field it reads
-    from a shared store is guaranteed present on tick 0."""
+    its private stores are created with schema defaults (so reads never KeyError),
+    and the config's ``initial_state`` / ``initial_state_overrides`` seed the real
+    starting values (e.g. the cell-wall ``murein_state`` counts) — config wins
+    over the bare schema default. Values the composite ALREADY owns from v2's
+    baseline are never overwritten by a schema default (only by an explicit
+    config initial_state targeting that store)."""
     try:
         v1 = cls(config or {})
         pschema = v1.ports_schema()
@@ -350,12 +417,34 @@ def _materialize_declared_state(cell_state: dict, cls, config: dict | None,
             node = node.setdefault(seg, {})
         if defaults and isinstance(node, dict):
             _merge_missing(node, defaults)
-    # Surface what new top-level stores this process introduced.
+    # Overlay the config-resolved initial_state (config wins over schema
+    # defaults) onto the NEW stores this injection introduced. Roots that v2's
+    # baseline already owns (``protected_roots`` — e.g. the structured ``bulk``
+    # array, ``boundary``) are NEVER touched here: their representation differs
+    # from a config's plain-dict counts, and matched bulk is seeded separately by
+    # --match-initial-state. So a config bulk override is skipped (logged), while
+    # the subsystem's own stores (murein_state / wall_state / pbp_state) seed.
+    protected = protected_roots or set()
+    skipped = []
+    for root, value in (initial_state or {}).items():
+        if root in protected:
+            skipped.append(root)
+            continue
+        if isinstance(value, dict) and isinstance(cell_state.get(root), dict):
+            cell_state[root] = _deep_merge(cell_state[root], value)
+        else:
+            cell_state[root] = value
+    # Surface what top-level stores this process introduced / seeded.
     intro = sorted({path[0] for path in topology.values()
                     if path and path[0] in cell_state})
+    seeded = sorted(r for r in (initial_state or {}) if r not in protected)
+    if skipped:
+        print(f"[inject] {name}: config initial_state for baseline store(s) "
+              f"{', '.join(sorted(skipped))} skipped (owned by v2 / --match-initial-state)")
     if intro:
-        print(f"[inject] {name}: declared-state materialized (roots touched: "
-              f"{', '.join(intro)})")
+        print(f"[inject] {name}: declared-state materialized (roots: "
+              f"{', '.join(intro)})"
+              + (f"; config initial_state → {', '.join(seeded)}" if seeded else ""))
 
 
 def apply_injected_processes(cell_state: dict, flow_order: list, core,
@@ -364,6 +453,9 @@ def apply_injected_processes(cell_state: dict, flow_order: list, core,
     from v2ecoli.library.vivarium_bridge import wrap_vivarium_process
     from v2ecoli.composites._helpers import make_edge
 
+    # Roots v2's baseline already owns BEFORE any injection — config
+    # initial_state must never clobber these (e.g. the structured bulk array).
+    baseline_roots = set(cell_state)
     added: list[str] = []
     for spec in specs:
         cls = _import_class(spec["module"], spec["qualname"])
@@ -380,12 +472,30 @@ def apply_injected_processes(cell_state: dict, flow_order: list, core,
             except Exception as e:  # noqa: BLE001 — never block on the probe
                 print(f"[inject] {spec['name']}: topology auto-port skipped "
                       f"({type(e).__name__}: {e})")
-            # Defer ports wiring to stores the composite already owns: use their
-            # existing types instead of this process's inferred ones (avoids the
-            # unitless-float vs quantity[fg] subtype conflict on shared stores
-            # like listeners.mass that the v2 mass deriver owns). An explicit
-            # spec defer_ports overrides this auto-default, so ports that need
-            # their real type (e.g. boundary's pint for .to("mM")) keep it.
+
+            # Materialize declared state + config initial_state BEFORE deferring
+            # ports, so this process's NEW root stores already exist in cell_state
+            # and are picked up by the auto-defer below. vivarium's Engine does
+            # this at build; without it a process that introduces its own stores
+            # (cell-wall's murein_state / wall_state / pbp_state) or reads a field
+            # absent from a shared store (boundary.volume before ecoli-shape's
+            # first write) crashes on tick 0. Fills only missing stores/fields,
+            # then overlays the config's initial_state (config wins).
+            _materialize_declared_state(cell_state, cls, spec["config"],
+                                        spec["topology"], spec["name"],
+                                        initial_state=spec.get("initial_state"),
+                                        protected_roots=baseline_roots)
+
+            # Defer ports to the composite's store type ({_type:node}) instead of
+            # the process's inferred type. Auto-default: defer every port whose
+            # root store now exists in cell_state — which (after materialization)
+            # covers BOTH shared stores (avoids the float-vs-quantity subtype
+            # clash on stores like listeners.mass) AND this process's own new
+            # stores (so a `_default: None` field like wall_state.lattice is held
+            # as a node that accepts None now and the model's sampled ndarray
+            # later, instead of failing to type). An explicit spec defer_ports
+            # overrides this — so ports that need their real type (e.g. boundary's
+            # pint for .to("mM")) keep it.
             if spec.get("defer_ports") is not None:
                 defer_ports = list(spec["defer_ports"])
             else:
@@ -399,27 +509,11 @@ def apply_injected_processes(cell_state: dict, flow_order: list, core,
                                             attach_pint_ports=spec.get("attach_pint_ports"))
         else:  # pbg_native
             wrapped = cls
-        core.register_link(spec["name"], wrapped)
-
-        # Materialize the state each injected process DECLARES in its
-        # ports_schema, so a process runs the moment it is wired — exactly what
-        # vivarium's Engine does at build. Without this, a process that
-        # introduces its own stores (the cell-wall subsystem's murein_state /
-        # wall_state / pbp_state) or reads a field absent from a shared store
-        # (e.g. boundary.volume before ecoli-shape's first write) crashes on
-        # tick 0. We fill ONLY missing stores/fields (never overwrite v2's
-        # existing values), from the process's schema ``_default``s — so ANY
-        # surprise fork process/config injects + runs unattended, no per-process
-        # tuning. (pbg_native processes declare via inputs()/outputs() and are
-        # materialized by the Composite itself.)
-        if spec["kind"] == "vivarium_1":
-            _materialize_declared_state(cell_state, cls, spec["config"],
-                                        spec["topology"], spec["name"])
-        else:
             for port, path in spec["topology"].items():
                 root = path[0] if path else None
                 if root is not None and root not in cell_state:
                     cell_state[root] = {}
+        core.register_link(spec["name"], wrapped)
 
         instance = wrapped(spec["config"] or {}, core=core)
         edge_type = "step" if spec["kind"] == "pbg_native" and spec["as_step"] \

--- a/scripts/run_comparison_ensemble.py
+++ b/scripts/run_comparison_ensemble.py
@@ -445,6 +445,11 @@ def _injected_from_resolved(resolved: dict, fork_repo: str,
         "defer_ports": resolved.get("defer_ports") or {},
         "strip_pint_ports": resolved.get("strip_pint_ports") or {},
         "attach_pint_ports": resolved.get("attach_pint_ports") or {},
+        # Honor the config's initial state for the injected stores (so a
+        # subsystem like cell-wall gets its real murein_state counts, and its
+        # own first-update logic builds the rest).
+        "initial_state": resolved.get("initial_state") or {},
+        "initial_state_overrides": resolved.get("initial_state_overrides") or [],
     }
     if fork_sim_data:
         inj["fork_sim_data"] = fork_sim_data

--- a/tests/test_compare_inject.py
+++ b/tests/test_compare_inject.py
@@ -131,3 +131,50 @@ def test_apply_introduces_process_owned_store():
     added = inject.apply_injected_processes(cell_state, [], core, specs)
     assert "example-secretion" in added
     assert "nonexistent_store" in cell_state  # auto-introduced, not rejected
+
+
+# ---------------------------------------------------------------------------
+# Config initial_state honoring + schema-default backfill
+# ---------------------------------------------------------------------------
+def test_resolve_config_initial_state_merges_inline_and_overrides(tmp_path):
+    """initial_state (inline) + initial_state_overrides (files under
+    <fork>/data) merge, overrides on top."""
+    fork = tmp_path / "fork"
+    (fork / "data" / "overrides").mkdir(parents=True)
+    (fork / "data" / "overrides" / "red.json").write_text(
+        '{"murein_state": {"unincorporated_murein": 2234940}, "wall_state": {}}')
+    cfg = {"initial_state": {"murein_state": {"shadow_murein": 0}},
+           "initial_state_overrides": ["overrides/red"]}
+    merged = inject.resolve_config_initial_state(str(fork), cfg)
+    assert merged["murein_state"]["unincorporated_murein"] == 2234940
+    assert merged["murein_state"]["shadow_murein"] == 0     # inline preserved
+    assert merged["wall_state"] == {}
+
+
+def test_apply_seeds_new_store_from_config_initial_state_not_baseline():
+    """Config initial_state seeds an injected NEW store, but never clobbers a
+    pre-existing v2 baseline store (e.g. the structured bulk array)."""
+    from v2ecoli.core import build_core
+    core = build_core()
+    cfg = {"add_processes": ["example-secretion"],
+           "topology": {"example-secretion": {"counts": ["new_store"]}},
+           "initial_state": {"new_store": {"seeded": 7}, "bulk": {"X": 1}},
+           "time_step": 1.0}
+    specs = inject.resolve_injections(FORK, cfg)
+    cell_state = {"bulk": {"_real_array": True}}      # baseline store v2 owns
+    inject.apply_injected_processes(cell_state, [], core, specs)
+    assert cell_state["new_store"]["seeded"] == 7     # new store seeded
+    assert cell_state["bulk"] == {"_real_array": True}  # baseline NOT clobbered
+
+
+def test_bridge_backfills_sentinel_none_leaf():
+    """The bridge presents a v1 process its declared leaves — including a
+    sentinel-None default the pbg store can't persist — so reads don't KeyError."""
+    from v2ecoli.library.vivarium_bridge import _backfill_schema_defaults
+    schema = {"wall_state": {"lattice": {"_default": None, "_updater": "set"},
+                             "rows": {"_default": 0}}}
+    state = {"wall_state": {"rows": 5}}   # 'lattice' dropped by the store
+    _backfill_schema_defaults(state, schema)
+    assert "lattice" in state["wall_state"]
+    assert state["wall_state"]["lattice"] is None     # sentinel present
+    assert state["wall_state"]["rows"] == 5           # existing value untouched

--- a/v2ecoli/library/vivarium_bridge.py
+++ b/v2ecoli/library/vivarium_bridge.py
@@ -59,6 +59,38 @@ def _strip_pint_magnitudes(obj):
     return obj
 
 
+def _backfill_schema_defaults(state, ports_schema):
+    """Ensure every leaf a v1 process DECLARES is present in ``state`` before its
+    ``next_update`` runs — backfilling absent leaves with their schema
+    ``_default`` (including ``None``), recursively.
+
+    This is what vivarium's Engine guarantees a process: it always sees its full
+    declared port state. The process-bigraph store layer drops a leaf whose value
+    is ``None`` (it cannot type it), so a sentinel-``None`` field like the
+    cell-wall model's ``wall_state.lattice`` (read as ``states[...]["lattice"]``,
+    ``is None`` → build) would otherwise KeyError. Backfilling at call time
+    presents the sentinel without needing the store to persist ``None``; the
+    value the process WRITES back (e.g. the sampled ndarray) types and persists
+    normally. Never overwrites a value already present in ``state``."""
+    if not isinstance(state, dict) or not isinstance(ports_schema, dict):
+        return state
+    for port, schema in ports_schema.items():
+        if not isinstance(schema, dict):
+            continue
+        if '_default' in schema or '_updater' in schema or '_emit' in schema:
+            # leaf metadata dict
+            if port not in state:
+                state[port] = schema.get('_default')
+        else:
+            # nested ports subtree
+            if port not in state or not isinstance(state[port], dict):
+                if port not in state:
+                    state[port] = {}
+            if isinstance(state.get(port), dict):
+                _backfill_schema_defaults(state[port], schema)
+    return state
+
+
 def _attach_pint_units(obj, unit):
     """Recursively wrap raw numbers as pint Quantities of ``unit``.
 
@@ -298,6 +330,13 @@ def wrap_vivarium_process(
 
         def update(self, state, interval=None):
             v1 = self._v1
+            # Present the v1 process its FULL declared state: backfill any leaf the
+            # pbg store dropped (notably sentinel-None fields it can't type, e.g.
+            # cell-wall's wall_state.lattice) with the schema default — mirroring
+            # vivarium's Engine guarantee. Without it a `states[...]["lattice"]`
+            # read KeyErrors on tick 0.
+            if isinstance(state, dict):
+                _backfill_schema_defaults(state, v1.ports_schema())
             # Per-port boundary unit-bridge: for ports the wrapped process attaches
             # its own (unum) units to, strip v2's pint Quantities to raw magnitudes
             # (e.g. metabolism_redux's ``cell_mass * units.fg``). Ports it reads as
@@ -375,6 +414,9 @@ def wrap_vivarium_instance(
 
         def update(self, state, interval=None):
             v1 = self._v1
+            # Backfill dropped/sentinel-None declared leaves (see process bridge).
+            if isinstance(state, dict):
+                _backfill_schema_defaults(state, v1.ports_schema())
             # Per-port boundary unit-bridge: for ports the wrapped process attaches
             # its own (unum) units to, strip v2's pint Quantities to raw magnitudes
             # (e.g. metabolism_redux's ``cell_mass * units.fg``). Ports it reads as


### PR DESCRIPTION
## What

Addresses the **computed-initial-state boundary**: two general capabilities so a surprise fork subsystem with non-trivial initial state injects and runs unattended.

1. **Honor config `initial_state` + `initial_state_overrides`.** `resolve_config_initial_state` merges inline `initial_state` with override files under `<fork>/data` (overrides on top, same order as `EcoliSim`). Each spec carries the slice for its own topology roots; `apply` seeds those **new** stores (config wins over schema defaults) but **never clobbers** a v2 baseline store like the structured `bulk` array (`protected_roots`). The cell-wall `murein_state` counts now seed correctly.
2. **Schema-default backfill in the bridge.** The process-bigraph store layer drops a leaf whose value is `None` (it can't type it), so a sentinel-`None` field — e.g. the cell-wall model's `wall_state.lattice` (read `is None` → build) — would `KeyError` on tick 0. The bridge now backfills every declared `ports_schema` leaf (including `None`) into the v1 state at call time, mirroring vivarium's Engine guarantee. The ndarray the process writes back types and persists normally.

Also: materialize declared state **before** computing `defer_ports`, so a process's new root stores are node-typed (accept `None` now / ndarray later).

## Validated

`cell_wall.json` (ecoli-cell-wall, ecoli-pbp-binding, ecoli-shape, murein-division) now converts, wires, materializes, **seeds murein**, and runs into the cell-wall processes — previously it failed at the missing lattice key.

## Residual (separate, deeper boundary)

The cell-wall subsystem is designed to initialize inside a vEcoli **EngineProcess** (nested engine) that orders PBPBinding's lattice construction before CellWall reads it; the config's `flow` doesn't order them, the EngineProcess does. Flat injection doesn't reproduce that nesting. **EngineProcess-nested subsystems** are the next capability — distinct from initial-state, which this PR closes.

## Tests

`test_compare_inject`: +3 (override merge, new-store-seed-not-baseline, sentinel-None backfill). Full inject/bridge/report suite green.