### PR TITLE
chore(deps): bump vivarium-dashboard + bigraph-loom pins (Setup & Run revamp)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -308,7 +308,7 @@ wheels = [
 [[package]]
 name = "bigraph-loom"
 version = "0.1.0"
-source = { git = "https://github.com/vivarium-collective/bigraph-loom.git?rev=main#41b556c7f93bc9b65f2ea593ccb82bf15ba386a4" }
+source = { git = "https://github.com/vivarium-collective/bigraph-loom.git?rev=main#8d06560df914e37686a5fc8329efc949f6850a5f" }
 
 [[package]]
 name = "bigraph-schema"
@@ -4581,7 +4581,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/3e/87/794e0b4c5dccbca30
 [[package]]
 name = "vivarium-dashboard"
 version = "0.1.0"
-source = { git = "https://github.com/vivarium-collective/vivarium-dashboard.git?branch=main#b19c8cdf9518afa9473a46e810d1300d872e6c85" }
+source = { git = "https://github.com/vivarium-collective/vivarium-dashboard.git?branch=main#cf92a0cf5184f1fbdbb1b6c59fef746b2b022a7d" }
 dependencies = [
     { name = "bigraph-loom" },
     { name = "bigraph-schema" },


### PR DESCRIPTION
Lands the bigraph-loom **Setup & Run revamp** on the v2ecoli read-only dashboard by bumping the two pins:

- `vivarium-dashboard`: `b19c8cd` → `cf92a0c` (PR #444 — bigraph-loom reintegration: flush, download, run-first UI)
- `bigraph-loom`: `41b556c` → `8d06560` (PR #5 — Setup & Run revamp: run-first composite viewer)

## What this brings
- **Consolidated composite explorer**: unify on bigraph-loom; drop the duplicate SP-C "Configure & Run" widget + outer tab pair; one **Explore** button per composite card.
- **Run-first configure/run**: viewer opens on a merged **Setup & Run** tab; post-run flush (analyses + report card); generic default "observables over time" figure; **Download results** zip.
- On the published (snapshot) read-only dashboard, the composite-explorer consolidation is visible; configure/run stays read-only (Wiring only) by design.

lock-only change; after merge, publish via `gh workflow run "Publish read-only dashboard" --ref main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)