### PR TITLE
publish-dashboard: force loom@main so read-only snapshot ships current UI

### DIFF
--- a/.github/workflows/publish-dashboard.yml
+++ b/.github/workflows/publish-dashboard.yml
@@ -56,12 +56,20 @@ jobs:
         # the job alive if an optional extra fails to build.
         run: uv sync --extra dev || uv sync
 
-      - name: Ensure the publish CLI is present (latest dashboard main)
+      - name: Ensure the publish CLI + loom bundle are current (latest main)
         # uv.lock may pin a vivarium-dashboard commit that predates the publish
         # CLI (vivarium_dashboard.publish). Force the current main so
         # `vivarium-dashboard-publish` exists and carries the latest publish
         # robustness fixes.
-        run: uv pip install --reinstall-package vivarium-dashboard "vivarium-dashboard @ git+https://github.com/vivarium-collective/vivarium-dashboard.git@main"
+        #
+        # bigraph-loom needs the SAME treatment: the read-only snapshot bundles
+        # loom's built `_dist` from the installed package, but reinstalling
+        # vivarium-dashboard alone does NOT re-fetch loom (the uv.lock-pinned
+        # loom already satisfies the `@main` git spec), so the snapshot would
+        # ship a stale loom UI. Force loom@main too.
+        run: |
+          uv pip install --reinstall-package vivarium-dashboard "vivarium-dashboard @ git+https://github.com/vivarium-collective/vivarium-dashboard.git@main"
+          uv pip install --reinstall-package bigraph-loom "bigraph-loom @ git+https://github.com/vivarium-collective/bigraph-loom.git@main"
 
       - name: Build dashboard snapshot
         # Builds the static SPA bundle (all investigations + studies) and strips


### PR DESCRIPTION
## Problem

The public read-only dashboard (https://vivarium-collective.github.io/v2ecoli/dashboard/) still shows the **old** loom UI — Configure/Run separate from a Wiring viewer — instead of the merged **Setup & Run** revamp ([bigraph-loom#5](https://github.com/vivarium-collective/bigraph-loom/pull/5), [vivarium-dashboard#444](https://github.com/vivarium-collective/vivarium-dashboard/pull/444)).

**Root cause:** the publish workflow force-reinstalls `vivarium-dashboard@main` (because `uv.lock` pins go stale) but had no equivalent for `bigraph-loom`. The snapshot bundles loom's built `_dist` from the installed package, and `uv pip install --reinstall-package vivarium-dashboard …@main` does **not** re-fetch loom — the `uv.lock`-pinned loom (`6edc480`, pre-revamp) already satisfies the `@main` git spec. So the snapshot kept shipping the stale loom bundle.

Verified against the live site: the published `bigraph-loom/assets/index-gL1CNpkh.js` has `Setup & Run` count 0; loom `origin/main`'s committed `_dist` (`index-DcfD0OqK.js`) has it (count 2).

## Fix

Mirror the vivarium-dashboard treatment: also `--reinstall-package bigraph-loom` to `@main` in the same step. Future loom changes now republish without a `uv.lock` bump.

Single-file workflow change; editing the workflow is itself in the `paths:` filter, so the merge auto-triggers a republish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)