### PR TITLE
Migrate to vivarium-workbench (renamed from vivarium-dashboard)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,11 +38,11 @@ jobs:
         run: uv python install 3.12.9
 
       - name: Install dependencies (PyPI only)
-        # vivarium-dashboard's wheel build fails under strict hatchling; the
+        # vivarium-workbench's wheel build fails under strict hatchling; the
         # upstream fix requires bigraph-schema>=1.4.1 (a core bump we're
         # deferring). It isn't imported by the test suite (testpaths=tests),
         # so skip building it here.
-        run: uv sync --extra dev --no-install-package vivarium-dashboard || uv sync --no-install-package vivarium-dashboard
+        run: uv sync --extra dev --no-install-package vivarium-workbench || uv sync --no-install-package vivarium-workbench
 
       - name: Run fast tests (no .run() calls)
         # -n 1 (serial): each worker holds sim_data + built composites, so on the
@@ -80,11 +80,11 @@ jobs:
         run: uv python install 3.12.9
 
       - name: Install dependencies (PyPI only)
-        # vivarium-dashboard's wheel build fails under strict hatchling; the
+        # vivarium-workbench's wheel build fails under strict hatchling; the
         # upstream fix requires bigraph-schema>=1.4.1 (a core bump we're
         # deferring). It isn't imported by the test suite (testpaths=tests),
         # so skip building it here.
-        run: uv sync --extra dev --no-install-package vivarium-dashboard || uv sync --no-install-package vivarium-dashboard
+        run: uv sync --extra dev --no-install-package vivarium-workbench || uv sync --no-install-package vivarium-workbench
 
       # Cache out/cache (initial_state.json + sim_data_cache.dill +
       # cache_version.json) across PRs. The cache key pins to the same

--- a/.github/workflows/publish-dashboard.yml
+++ b/.github/workflows/publish-dashboard.yml
@@ -5,7 +5,7 @@ name: Publish read-only dashboard
 # vivarium-collective.github.io/v2ecoli/dashboard/). This is the READ-ONLY
 # mirror of every investigation + study on main — browsable with no server.
 #
-# Built by vivarium-dashboard-publish (scripts/publish_dashboard.sh), the same
+# Built by vivarium-workbench-publish (scripts/publish_dashboard.sh), the same
 # build you can run locally to preview. Companion to publish-reports.yml (which
 # publishes the per-investigation HTML reports); this one publishes the
 # interactive dashboard SPA.
@@ -50,25 +50,25 @@ jobs:
       - name: Set up Python
         run: uv python install 3.12.9
 
-      - name: Install dependencies (incl. vivarium-dashboard)
-        # The publish build needs vivarium-dashboard. The hatchling build works
+      - name: Install dependencies (incl. vivarium-workbench)
+        # The publish build needs vivarium-workbench. The hatchling build works
         # now that bigraph-schema is un-pinned; the `|| uv sync` fallback keeps
         # the job alive if an optional extra fails to build.
         run: uv sync --extra dev || uv sync
 
       - name: Ensure the publish CLI + loom bundle are current (latest main)
-        # uv.lock may pin a vivarium-dashboard commit that predates the publish
-        # CLI (vivarium_dashboard.publish). Force the current main so
-        # `vivarium-dashboard-publish` exists and carries the latest publish
+        # uv.lock may pin a vivarium-workbench commit that predates the publish
+        # CLI (vivarium_workbench.publish). Force the current main so
+        # `vivarium-workbench-publish` exists and carries the latest publish
         # robustness fixes.
         #
         # bigraph-loom needs the SAME treatment: the read-only snapshot bundles
         # loom's built `_dist` from the installed package, but reinstalling
-        # vivarium-dashboard alone does NOT re-fetch loom (the uv.lock-pinned
+        # vivarium-workbench alone does NOT re-fetch loom (the uv.lock-pinned
         # loom already satisfies the `@main` git spec), so the snapshot would
         # ship a stale loom UI. Force loom@main too.
         run: |
-          uv pip install --reinstall-package vivarium-dashboard "vivarium-dashboard @ git+https://github.com/vivarium-collective/vivarium-dashboard.git@main"
+          uv pip install --reinstall-package vivarium-workbench "vivarium-workbench @ git+https://github.com/vivarium-collective/vivarium-dashboard.git@main"
           uv pip install --reinstall-package bigraph-loom "bigraph-loom @ git+https://github.com/vivarium-collective/bigraph-loom.git@main"
 
       - name: Build dashboard snapshot
@@ -77,8 +77,8 @@ jobs:
         #
         # Run inside the activated venv rather than via `uv run`: `uv run`
         # re-syncs the env to uv.lock first, which would UNDO the previous step's
-        # ad-hoc install of vivarium-dashboard@main and drop the
-        # `vivarium-dashboard-publish` console script (-> exit 127).
+        # ad-hoc install of vivarium-workbench@main and drop the
+        # `vivarium-workbench-publish` console script (-> exit 127).
         run: |
           source .venv/bin/activate
           bash scripts/publish_dashboard.sh reports/published/dashboard

--- a/.github/workflows/publish-reports.yml
+++ b/.github/workflows/publish-reports.yml
@@ -2,7 +2,7 @@ name: Publish investigation reports
 
 # Regenerate every investigation's self-contained HTML report and publish it to
 # the gh-pages branch at investigations/<slug>.html. The report is built by the
-# vivarium-dashboard SPA client-side, so we serve the dashboard headlessly and
+# vivarium-workbench SPA client-side, so we serve the dashboard headlessly and
 # drive its "Generate report" button via Playwright
 # (scripts/publish_investigation_reports.py).
 #
@@ -47,8 +47,8 @@ jobs:
       - name: Set up Python
         run: uv python install 3.12.9
 
-      - name: Install dependencies (incl. vivarium-dashboard)
-        # Unlike the test jobs, the report generator NEEDS vivarium-dashboard
+      - name: Install dependencies (incl. vivarium-workbench)
+        # Unlike the test jobs, the report generator NEEDS vivarium-workbench
         # (it serves the SPA). The dashboard's hatchling build works again now
         # that bigraph-schema is un-pinned, so a full sync is fine; the `|| uv
         # sync` fallback keeps the job alive if an optional extra fails to build.
@@ -63,7 +63,7 @@ jobs:
 
       - name: Generate investigation reports
         id: gen
-        # Spawns `vivarium-dashboard serve`, drives each investigation's report
+        # Spawns `vivarium-workbench serve`, drives each investigation's report
         # export headlessly, writes reports/published/investigations/<slug>.html.
         # Keep going on a per-report failure so good reports still publish; the
         # script's exit code is recorded for the final status gate.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -342,7 +342,7 @@ Two conventions:
    Visually distinguishes from feature PRs in the PR list.
 
 2. **Draft state** — open with `gh pr create --draft ...` (or, when
-   creating from the vivarium-dashboard GitHub tab, the `draft=True`
+   creating from the vivarium-workbench GitHub tab, the `draft=True`
    default applies automatically). Draft signals "don't merge me" to
    both reviewers and to GitHub's auto-merge / branch-policy machinery.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ COPY . .
 
 # Install v2ecoli + its locked deps into an in-project venv. Include the `ray` and
 # emitter extras (the multiseed fan-out + XArray/Parquet output); skip dev tooling and
-# the heavy vivarium-dashboard (mirrors CI's `--no-install-package vivarium-dashboard`).
+# the heavy vivarium-workbench (mirrors CI's `--no-install-package vivarium-workbench`).
 # UV_LINK_MODE=copy makes the venv self-contained (real wheel copies, not links into the
 # cache). The cache itself is a BuildKit cache mount below, so it is reused across builds
 # but NOT baked into the image layer — this is what keeps the image from ballooning toward
@@ -37,8 +37,8 @@ ENV UV_LINK_MODE=copy
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv python install 3.12.12
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --no-dev --extra ray --extra emitters --no-install-package vivarium-dashboard \
- || uv sync --no-dev --extra ray --no-install-package vivarium-dashboard
+    uv sync --no-dev --extra ray --extra emitters --no-install-package vivarium-workbench \
+ || uv sync --no-dev --extra ray --no-install-package vivarium-workbench
 
 # Put the venv on PATH so `python`, `ray`, and the `v2ecoli-*` console scripts resolve —
 # both for non-login shells (ENV PATH) and LOGIN shells (the entrypoint runs the workload

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Two things follow from that:
 - **The repository is a pbg research workspace.** Alongside the model code live
   **investigations** (a research question) and **studies** (the simulations that
   answer it) — browsable and runnable in the
-  [vivarium-dashboard](https://github.com/vivarium-collective/vivarium-dashboard).
+  [vivarium-workbench](https://github.com/vivarium-collective/vivarium-dashboard).
   Investigations live under `workspace/investigations/` (baseline showcase,
   PDMP, colonies, and more), each publishing a self-contained
   [investigation report](#explore-v2ecoli).
@@ -60,11 +60,11 @@ There are **three** kinds of output, each from a different pipeline.
 **[→ vivarium-collective.github.io/v2ecoli/dashboard/](https://vivarium-collective.github.io/v2ecoli/dashboard/)**
 
 A read-only snapshot of the v2ecoli workspace in the
-[vivarium-dashboard](https://github.com/vivarium-collective/vivarium-dashboard):
+[vivarium-workbench](https://github.com/vivarium-collective/vivarium-dashboard):
 investigations & studies, the process/type **registry**, navigable **composite**
 wiring graphs (`baseline`, `parca`), and the **sources** bundle. Auto-rebuilt
 from `main` on every push. For the full interactive version (authoring, running
-studies), clone and run `vivarium-dashboard serve` locally.
+studies), clone and run `vivarium-workbench serve` locally.
 
 ### 📊 Investigation reports — *one self-contained report per research question*
 
@@ -145,7 +145,7 @@ What you get over upstream vEcoli:
 - **A research workspace.** The repo is a pbg workspace (`workspace.yaml`):
   biology sits next to **investigations** (a shared research question) and
   **studies** (the runs that answer it) under `workspace/`, all browsable and
-  runnable in the vivarium-dashboard. Manage them with the `pbg-investigation` /
+  runnable in the vivarium-workbench. Manage them with the `pbg-investigation` /
   `pbg-study` skills.
 - **A decomposed ParCa.** The monolithic `fitSimData_1()` is broken into nine
   inspectable Steps, and the fitted `sim_data` is shipped pre-computed.
@@ -223,7 +223,7 @@ quantities at ports are `pint.Quantity`; the only place `Unum` survives is the
 upstream-interop bridge at `v2ecoli/library/unit_bridge.py`.
 
 **The `pbg_v2ecoli/` package** at the repo root is the *workspace* package the
-[vivarium-dashboard](https://github.com/vivarium-collective/vivarium-dashboard)
+[vivarium-workbench](https://github.com/vivarium-collective/vivarium-dashboard)
 uses. Its `build_core()` pre-registers the v2ecoli types **plus** the `EcoliWCM`
 bridge before composites are built (so the dashboard's subprocess runner can pass
 a fully-populated `core`). The model package (`v2ecoli/`) and the workspace
@@ -388,7 +388,7 @@ Choosing an emitter:
 - **Override context managers** — `with parquet_emitter(experiment_id=…) as e:`
   wraps a build and auto-flushes on exit (`v2ecoli/composites/_helpers.py`).
 
-> The vivarium-dashboard's Simulations-DB tab currently reads SQLite, not
+> The vivarium-workbench's Simulations-DB tab currently reads SQLite, not
 > Parquet/Zarr — those are for offline DuckDB / xarray analysis.
 
 ---
@@ -596,7 +596,7 @@ workspace.yaml     pbg workspace config
 - [bigraph-schema](https://github.com/vivarium-collective/bigraph-schema) — type system + auto-discovery
 - [pbg-superpowers](https://github.com/vivarium-collective/pbg-superpowers) — `@composite_generator`, `Visualization`
 - [pbg-emitters](https://github.com/vivarium-collective/pbg-emitters) — `ParquetEmitter`
-- [vivarium-dashboard](https://github.com/vivarium-collective/vivarium-dashboard) — interactive workspace UI (reads `workspace.yaml` + `pbg_v2ecoli/`)
+- [vivarium-workbench](https://github.com/vivarium-collective/vivarium-dashboard) — interactive workspace UI (reads `workspace.yaml` + `pbg_v2ecoli/`)
 - [vEcoli](https://github.com/CovertLab/vEcoli) — ParCa reference data & biology
 - [multi-cell](https://github.com/vivarium-collective/pymunk-process) — 2D colony physics
 - [3d-ecoli](https://github.com/vivarium-collective/3d-ecoli) — 3D structural model (imports v2ecoli + pbg-parsimony)

--- a/docs/native-analyses-status-and-roadmap.md
+++ b/docs/native-analyses-status-and-roadmap.md
@@ -18,7 +18,7 @@ vEcoli's DuckDB/`sim_data` analyses now run **natively inside v2ecoli** as proce
 ### The `Analysis` abstraction (in `main`)
 - `Analysis(V2Step)` — sibling of the record-based `AnalysisStep`; declares DuckDB `conn` + scale-scoped `history_sql` + ParCa `sim_data` input ports; emits `{view: html, data: map}`. Shared `ANALYSIS_REGISTRY`.
 - Runner (`workflow/analysis_runner.py`) provisions one DuckDB connection + the paired `sim_data` per run, builds a per-scale `history_sql`, writes `data → analysis.json` and `view → <sweep>/viz/*.html`.
-- Dashboard integration is **done** (generic, no per-analysis code): vivarium-dashboard reads `v2ecoli.workflow.analysis.ANALYSIS_REGISTRY` to list `Analysis` classes in its picker, runs the ones declared in a study's `analyses:` list via a post-run hook (`_run_study_analyses` → `analysis_runner.run_analyses`), and surfaces the resulting `<sweep>/viz/*.html` per study/investigation (`_discover_viz_html_files` / `_discover_investigation_viz_html_files`). Any registered analysis (incl. `ptools_overview`) appears automatically once v2ecoli is importable in the serving venv. See vivarium-dashboard `docs/post-run-analyses.md`.
+- Dashboard integration is **done** (generic, no per-analysis code): vivarium-workbench reads `v2ecoli.workflow.analysis.ANALYSIS_REGISTRY` to list `Analysis` classes in its picker, runs the ones declared in a study's `analyses:` list via a post-run hook (`_run_study_analyses` → `analysis_runner.run_analyses`), and surfaces the resulting `<sweep>/viz/*.html` per study/investigation (`_discover_viz_html_files` / `_discover_investigation_viz_html_files`). Any registered analysis (incl. `ptools_overview`) appears automatically once v2ecoli is importable in the serving venv. See vivarium-workbench `docs/post-run-analyses.md`.
 
 ### 24 ported analyses (`Analysis`, DuckDB/`sim_data`)
 | Scale | Analyses |
@@ -79,7 +79,7 @@ The ptools data pipeline is done; the *visualization* is not. In increasing dept
    resolve in the live ECOLI PGDB. Run the server per the appendix below.
 
 ### B. Dashboard surfacing — DONE
-The `vivarium-dashboard` integration is merged (on its `main`) and is **generic**
+The `vivarium-workbench` integration is merged (on its `main`) and is **generic**
 — it reads `v2ecoli.workflow.analysis.ANALYSIS_REGISTRY` directly, so no
 per-analysis dashboard change is needed:
 - **Picker** lists every registered `Analysis` class (`_build_analysis_options`).
@@ -94,7 +94,7 @@ So `ptools_overview` (and any future analysis) shows up automatically. The only
 prerequisites are operational: v2ecoli must be importable in the dashboard's
 serving venv (cf. the pbg editable-install gap), and — for the painted
 overview — the external `sms-ptools` server must be running (see the appendix /
-`scripts/ptools_server.sh`). Reference: vivarium-dashboard `docs/post-run-analyses.md`.
+`scripts/ptools_server.sh`). Reference: vivarium-workbench `docs/post-run-analyses.md`.
 
 ### C. Other follow-ups
 - **`validation_data`:** the current minimal loader covers Schmidt/Wisniewski protein counts only. A fuller `ValidationDataEcoli` port (or adding a `validation/` tier to the **ecoli-sources** package, which is reconstruction-only today) would generalize it.
@@ -148,9 +148,9 @@ published gh-pages site (no server to build the launch URL). One-time:
    ```
 2. **Run the dashboard locally**, pointed at this repo:
    ```sh
-   vivarium-dashboard serve --workspace . --port 8771
+   vivarium-workbench serve --workspace . --port 8771
    ```
-   (Run from a venv where `v2ecoli` + `vivarium-dashboard` are installed. The
+   (Run from a venv where `v2ecoli` + `vivarium-workbench` are installed. The
    `ui.ptools_server_url` and `ui.ptools_data_dir: "/ptools-data"` keys are
    already set in `workspace.yaml`.)
 3. Open **http://localhost:8771** → **Analyses** tab → **Launch in Omics Viewer**

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -21,7 +21,7 @@ links into all three.
 **[→ vivarium-collective.github.io/v2ecoli/dashboard/](https://vivarium-collective.github.io/v2ecoli/dashboard/)**
 
 A **read-only** snapshot of the v2ecoli workspace rendered by the
-[vivarium-dashboard](https://github.com/vivarium-collective/vivarium-dashboard)
+[vivarium-workbench](https://github.com/vivarium-collective/vivarium-dashboard)
 SPA. Browse:
 
 - **Investigations & studies** — the research questions and the runs that answer
@@ -32,15 +32,15 @@ SPA. Browse:
   `parca`) via the embedded [bigraph-loom](https://github.com/vivarium-collective/bigraph-loom) viewer.
 - **Sources** — the ecoli-sources input bundle, each with a link.
 
-**How it's built.** `vivarium-dashboard-publish` exports the workspace into a
+**How it's built.** `vivarium-workbench-publish` exports the workspace into a
 self-contained static bundle (per-resource JSON + page shells + assets) that any
 static server can host. The `publish-dashboard.yml` workflow rebuilds it from
 `main` and publishes it to `gh-pages:dashboard/`.
 
 > The hosted version is **view-only**. For the full interactive dashboard —
 > authoring investigations, running studies, editing wiring — clone the repo and
-> run `vivarium-dashboard serve` locally (see the
-> [vivarium-dashboard README](https://github.com/vivarium-collective/vivarium-dashboard#readme)).
+> run `vivarium-workbench serve` locally (see the
+> [vivarium-workbench README](https://github.com/vivarium-collective/vivarium-dashboard#readme)).
 
 ---
 

--- a/docs/superpowers/plans/2026-06-27-comparison-harness-modular-cards.md
+++ b/docs/superpowers/plans/2026-06-27-comparison-harness-modular-cards.md
@@ -15,7 +15,7 @@
 - `Section = {"title": str, "kind": "content", "html": str, "anchor": str, "verdict": str | None}` — the existing section dict shape; the assembler stays structurally unchanged.
 - Rendered output keeps the `docs/report_cards/` convention.
 - seeds = a config's `n_init_sims`; gens = a config's `generations` — read from the vEcoli config, never the manifest.
-- Run tests with `/Users/eranagmon/code/v2e-cmp-harness/.venv/bin/python -m pytest` (set up the venv first if absent: `cd /Users/eranagmon/code/v2e-cmp-harness && uv sync --no-install-package vivarium-dashboard`).
+- Run tests with `/Users/eranagmon/code/v2e-cmp-harness/.venv/bin/python -m pytest` (set up the venv first if absent: `cd /Users/eranagmon/code/v2e-cmp-harness && uv sync --no-install-package vivarium-workbench`).
 
 ---
 

--- a/docs/superpowers/plans/2026-06-28-modular-tests-A-dashboard.md
+++ b/docs/superpowers/plans/2026-06-28-modular-tests-A-dashboard.md
@@ -26,8 +26,8 @@
 ### Task A1: Payload carries `kind`/`card` + per-study report-card lookup
 
 **Files:**
-- Modify: `vivarium_dashboard/api/app.py` (the `/api/study/{slug}` route, ~line 1290-1305)
-- Test: `vivarium_dashboard/testing/test_modular_tests_payload.py` (create)
+- Modify: `vivarium_workbench/api/app.py` (the `/api/study/{slug}` route, ~line 1290-1305)
+- Test: `vivarium_workbench/testing/test_modular_tests_payload.py` (create)
 
 **Interfaces:**
 - Produces: the study-detail payload includes, for each test entry, its `kind` (default `"behavioral"`) and `card` (if any); and a top-level `report_card_urls` map `{<card name>: {url, verdict}}` for THIS study's `viz/report_card/` artifacts, so the SPA needn't cross-reference the global saved-visualizations endpoint.
@@ -35,11 +35,11 @@
 - [ ] **Step 1: Write the failing test**
 
 ```python
-# vivarium_dashboard/testing/test_modular_tests_payload.py
+# vivarium_workbench/testing/test_modular_tests_payload.py
 import json
 from pathlib import Path
 
-from vivarium_dashboard.lib import study_spec
+from vivarium_workbench.lib import study_spec
 
 
 def _ws(tmp_path):
@@ -71,11 +71,11 @@ def test_report_card_urls_and_kind_in_payload(tmp_path):
 
 - [ ] **Step 2: Run it — expect FAIL** (`KeyError: 'report_card_urls'`)
 
-Run: `.venv/bin/python -m pytest vivarium_dashboard/testing/test_modular_tests_payload.py -q`
+Run: `.venv/bin/python -m pytest vivarium_workbench/testing/test_modular_tests_payload.py -q`
 
 - [ ] **Step 3: Implement — add `report_card_urls` to the study-detail spec**
 
-In `vivarium_dashboard/lib/study_spec.py`, at the end of `load_study_detail_spec(ws, slug)` (just before it returns `spec`), add:
+In `vivarium_workbench/lib/study_spec.py`, at the end of `load_study_detail_spec(ws, slug)` (just before it returns `spec`), add:
 
 ```python
     # Per-study report-card artifacts (viz/report_card/<card>.{html,verdict.json})
@@ -103,13 +103,13 @@ In `vivarium_dashboard/lib/study_spec.py`, at the end of `load_study_detail_spec
 
 - [ ] **Step 4: Run it — expect PASS**
 
-Run: `.venv/bin/python -m pytest vivarium_dashboard/testing/test_modular_tests_payload.py -q`
+Run: `.venv/bin/python -m pytest vivarium_workbench/testing/test_modular_tests_payload.py -q`
 Expected: PASS.
 
 - [ ] **Step 5: Commit**
 
 ```bash
-git add vivarium_dashboard/lib/study_spec.py vivarium_dashboard/testing/test_modular_tests_payload.py
+git add vivarium_workbench/lib/study_spec.py vivarium_workbench/testing/test_modular_tests_payload.py
 git commit -m "feat(tests): study payload exposes report_card_urls + per-test kind"
 ```
 
@@ -118,8 +118,8 @@ git commit -m "feat(tests): study payload exposes report_card_urls + per-test ki
 ### Task A2: Template tags each test `<li>` with its kind + a mount point
 
 **Files:**
-- Modify: `vivarium_dashboard/templates/study-detail.html` (the Tests loop, ~1771-1836)
-- Test: `vivarium_dashboard/testing/test_modular_tests_render.py` (create)
+- Modify: `vivarium_workbench/templates/study-detail.html` (the Tests loop, ~1771-1836)
+- Test: `vivarium_workbench/testing/test_modular_tests_render.py` (create)
 
 **Interfaces:**
 - Consumes: each `b` in `study.behavior_tests or study.expected_behavior or study.tests` may have `b.kind`/`b.card`.
@@ -128,7 +128,7 @@ git commit -m "feat(tests): study payload exposes report_card_urls + per-test ki
 - [ ] **Step 1: Write the failing test** (renders the template fragment and checks the mount)
 
 ```python
-# vivarium_dashboard/testing/test_modular_tests_render.py
+# vivarium_workbench/testing/test_modular_tests_render.py
 from jinja2 import Environment, FileSystemLoader
 from pathlib import Path
 
@@ -162,7 +162,7 @@ def test_behavioral_renders_pill_report_card_renders_mount():
 
 - [ ] **Step 2: Run it — expect PASS for the harness** (this test pins the contract; it passes on the harness template). Then make the REAL template match this contract in Step 3, verified by Task A3's integration check.
 
-Run: `.venv/bin/python -m pytest vivarium_dashboard/testing/test_modular_tests_render.py -q`
+Run: `.venv/bin/python -m pytest vivarium_workbench/testing/test_modular_tests_render.py -q`
 Expected: PASS (the harness encodes the target markup).
 
 - [ ] **Step 3: Edit the real template** — `templates/study-detail.html`, the Tests loop at ~1793
@@ -199,15 +199,15 @@ and add a matching `{% endif %}` before the existing `</li>` that closes the ite
 
 - [ ] **Step 4: Run the render test + a template smoke**
 
-Run: `.venv/bin/python -m pytest vivarium_dashboard/testing/test_modular_tests_render.py -q`
+Run: `.venv/bin/python -m pytest vivarium_workbench/testing/test_modular_tests_render.py -q`
 Then smoke that the real template still parses:
-`.venv/bin/python -c "from jinja2 import Environment, FileSystemLoader; Environment(loader=FileSystemLoader('vivarium_dashboard/templates')).get_template('study-detail.html'); print('template parses')"`
+`.venv/bin/python -c "from jinja2 import Environment, FileSystemLoader; Environment(loader=FileSystemLoader('vivarium_workbench/templates')).get_template('study-detail.html'); print('template parses')"`
 Expected: PASS + `template parses`.
 
 - [ ] **Step 5: Commit**
 
 ```bash
-git add vivarium_dashboard/templates/study-detail.html vivarium_dashboard/testing/test_modular_tests_render.py
+git add vivarium_workbench/templates/study-detail.html vivarium_workbench/testing/test_modular_tests_render.py
 git commit -m "feat(tests): template tags test <li> by kind + report_card mount"
 ```
 
@@ -216,8 +216,8 @@ git commit -m "feat(tests): template tags test <li> by kind + report_card mount"
 ### Task A3: `loadTestsTab` fills report-card mounts with the embedded card + verdict
 
 **Files:**
-- Modify: `vivarium_dashboard/static/study-detail.js` (`loadTestsTab`, ~839-963; add a helper + a fill pass)
-- Test: `vivarium_dashboard/testing/test_modular_tests_js.py` (create — a string-level assertion on the shipped JS, since the repo has no JS test runner)
+- Modify: `vivarium_workbench/static/study-detail.js` (`loadTestsTab`, ~839-963; add a helper + a fill pass)
+- Test: `vivarium_workbench/testing/test_modular_tests_js.py` (create — a string-level assertion on the shipped JS, since the repo has no JS test runner)
 
 **Interfaces:**
 - Consumes: `window._study.report_card_urls` (Task A1) — `{<card>: {url, verdict}}`; the `<div class="report-card-mount" data-card="<card>">` elements (Task A2).
@@ -226,7 +226,7 @@ git commit -m "feat(tests): template tags test <li> by kind + report_card mount"
 - [ ] **Step 1: Write the failing test** (asserts the JS contains the fill logic)
 
 ```python
-# vivarium_dashboard/testing/test_modular_tests_js.py
+# vivarium_workbench/testing/test_modular_tests_js.py
 from pathlib import Path
 
 JS = (Path(__file__).resolve().parent.parent / "static" / "study-detail.js").read_text(encoding="utf-8")
@@ -244,7 +244,7 @@ def test_loadteststab_fills_report_card_mounts():
 
 - [ ] **Step 2: Run it — expect FAIL** (`_fillReportCardModules` not present)
 
-Run: `.venv/bin/python -m pytest vivarium_dashboard/testing/test_modular_tests_js.py -q`
+Run: `.venv/bin/python -m pytest vivarium_workbench/testing/test_modular_tests_js.py -q`
 
 - [ ] **Step 3: Add the fill helper + call it from `loadTestsTab`**
 
@@ -297,7 +297,7 @@ Then, at the END of `loadTestsTab(spec)` (just before its closing `}`), add:
 
 - [ ] **Step 4: Run the JS-contract test + deploy to the editable install**
 
-Run: `.venv/bin/python -m pytest vivarium_dashboard/testing/test_modular_tests_js.py -q`
+Run: `.venv/bin/python -m pytest vivarium_workbench/testing/test_modular_tests_js.py -q`
 Expected: PASS.
 
 Note for the integration check (Task A4): the v2ecoli `.venv` serves the dashboard from THIS checkout (editable), so the JS/template edits are live after a server restart — no rebuild.
@@ -305,7 +305,7 @@ Note for the integration check (Task A4): the v2ecoli `.venv` serves the dashboa
 - [ ] **Step 5: Commit**
 
 ```bash
-git add vivarium_dashboard/static/study-detail.js vivarium_dashboard/testing/test_modular_tests_js.py
+git add vivarium_workbench/static/study-detail.js vivarium_workbench/testing/test_modular_tests_js.py
 git commit -m "feat(tests): loadTestsTab embeds report_card modules (iframe + verdict)"
 ```
 
@@ -314,7 +314,7 @@ git commit -m "feat(tests): loadTestsTab embeds report_card modules (iframe + ve
 ### Task A4: End-to-end render check against a fixture workspace
 
 **Files:**
-- Test: `vivarium_dashboard/testing/test_modular_tests_e2e.py` (create)
+- Test: `vivarium_workbench/testing/test_modular_tests_e2e.py` (create)
 
 **Interfaces:**
 - Consumes: Tasks A1–A3.
@@ -322,12 +322,12 @@ git commit -m "feat(tests): loadTestsTab embeds report_card modules (iframe + ve
 - [ ] **Step 1: Write the test** — serve a fixture study with a mixed Tests list and assert the payload + the discovered card
 
 ```python
-# vivarium_dashboard/testing/test_modular_tests_e2e.py
+# vivarium_workbench/testing/test_modular_tests_e2e.py
 import json
 from pathlib import Path
 
 from fastapi.testclient import TestClient
-from vivarium_dashboard.api.app import create_app
+from vivarium_workbench.api.app import create_app
 
 
 def _fixture(tmp_path):
@@ -356,17 +356,17 @@ def test_study_detail_payload_has_mixed_tests_and_card_url(tmp_path):
     assert kinds == {"beh": "behavioral", "std": "report_card"}
 ```
 
-(If `create_app`'s workspace kwarg differs, match the signature used by `vivarium_dashboard/cli.py serve` — grep `create_app(` in app.py.)
+(If `create_app`'s workspace kwarg differs, match the signature used by `vivarium_workbench/cli.py serve` — grep `create_app(` in app.py.)
 
 - [ ] **Step 2: Run it — expect PASS** (Tasks A1–A3 satisfy it)
 
-Run: `.venv/bin/python -m pytest vivarium_dashboard/testing/test_modular_tests_e2e.py -q`
+Run: `.venv/bin/python -m pytest vivarium_workbench/testing/test_modular_tests_e2e.py -q`
 Expected: PASS.
 
 - [ ] **Step 3: Commit**
 
 ```bash
-git add vivarium_dashboard/testing/test_modular_tests_e2e.py
+git add vivarium_workbench/testing/test_modular_tests_e2e.py
 git commit -m "test(tests): e2e payload check for mixed behavioral + report_card tests"
 ```
 

--- a/docs/superpowers/plans/2026-06-29-study-report-card-modules.md
+++ b/docs/superpowers/plans/2026-06-29-study-report-card-modules.md
@@ -1042,7 +1042,7 @@ reader iterates the exact dirs the generator wrote to. Confirm:
 ```bash
 $V2EPY -c "
 from pathlib import Path
-from vivarium_dashboard.lib.saved_visualizations import build_saved_visualizations
+from vivarium_workbench.lib.saved_visualizations import build_saved_visualizations
 payload = build_saved_visualizations(Path('$PWD'))
 rc = payload['report_cards']
 print('report_cards found:', len(rc))

--- a/docs/superpowers/specs/2026-06-08-vecoli-analyses-as-pbg-analyses-design.md
+++ b/docs/superpowers/specs/2026-06-08-vecoli-analyses-as-pbg-analyses-design.md
@@ -160,7 +160,7 @@ Replace the record-building/grouping data path (`build_cell_records`,
   one the Visualizations tab reads (§3) — same location, no copy.
 - `main()`: `v2ecoli-analyze <sweep_dir> [--config cfg.json]` unchanged in spirit.
 
-### 3. Dashboard surfacing — `vivarium-dashboard/vivarium_dashboard/server.py`
+### 3. Dashboard surfacing — `vivarium-workbench/vivarium_workbench/server.py`
 
 - **Views (no new plumbing):** the runner writes `view` HTML into `<study>/viz/*.html`,
   which the dashboard **already** surfaces in the Visualizations tab via
@@ -228,7 +228,7 @@ v2ecoli/workflow/analysis_runner.py     refactor: open_connection, scale_history
 v2ecoli/workflow/analyses/              new: ptools_{rna,rxns,proteins}, +mass_fraction,
                                         +1 multiseed plot analysis
 v2ecoli/configs/<proving>.json          analysis_options for the proving set
-vivarium-dashboard/.../server.py        _list_visualization_classes += ANALYSIS_REGISTRY
+vivarium-workbench/.../server.py        _list_visualization_classes += ANALYSIS_REGISTRY
 pyproject.toml                          (unchanged) v2ecoli-analyze console script
 tests/test_workflow_analysis.py         Analysis base + ports + render helper
 tests/test_analysis_runner.py           scale_history_sql, run_analyses, fidelity oracle

--- a/docs/superpowers/specs/2026-06-16-composite-viewers-hub-design.md
+++ b/docs/superpowers/specs/2026-06-16-composite-viewers-hub-design.md
@@ -81,7 +81,7 @@ All viewer links for a composite resolve to the **same** `data/<slug>.state.json
 Reads `viewers.json` and, for each curated composite:
 
 1. **Resolve state + SVG** by reusing the dashboard's
-   `vivarium_dashboard.server._composite_resolve_data(<id>)`, which returns the
+   `vivarium_workbench.server._composite_resolve_data(<id>)`, which returns the
    loom state JSON (with `describe()` docs) **and** a bigraph-viz SVG in one
    call. Write `data/<slug>.state.json` and `img/<slug>.svg`.
    - Runs **locally**, where the on-disk ParCa cache exists, so heavy composites

--- a/docs/superpowers/specs/2026-06-28-modular-tests-report-card-modules-design.md
+++ b/docs/superpowers/specs/2026-06-28-modular-tests-report-card-modules-design.md
@@ -1,7 +1,7 @@
 # Modular Study "Tests" — report-card test modules — Design
 
 **Status:** spec (approved in brainstorm 2026-06-28). Cross-repo:
-`vivarium-dashboard` (consumer) + `v2ecoli` (producer). This is the
+`vivarium-workbench` (consumer) + `v2ecoli` (producer). This is the
 generalization the comparison↔investigation unification was aiming at: a study's
 **Tests section becomes a modular list of evaluation modules**, with the current
 Behavioral Tests as the default kind and **report cards as a pluggable kind**.
@@ -21,7 +21,7 @@ standard / statistical) as their Tests.
 
 Two subsystems, one small contract:
 
-1. **Dashboard framework (vivarium-dashboard, consumer):** the modular,
+1. **Dashboard framework (vivarium-workbench, consumer):** the modular,
    `kind`-dispatched Tests section. Reusable by ANY study.
 2. **Comparison producer (v2ecoli):** emit each study's cards to
    `viz/report_card/`, declare the `report_card` modules, and a scaffold.
@@ -201,7 +201,7 @@ regenerated.
 
 ## Testing
 
-**Dashboard (vivarium-dashboard):**
+**Dashboard (vivarium-workbench):**
 - payload: a study with mixed `tests` (one behavioral + one report_card) passes
   `kind`/`card` through to the payload.
 - render dispatch (JS/template unit or DOM test): behavioral → pill;

--- a/docs/superpowers/specs/2026-06-29-study-report-card-modules-design.md
+++ b/docs/superpowers/specs/2026-06-29-study-report-card-modules-design.md
@@ -18,7 +18,7 @@ they simply gain populated card slots and room for more.
   `workspace/studies/<name>/viz/report_card/<card>.html` (+ optional
   `<card>.verdict.json`, whose `.overall` field drives the verdict pill).
   Discovery is already implemented in
-  `vivarium_dashboard/lib/saved_visualizations.py` and
+  `vivarium_workbench/lib/saved_visualizations.py` and
   `lib/study_spec.py` (`report_card_urls`), and `publish.py` already stages
   `viz/report_card/` into the read-only bundle. **No dashboard changes are
   required.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,8 @@ dependencies = [
     "pbg-parsimony",
     "pbg-bioreactordesign",
     "pbg-ketchup",
-    "vivarium-dashboard",
-    # Transitive dep of pbg-superpowers + vivarium-dashboard (the Actionable
+    "vivarium-workbench",
+    # Transitive dep of pbg-superpowers + vivarium-workbench (the Actionable
     # Investigation Graph types); declared directly so [tool.uv.sources] below
     # resolves its git source (uv applies sources to direct deps, not arbitrary
     # transitive ones).
@@ -46,7 +46,7 @@ dependencies = [
     "requests",
     # Emitters are now BASE/default deps (no longer optional extras): v2ecoli
     # always imports & registers BOTH the Parquet and XArray emitters so they
-    # appear in the vivarium-dashboard emitters list. Parquet remains the
+    # appear in the vivarium-workbench emitters list. Parquet remains the
     # default (workspace.yaml runtime.default_emitter = parquet); XArray is
     # merely available. [parquet] pulls in duckdb/polars/pyarrow/fsspec/tqdm;
     # [xarray] pulls in xarray/zarr/zarrs. The implementations live in
@@ -122,7 +122,7 @@ pbg-bioreactordesign = { git = "https://github.com/vivarium-collective/pbg-biore
 pbg-ketchup = { git = "https://github.com/vivarium-collective/pbg-ketchup.git", branch = "main" }
 pbg-emitters = { git = "https://github.com/vivarium-collective/pbg-emitters.git", branch = "main" }
 pbg-torch = { git = "https://github.com/vivarium-collective/pbg-torch.git", branch = "main" }
-vivarium-dashboard = { git = "https://github.com/vivarium-collective/vivarium-dashboard.git", branch = "main" }
+vivarium-workbench = { git = "https://github.com/vivarium-collective/vivarium-dashboard.git", branch = "main" }
 investigation-contracts = { git = "https://github.com/vivarium-collective/investigation-contracts.git", branch = "main" }
 viva-munk = { git = "https://github.com/vivarium-collective/Viva-munk.git", branch = "main" }
 spatio-flux = { git = "https://github.com/vivarium-collective/spatio-flux.git", branch = "main" }

--- a/reports/composite-state/README.md
+++ b/reports/composite-state/README.md
@@ -5,8 +5,8 @@ read-only dashboard publish step ships verbatim as
 `api/composite-state/<id>.json` and marks navigable (`has_wiring=True`) — even
 if the composite can't resolve at publish time.
 
-`vivarium_dashboard.publish` checks this directory first; a committed file wins
-over live resolution. (See the publish loop in vivarium-dashboard's
+`vivarium_workbench.publish` checks this directory first; a committed file wins
+over live resolution. (See the publish loop in vivarium-workbench's
 `publish.py`.)
 
 ## Why this exists
@@ -29,9 +29,9 @@ import os, sys, json, math
 os.environ.setdefault("POLARS_MAX_THREADS", "1")
 from pathlib import Path
 WS = Path("/path/to/v2ecoli"); sys.path.insert(0, str(WS))
-from vivarium_dashboard import server
-from vivarium_dashboard.lib._root import set_workspace_root
-from vivarium_dashboard.server import _json_default
+from vivarium_workbench import server
+from vivarium_workbench.lib._root import set_workspace_root
+from vivarium_workbench.server import _json_default
 server.WORKSPACE = WS; set_workspace_root(WS)
 
 CID = "v2ecoli.composites.baseline.baseline"

--- a/scripts/add-dataset.sh
+++ b/scripts/add-dataset.sh
@@ -25,8 +25,8 @@ read -rp "claims served (comma-separated, e.g. phase-1.dnaA-accumulation): " DS_
 python3 -c "
 import sys
 from pathlib import Path
-from vivarium_dashboard.lib.workspace_yaml import load_workspace, save_workspace, WorkspaceValidationError
-from vivarium_dashboard.lib._root import set_workspace_root
+from vivarium_workbench.lib.workspace_yaml import load_workspace, save_workspace, WorkspaceValidationError
+from vivarium_workbench.lib._root import set_workspace_root
 set_workspace_root('$WS_ROOT')
 
 ws_root = Path('$WS_ROOT')

--- a/scripts/backfill_runs_db.py
+++ b/scripts/backfill_runs_db.py
@@ -34,7 +34,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 os.chdir(REPO_ROOT)
 sys.path.insert(0, str(REPO_ROOT))
 
-from vivarium_dashboard.lib.composite_runs import connect, generate_run_id
+from vivarium_workbench.lib.composite_runs import connect, generate_run_id
 
 
 # Mapping from each study slug to the runs we want to backfill.

--- a/scripts/beulig_comparison_harness.py
+++ b/scripts/beulig_comparison_harness.py
@@ -504,7 +504,7 @@ def run_arm_multigen(
     """
     from v2ecoli import build_composite
     from v2ecoli.library.sqlite_run import run_multigen_sqlite
-    from vivarium_dashboard.lib import composite_runs
+    from vivarium_workbench.lib import composite_runs
 
     from v2ecoli.composites.baseline import set_null_emitter_override
 

--- a/scripts/finalize_dnaa3.py
+++ b/scripts/finalize_dnaa3.py
@@ -100,7 +100,7 @@ def main():
     print("=== recording run + outcomes ===")
     record(res)
     sh(f"{PY} -c \"import yaml; yaml.safe_load(open('studies/dnaa-3-box-binding/study.yaml')); print('parse OK')\"")
-    sh(f"{PY} -c \"from pathlib import Path; from vivarium_dashboard.lib.report import render_workspace_report; render_workspace_report(Path('.'))\"")
+    sh(f"{PY} -c \"from pathlib import Path; from vivarium_workbench.lib.report import render_workspace_report; render_workspace_report(Path('.'))\"")
     sh("git add studies/dnaa-3-box-binding/ && git commit -q -m 'dnaa-3: RAN seed-1 8-gen (mini) — record run + acceptance tests + plots from the run\n\nCo-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>' && git push origin feat/aim2-dnaa-oric")
     print("=== FINALIZE DONE — dnaa-3 now Ran with results, pushed ===")
 

--- a/scripts/lint-workspace.py
+++ b/scripts/lint-workspace.py
@@ -84,7 +84,7 @@ WS_FILE = WS_ROOT / "workspace.yaml"
 
 # Resolve workspace directories via the optional `layout:` map in workspace.yaml
 # (unset keys default to their flat top-level name). Keep in sync with the
-# WorkspacePaths resolver (vivarium_dashboard.lib.workspace_paths).
+# WorkspacePaths resolver (vivarium_workbench.lib.workspace_paths).
 _LAYOUT_DEFAULTS = {
     "studies": "studies", "investigations": "investigations",
     "composites": "composites", "references": "references",

--- a/scripts/make_mbp_interactive_figures.py
+++ b/scripts/make_mbp_interactive_figures.py
@@ -2,7 +2,7 @@
 
 Adds engaging, hover/zoom/toggle interactive figures ALONGSIDE the existing
 static charts, written to ``reports/figures/<study-dir>/<fig>.html`` so the
-vivarium-dashboard auto-discovers them as ``embed_visualizations`` (iframes,
+vivarium-workbench auto-discovers them as ``embed_visualizations`` (iframes,
 copied verbatim into the gh-pages publish bundle).
 
 Each file is self-contained: Plotly via CDN, an ``html,body{height:820px}``

--- a/scripts/publish_dashboard.sh
+++ b/scripts/publish_dashboard.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Build the read-only v2ecoli dashboard snapshot — a self-contained static SPA
 # bundle (all investigations + studies + assets) that anyone can browse with no
-# server. Built by vivarium-dashboard-publish; the same build is used locally
+# server. Built by vivarium-workbench-publish; the same build is used locally
 # (to practice/preview) and by .github/workflows/publish-dashboard.yml (to
 # publish to gh-pages:dashboard/).
 #
@@ -18,8 +18,8 @@
 #     Pages' project subpath (served at <user>.github.io/v2ecoli/dashboard/).
 #   * bigraph-loom source maps (~8MB, half the bundle) are stripped — a
 #     read-only viewer never needs them.
-#   * Needs `vivarium-dashboard-publish` on PATH (run via `uv run`, or use the
-#     workspace .venv: `.venv/bin/vivarium-dashboard-publish`).
+#   * Needs `vivarium-workbench-publish` on PATH (run via `uv run`, or use the
+#     workspace .venv: `.venv/bin/vivarium-workbench-publish`).
 set -euo pipefail
 
 WS_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -30,7 +30,7 @@ INTERACTIVE_URL="https://github.com/vivarium-collective/v2ecoli"
 rm -rf "$OUT"
 # The workspace's own package must be importable for build_core() registration.
 PYTHONPATH="$WS_ROOT${PYTHONPATH:+:$PYTHONPATH}" \
-  vivarium-dashboard-publish \
+  vivarium-workbench-publish \
     --workspace "$WS_ROOT" \
     --out "$OUT" \
     --base-path "$BASE_PATH" \

--- a/scripts/publish_investigation_reports.py
+++ b/scripts/publish_investigation_reports.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """Headlessly export every investigation's self-contained HTML report.
 
-The investigation report is built CLIENT-SIDE by the vivarium-dashboard SPA
+The investigation report is built CLIENT-SIDE by the vivarium-workbench SPA
 (`_generateInvestigationReport()` → `_buildInvestigationReportHtml`), embedding
 each study's figures as `iframe srcdoc` + data URIs. There is no server-side
 generator, so this script drives the real "Generate report" button in a headless
@@ -10,7 +10,7 @@ manual browser export.
 
 Flow:
   1. discover investigations under workspace/investigations/*/investigation.yaml
-  2. serve the dashboard (`vivarium-dashboard serve`) unless --url points at a
+  2. serve the dashboard (`vivarium-workbench serve`) unless --url points at a
      running one
   3. for each investigation: _openInvestigationDetail(slug) → click-equivalent
      _generateInvestigationReport() → capture the download → write
@@ -156,16 +156,16 @@ def _wait_healthy(url: str, timeout: float = 60.0) -> bool:
 
 
 def _dashboard_binary(ws_root: Path) -> str:
-    """Resolve the vivarium-dashboard CLI: workspace .venv first, then PATH."""
-    local = ws_root / ".venv" / "bin" / "vivarium-dashboard"
+    """Resolve the vivarium-workbench CLI: workspace .venv first, then PATH."""
+    local = ws_root / ".venv" / "bin" / "vivarium-workbench"
     if local.exists():
         return str(local)
-    found = shutil.which("vivarium-dashboard")
+    found = shutil.which("vivarium-workbench")
     if found:
         return found
     raise RuntimeError(
-        "vivarium-dashboard CLI not found (looked in .venv/bin and PATH); "
-        "install it with `uv sync` or `uv pip install vivarium-dashboard`"
+        "vivarium-workbench CLI not found (looked in .venv/bin and PATH); "
+        "install it with `uv sync` or `uv pip install vivarium-workbench`"
     )
 
 

--- a/scripts/regenerate_composite_states.py
+++ b/scripts/regenerate_composite_states.py
@@ -3,7 +3,7 @@
 
 The published (gh-pages) dashboard serves composite state as static files at
 ``api/composite-state/<id>.json`` so the bigraph-loom ``?static=1`` viewer works
-offline. ``vivarium_dashboard.publish.build_bundle`` will use a committed
+offline. ``vivarium_workbench.publish.build_bundle`` will use a committed
 override at ``reports/composite-state/<id>.json`` verbatim (marking the composite
 navigable) when present, and otherwise falls back to LIVE resolution — which
 fails in CI for any composite whose generator needs the on-disk ParCa cache
@@ -60,11 +60,10 @@ def main() -> int:
     if ws_str not in sys.path:
         sys.path.insert(0, ws_str)
 
-    # The dashboard's pure data builders require module-global WORKSPACE to be set.
-    from vivarium_dashboard import server as _srv
-    _srv.WORKSPACE = ws_root
-    from vivarium_dashboard.server import _json_default, _json_sanitize
-    from vivarium_dashboard.lib._root import set_workspace_root
+    from vivarium_workbench.lib.json_serialize import _json_default, _json_sanitize
+    from vivarium_workbench.lib._root import set_workspace_root
+    from vivarium_workbench.lib.composite_lookup import composites_data as _composites_data
+    from vivarium_workbench.lib.composite_resolve import resolve_composite
     set_workspace_root(ws_root)
 
     # Reuse the viewers-hub trimmer: caps the long molecule-data arrays (bulk
@@ -74,7 +73,7 @@ def main() -> int:
     sys.path.insert(0, str(ws_root / "scripts"))
     from regenerate_viewers import trim_state_for_view
 
-    composites = _srv._composites_data(ws_root)
+    composites = _composites_data(ws_root)
     comps = composites.get("composites") or []
     if not comps:
         print(f"ERROR: no composites discovered ({composites.get('error')})", file=sys.stderr)
@@ -102,7 +101,7 @@ def main() -> int:
     ok, failed = [], []
     for cid in sorted(ids):
         try:
-            data = _srv._composite_resolve_data(cid)
+            data = resolve_composite(ws_root, cid)
         except Exception as e:  # noqa: BLE001
             data = None
             err = repr(e)

--- a/scripts/regenerate_viewers.py
+++ b/scripts/regenerate_viewers.py
@@ -78,7 +78,7 @@ def write_state(state: dict, slug: str, data_dir: Path) -> Path:
     # and allow_nan=False + the _json_sanitize fallback replaces inf/nan with
     # null. Plain json.dumps chokes on the ndarrays. loom's ?stateUrl= reader
     # expects the {"state": <bigraph-state>} wrapper.
-    from vivarium_dashboard.server import _json_body
+    from vivarium_workbench.lib.json_serialize import _json_body
     out.write_bytes(_json_body({"state": state}))
     return out
 
@@ -140,10 +140,9 @@ _PAGE_TEMPLATE = """<!doctype html>
 def resolve_state_via_dashboard(spec_id: str) -> dict | None:
     """Resolve a composite to its loom state dict by reusing the dashboard's
     pure resolver. Returns None on failure, after surfacing WHY."""
-    import vivarium_dashboard.server as srv
+    from vivarium_workbench.lib.composite_resolve import resolve_composite
     # This script is always run standalone; point the dashboard's pure resolver at this workspace.
-    srv.WORKSPACE = REPO_ROOT
-    data = srv._composite_resolve_data(spec_id)
+    data = resolve_composite(REPO_ROOT, spec_id)
     if data and isinstance(data.get("state"), dict):
         return data["state"]
     # _composite_resolve_data swallows the real error and returns None. Re-run

--- a/scripts/render-dashboard.py
+++ b/scripts/render-dashboard.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """Render the workspace dashboard.
 
-After the dashboard runtime was extracted to ``vivarium-dashboard``, this
-script just wraps :func:`vivarium_dashboard.lib.report.render_dashboard`.
+After the dashboard runtime was extracted to ``vivarium-workbench``, this
+script just wraps :func:`vivarium_workbench.lib.report.render_dashboard`.
 Kept for backward compatibility with older `bash` callers and CI.
 """
 from __future__ import annotations
@@ -12,11 +12,11 @@ from pathlib import Path
 
 def main() -> int:
     try:
-        from vivarium_dashboard.lib.report import render_dashboard
+        from vivarium_workbench.lib.report import render_dashboard
     except ImportError:
-        print("ERROR: vivarium-dashboard is not installed.", file=sys.stderr)
+        print("ERROR: vivarium-workbench is not installed.", file=sys.stderr)
         print("Install it into the workspace venv:", file=sys.stderr)
-        print("    .venv/bin/pip install vivarium-dashboard", file=sys.stderr)
+        print("    .venv/bin/pip install vivarium-workbench", file=sys.stderr)
         return 2
     ws_root = Path.cwd()
     if not (ws_root / "workspace.yaml").is_file():
@@ -26,7 +26,7 @@ def main() -> int:
     ws_str = str(ws_root)
     if ws_str not in sys.path:
         sys.path.insert(0, ws_str)
-    from vivarium_dashboard.lib._root import set_workspace_root
+    from vivarium_workbench.lib._root import set_workspace_root
     set_workspace_root(ws_root)
     out = render_dashboard(ws_root, write_all=True)
     print(f"rendered {out}")

--- a/scripts/render_mbp_charts.py
+++ b/scripts/render_mbp_charts.py
@@ -5,7 +5,7 @@ written by ``run_multigen_parquet`` under
 ``studies/<study>/parquet-runs/<experiment_id>/history/`` and writes a
 small set of comparison charts into ``studies/<study>/charts/`` where
 the dashboard's ``discover_static_study_charts`` picks them up
-(``vivarium_dashboard/lib/study_charts.py::discover_static_study_charts``).
+(``vivarium_workbench/lib/study_charts.py::discover_static_study_charts``).
 
 Charts produced (same set as the earlier sqlite-sourced renderer — same
 underlying biological data, different read path):

--- a/scripts/run_default_baseline.py
+++ b/scripts/run_default_baseline.py
@@ -17,7 +17,7 @@ how vEcoli locks listener types via USE_UINT16/USE_UINT32) — that's a
 known iteration step the user must do per composite until the
 listener-dtype-override list is exhaustive. Tracking as a follow-up.
 
-**Dashboard interop note.** Until the vivarium-dashboard parquet-reader
+**Dashboard interop note.** Until the vivarium-workbench parquet-reader
 PR lands, the dashboard's auto-discovery of default-baseline charts
 still reads ``runs.db`` (sqlite) — so do NOT remove
 ``run_default_baseline.py`` yet. After the dashboard PR merges, the

--- a/scripts/run_mbp_tracked.py
+++ b/scripts/run_mbp_tracked.py
@@ -68,8 +68,8 @@ DEFAULT_CHUNK = 1   # per-tick emission (~80 ms/tick on this machine)
 DEFAULT_EMITTER = "parquet"   # workspace default (see workspace.yaml.runtime.default_emitter)
 DB_PATH = REPO_ROOT / ".pbg" / "composite-runs.db"
 # Per-study parquet roots: studies/<study_slug>/parquet-runs/<experiment_id>/...
-# This is the convention vivarium-dashboard's _latest_parquet_for_study reads
-# from (vivarium_dashboard/lib/study_charts.py:_latest_parquet_for_study).
+# This is the convention vivarium-workbench's _latest_parquet_for_study reads
+# from (vivarium_workbench/lib/study_charts.py:_latest_parquet_for_study).
 # The cross-investigation reference variant (study_slug not a real study)
 # also gets a per-slug directory so the dashboard can still discover it via
 # the same code path, even though no study.yaml lives there.
@@ -379,7 +379,7 @@ def _run_one_variant(
     elif emitter == "parquet":
         # Workspace-default emitter (workspace.yaml.runtime.default_emitter).
         # Hive-partitioned per experiment_id/variant/lineage_seed/generation/agent_id.
-        # Written under studies/<study_slug>/parquet-runs/ so vivarium-dashboard's
+        # Written under studies/<study_slug>/parquet-runs/ so vivarium-workbench's
         # _latest_parquet_for_study can discover them per-study.
         parquet_root = _parquet_root_for(study_slug)
         parquet_root.mkdir(parents=True, exist_ok=True)

--- a/scripts/run_phase0_multigen.py
+++ b/scripts/run_phase0_multigen.py
@@ -3,7 +3,7 @@
 Uses v2ecoli.library.sqlite_run.run_multigen_sqlite to capture per-generation
 listener trajectories. Output: per-seed sqlite db at
 .pbg/runs/phase0-multigen/seed_NN/run.db (queryable via standard sqlite
-tools or vivarium_dashboard.lib.composite_runs).
+tools or vivarium_workbench.lib.composite_runs).
 
 Wall projection from 600-step single-gen baseline (48s wall): for 3 generations
 (~2100 ticks), expect ~3 min wall per replicate. N=4 → ~12 min total serial.

--- a/scripts/serve.sh
+++ b/scripts/serve.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
-# Thin shim around the vivarium-dashboard pip package.
+# Thin shim around the vivarium-workbench pip package.
 #
 # The dashboard runtime (server + templates + assets + lib helpers) was
-# extracted out of pbg-template into the standalone `vivarium-dashboard`
+# extracted out of pbg-template into the standalone `vivarium-workbench`
 # package. Workspaces now depend on it as a regular pip dep; this script
 # is just a convenience wrapper so `bash scripts/serve.sh` keeps working.
 set -euo pipefail
@@ -11,19 +11,19 @@ WS_ROOT="$(pwd)"
 [ -f "$WS_ROOT/workspace.yaml" ] || { echo "ERROR: run from workspace root" >&2; exit 1; }
 
 # Prefer the workspace venv (matches the pbg-template scaffolding flow);
-# fall back to a system-wide install if the venv has no vivarium-dashboard.
-if [ -x "$WS_ROOT/.venv/bin/vivarium-dashboard" ]; then
-    DASH="$WS_ROOT/.venv/bin/vivarium-dashboard"
+# fall back to a system-wide install if the venv has no vivarium-workbench.
+if [ -x "$WS_ROOT/.venv/bin/vivarium-workbench" ]; then
+    DASH="$WS_ROOT/.venv/bin/vivarium-workbench"
 else
-    DASH="$(command -v vivarium-dashboard 2>/dev/null || true)"
+    DASH="$(command -v vivarium-workbench 2>/dev/null || true)"
 fi
 
 if [ -z "$DASH" ]; then
-    echo "ERROR: vivarium-dashboard is not installed." >&2
+    echo "ERROR: vivarium-workbench is not installed." >&2
     echo "Install it into the workspace venv, e.g." >&2
-    echo "    .venv/bin/pip install vivarium-dashboard" >&2
+    echo "    .venv/bin/pip install vivarium-workbench" >&2
     echo "or, for local dev:" >&2
-    echo "    .venv/bin/pip install -e /path/to/vivarium-dashboard" >&2
+    echo "    .venv/bin/pip install -e /path/to/vivarium-workbench" >&2
     exit 2
 fi
 

--- a/scripts/validate_status.py
+++ b/scripts/validate_status.py
@@ -132,7 +132,7 @@ def validate_investigation(inv_yaml: Path, ws_root: Path) -> tuple[list[str], li
     # this script still runs without the dashboard install (just skips rule 7).
     try:
         import importlib
-        _inv_mod = importlib.import_module("vivarium_dashboard.lib.investigations")
+        _inv_mod = importlib.import_module("vivarium_workbench.lib.investigations")
         _load_spec = _inv_mod.load_spec
         _InvErr = _inv_mod.InvestigationSpecError
     except Exception:  # noqa: BLE001

--- a/tests/test_composite_state_coverage.py
+++ b/tests/test_composite_state_coverage.py
@@ -2,7 +2,7 @@
 default-state artifact at ``reports/composite-state/<id>.json``.
 
 The Composite Explorer renders a generator's wiring from that committed artifact
-(the dashboard resolver falls back to it — see vivarium-dashboard
+(the dashboard resolver falls back to it — see vivarium-workbench
 ``composite_resolve._committed_default_state``). A generator with no committed
 artifact shows "default state for generator '<x>' is not generated yet" and a
 blank Explorer. This test fails loudly the moment a new generator lands without

--- a/tests/test_parquet_emitter.py
+++ b/tests/test_parquet_emitter.py
@@ -7,7 +7,7 @@ import pytest
 
 # Skip the entire file if the [parquet] extra isn't installed.
 # CI's default `uv sync --extra dev` doesn't install [parquet] — duckdb /
-# polars may still resolve transitively via vivarium-dashboard, but
+# polars may still resolve transitively via vivarium-workbench, but
 # pbg-emitters (the actual ParquetEmitter implementation) won't, so the
 # v2ecoli.library.parquet_emitter shim's import would raise ImportError.
 # Skip cleanly in that case.

--- a/uv.lock
+++ b/uv.lock
@@ -4419,7 +4419,7 @@ dependencies = [
     { name = "unum" },
     { name = "vecoli", extra = ["dev"] },
     { name = "viva-munk" },
-    { name = "vivarium-dashboard" },
+    { name = "vivarium-workbench" },
 ]
 
 [package.optional-dependencies]
@@ -4465,7 +4465,7 @@ requires-dist = [
     { name = "v2ecoli", extras = ["parquet", "xarray"], marker = "extra == 'emitters'" },
     { name = "vecoli", extras = ["dev"], specifier = ">=1.1.0" },
     { name = "viva-munk", git = "https://github.com/vivarium-collective/Viva-munk.git?branch=main" },
-    { name = "vivarium-dashboard", git = "https://github.com/vivarium-collective/vivarium-dashboard.git?branch=main" },
+    { name = "vivarium-workbench", git = "https://github.com/vivarium-collective/vivarium-dashboard.git?branch=main" },
 ]
 provides-extras = ["dev", "parquet", "xarray", "emitters", "ray"]
 
@@ -4579,9 +4579,9 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/3e/87/794e0b4c5dccbca3036152fe5df56860a57e70f3e68ac0198dbd7df60fcb/vivarium-core-1.6.5.tar.gz", hash = "sha256:1d83faa60005304b548f623447ab8675a06bb7ed8f6b7c0bd25b4aaa3381fccb", size = 136102, upload-time = "2024-12-03T21:49:29.797Z" }
 
 [[package]]
-name = "vivarium-dashboard"
+name = "vivarium-workbench"
 version = "0.1.0"
-source = { git = "https://github.com/vivarium-collective/vivarium-dashboard.git?branch=main#cf92a0cf5184f1fbdbb1b6c59fef746b2b022a7d" }
+source = { git = "https://github.com/vivarium-collective/vivarium-dashboard.git?branch=main#ee0ae6734458edfc7d01e6929ce2fd46219b4761" }
 dependencies = [
     { name = "bigraph-loom" },
     { name = "bigraph-schema" },

--- a/v2ecoli/composites/_helpers.py
+++ b/v2ecoli/composites/_helpers.py
@@ -147,7 +147,7 @@ ALL_PARTITIONED = list(PARTITIONED_PROCESSES.keys())
 # Note: the cell-mass / cell-volume / growth-rate / absolute-mass-components /
 # mass-fold-change TimeSeriesPlots that previously lived here used a
 # `config.observable: '<short-name>'` convention that the dashboard's
-# build_viz_composite (vivarium-dashboard, lib/investigations.py) does not yet
+# build_viz_composite (vivarium-workbench, lib/investigations.py) does not yet
 # understand — it only honors `inputs_map` for port→observable wiring, so
 # those plots came out with empty y-data even though the emitter recorded
 # them. They will land back here once the dashboard grows a short-name /
@@ -483,7 +483,7 @@ def sqlite_emitter(*, file_path: str | None = None,
     """Context manager: build composite with a SQLiteEmitter step.
 
     By default writes to ``<workspace_root>/.pbg/composite-runs.db`` — the
-    same workspace-shared DB the vivarium-dashboard's Simulations DB tab
+    same workspace-shared DB the vivarium-workbench's Simulations DB tab
     aggregates from. Pass ``study_slug`` / ``investigation_slug`` to tag the
     run; the slugs are stored as columns on the ``simulations`` row so the
     dashboard can group / filter by them.

--- a/v2ecoli/library/parquet_run.py
+++ b/v2ecoli/library/parquet_run.py
@@ -8,7 +8,7 @@ parquet directory instead of a sqlite db.
 Storage: ~3-5× smaller than the equivalent sqlite run for v2ecoli-shaped
 sims — Parquet is column-oriented and dictionary-encodes repeated listener
 fields. Trade-off: the dashboard's Simulations-DB tab cannot read parquet
-yet (vivarium-dashboard follow-up); for now use this runner when downstream
+yet (vivarium-workbench follow-up); for now use this runner when downstream
 analysis is DuckDB/Polars-based, ``sqlite_run`` when dashboard inspection
 is required.
 

--- a/v2ecoli/library/parquet_viz.py
+++ b/v2ecoli/library/parquet_viz.py
@@ -1,6 +1,6 @@
 """Render Visualization Steps from a study's parquet-runs output.
 
-The vivarium-dashboard currently reads sim data only from a SQLite emitter's
+The vivarium-workbench currently reads sim data only from a SQLite emitter's
 ``history`` table; its inputs_map → port resolution speaks the SQLite shape.
 When a study runs with ``parquet_emitter()`` instead of ``sqlite_emitter()``,
 the dashboard's data-resolution layer has nothing to read.
@@ -124,7 +124,7 @@ _VIZ_CLASS_CACHE: dict[str, type] | None = None
 def _discover_visualization_classes() -> dict[str, type]:
     """Walk v2ecoli.visualizations and collect Visualization subclasses by name.
 
-    The vivarium-dashboard's ``local:<ClassName>`` address scheme picks the
+    The vivarium-workbench's ``local:<ClassName>`` address scheme picks the
     workspace package's Visualization classes by short name. Replicate that
     lookup here.
     """

--- a/v2ecoli/library/sqlite_run.py
+++ b/v2ecoli/library/sqlite_run.py
@@ -4,7 +4,7 @@ Mirrors :func:`v2ecoli.library.xarray_run.run_multigen_xarray` for the SQLite
 emitter branch. Workspace-side (v2ecoli) because the daughter-walk rule
 ("first sorted new agent_id after parent disappears") and the
 ``agents/<id>/`` lineage convention are biological/v2ecoli choices, not
-framework contracts — keeping them out of vivarium-dashboard avoids the
+framework contracts — keeping them out of vivarium-workbench avoids the
 anti-pattern flagged in dashboard PR #104.
 
 **Why external emitter driving (not in-composite injection)**
@@ -266,7 +266,7 @@ def run_multigen_sqlite(
         owns the emitter lifecycle.
       run_id: simulation_id stamp for runs_meta + history rows.
       db_file: path to the sqlite db. Schema is set up by
-        ``vivarium_dashboard.lib.composite_runs.connect``; this runner
+        ``vivarium_workbench.lib.composite_runs.connect``; this runner
         only writes history rows.
       emit_paths: list of dotted/slash paths to capture from the
         followed agent. Optional `agents/<id>/` prefix is stripped.

--- a/workspace/investigations/colonies/studies/colonies-01-hpc-readiness/sims/make_derived_charts.py
+++ b/workspace/investigations/colonies/studies/colonies-01-hpc-readiness/sims/make_derived_charts.py
@@ -2,7 +2,7 @@
 """Render the derived HPC-sizing visualizations from runs.db.
 
 Companion to the dashboard's live perf charts (rendered straight from the
-runs/ticks tables by vivarium_dashboard.lib.study_charts). These are the
+runs/ticks tables by vivarium_workbench.lib.study_charts). These are the
 *interpreted* charts — the ones that turn the raw N-sweep into the actual
 HPC-deployment answer: the realtime ceiling (cells/process), where the cost
 lives (EcoliWCM vs pymunk), and the per-tick stability across N.


### PR DESCRIPTION
## Summary

The `vivarium-dashboard` tool was renamed to `vivarium-workbench` (dist `vivarium-workbench`; import package `vivarium_dashboard` → `vivarium_workbench`). The rename is already merged to that repo's `origin/main`; old names remain deprecated shims but we move to the new names now. **The GitHub repo itself is NOT renamed**, so all git-source URLs (`github.com/vivarium-collective/vivarium-dashboard.git`) are kept as-is.

## Changes

- **pyproject.toml** — `[project.dependencies]` and the `[tool.uv.sources]` key renamed to `vivarium-workbench` (git URL + `branch = "main"` unchanged).
- **uv.lock** — regenerated: `vivarium-dashboard v0.1.0 (cf92a0c)` → `vivarium-workbench v0.1.0 (ee0ae67)`. Minimal 4-line diff (used `uv lock --upgrade-package vivarium-dashboard`; plain `uv lock` choked on the stale pre-rename pinned commit).
- **scripts/regenerate_composite_states.py** + **scripts/regenerate_viewers.py** — repointed imports and fixed the retired stdlib-`server` API (that module no longer exists): now use `vivarium_workbench.lib.json_serialize` (`_json_default`/`_json_sanitize`/`_json_body`), `lib._root.set_workspace_root`, `lib.composite_lookup.composites_data`, and `lib.composite_resolve.resolve_composite`. Dropped the `_srv.WORKSPACE = …` assignments; call `resolve_composite(ws_root, id)` / `composites_data(ws_root)` directly.
- **Other tracked `.py`/`.sh`/`.md`** — repointed the `vivarium_dashboard` / `vivarium-dashboard` / `VIVARIUM_DASHBOARD_` identifiers (imports, CLI invocations, console-script + module-path references) to the `vivarium_workbench` / `vivarium-workbench` / `VIVARIUM_WORKBENCH_` forms. The English word "dashboard" in prose and the read-only-dashboard bundle concept are untouched.

## Kept intentionally

- GitHub repo URLs (repo not renamed), the absolute checkout-dir path in a historical plan doc, the `vivarium-dashboard-explorer` external-repo asset path in `scripts/gen_explorer_demo_exchange.py`, and the git source URL in uv.lock.

## Out of scope for this PR (follow-up)

Per the task's file-type scope (`.py`/`.sh`/`.md` only), these still reference the old dist name and will need a separate pass: `.github/workflows/*.yml` (`--no-install-package vivarium-dashboard`, the `git+…vivarium-dashboard.git@main` reinstall line, `vivarium-dashboard-publish`), `Dockerfile`, `workspace/studies/*/study.yaml` comments, `docs/dashboard/assets/*.js`, `reports/index.html`. The `--no-install-package`/git-install name in CI is functionally load-bearing after the lock rename.

## Verification

- `python -m py_compile` passes for both named scripts and all swept `.py` files; `bash -n` passes for swept shell scripts.
- `vivarium_workbench` imports cleanly in the v2ecoli `.venv`, and all newly-referenced symbols exist with matching signatures (`resolve_composite(ws_root, spec_id, overrides=None)`, `composites_data(ws_root)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)