### PR TITLE
feat(demo): vivarium-workbench dashboard walkthrough demo infrastructure

### DIFF
--- a/demos/dashboard/.gitignore
+++ b/demos/dashboard/.gitignore
@@ -1,0 +1,4 @@
+# Generated demo state — never commit these
+.demo_state.json
+demo-runs/
+downloads/

--- a/demos/dashboard/PLAN.md
+++ b/demos/dashboard/PLAN.md
@@ -1,0 +1,599 @@
+# vivarium-workbench Dashboard Demo — Plan
+
+**Status**: Draft — awaiting review
+**Last updated**: 2026-07-06
+
+---
+
+## 1. Overview
+
+### 1.1 What this demo demonstrates
+
+`vivarium-workbench` is a local web UI for [process-bigraph](https://github.com/vivarium-collective/process-bigraph) workspaces. This demo walks through every major feature of the dashboard using the `v2ecoli` workspace as the demonstration substrate. The demo is designed to serve two audiences:
+
+| Mode | Audience | Duration | Format |
+|------|----------|----------|--------|
+| **Presenter script** | Live audience (demo day, stakeholder meeting, conference) | ~20 minutes | Screen-shared narrated walkthrough with talking points |
+| **Self-guided guide** | Individual user (new team member, curious engineer) | ~45 minutes | Detailed step-by-step with expected outputs and troubleshooting |
+
+### 1.2 Decoupling principle
+
+**The demo assets never modify existing v2ecoli content.** All new artifacts (prep scripts, demo-specific studies, verification tools) live under `demos/dashboard/` and reference existing composites, studies, and investigations as read-only data. This means:
+
+- No edits to existing `study.yaml`, `workspace.yaml`, composite generators, or investigations
+- No commits to the v2ecoli workspace git history on behalf of the demo
+- The demo can be torn down without affecting the workspace
+
+### 1.3 What we cover
+
+| Feature | Tab / Page | Key demo point |
+|---|---|---|
+| Simulator agnosticism | **Registry** | 7 installed pbg-* packages co-existing in one type system |
+| Swappability | **Composites** | 3 cell engines (WCM, Millard, PDMP) share the same reactor coupler |
+| ParCa modularization | **Composite Explorer** | 9-step pipeline, each step independently registered |
+| Investigation DAG & gating | **Investigations** | 6-study showcase with pass/fail gates and dependency edges |
+| Study management & charts | **Studies** | Variant sweeps, behavior tests, self-contained reports |
+| Simulations DB & remote runs | **Simulations DB** | Local + remote runs side-by-side; live sms-api build→submit→poll→land |
+| Visualizations | **Analyses** | Saved viz gallery, 3D viewers, PTools omics integration |
+| Audit trail | **Branch** | Git commits, PR workflow |
+
+---
+
+## 2. Prerequisites
+
+### 2.1 Hardware
+
+- macOS or Linux with ≥16 GB RAM
+- ≥5 GB free disk (for ParCa cache, run outputs, sms-api workspace tarballs)
+- Network access to GitHub and (for remote demo) AWS GovCloud via SSM
+
+### 2.2 Software
+
+| Component | Minimum version | How to verify |
+|---|---|---|
+| Python | 3.12 | `python3 --version` |
+| uv | 0.4+ | `uv --version` |
+| Git | 2.40+ | `git --version` |
+| AWS CLI (remote demo) | 2.15+ | `aws --version` |
+| Session Manager plugin (remote demo) | latest | `session-manager-plugin --version` |
+| A modern browser | Chrome/Firefox/Safari current | — |
+
+### 2.3 Repositories
+
+| Repo | Purpose | Expected location |
+|---|---|---|
+| `vivarium-collective/vivarium-workbench` | The dashboard itself | `~/vivarium-app/vivarium-dashboard/` |
+| `vivarium-collective/v2ecoli` | The demo workspace (read-only for this demo) | `~/vivarium-app/v2ecoli/` |
+| `vivarium-collective/sms-api` | Remote run backend | Not cloned locally; reached via SSM tunnel |
+
+### 2.4 Installed packages in the v2ecoli venv
+
+The v2ecoli workspace's `.venv` must have these installed (should already be true for a working workspace):
+
+```
+process-bigraph, bigraph-schema, bigraph-viz, vivarium-workbench
+pbg_superpowers, pbg_ketchup, pbg_copasi, pbg_parsimony
+pbg_bioreactordesign, pbg_torch, viva_munk, pbg_emitters
+```
+
+Verify with:
+```bash
+cd ~/vivarium-app/v2ecoli
+source .venv/bin/activate
+python -c "import v2ecoli; import viva_munk; import pbg_ketchup; import pbg_copasi; print('OK')"
+```
+
+### 2.5 ParCa cache (optional but recommended)
+
+The existing `models/parca/parca_state.pkl.gz` fixture ships with the repo. If it's missing or stale, re-run the ParCa in fast mode once:
+
+```bash
+cd ~/vivarium-app/v2ecoli
+source .venv/bin/activate
+v2ecoli-parca --mode fast --cpus 4 --output out/cache-demo
+```
+
+This is read from `models/parca/` and `out/cache/` by the composites — the demo does not modify these.
+
+### 2.6 sms-api tunnel (for remote demo segments)
+
+```bash
+# Replace <INSTANCE_ID> with the actual GovCloud EC2 instance ID
+aws ssm start-session \
+  --region us-gov-west-1 \
+  --target <INSTANCE_ID> \
+  --document-name AWS-StartPortForwardingSession \
+  --parameters '{"portNumber":["8080"],"localPortNumber":["8080"]}'
+```
+
+Verify:
+```bash
+curl -s http://localhost:8080/core/v1/simulator/versions | python -m json.tool | head -5
+```
+
+The demo plan includes a fallback for when the tunnel is unavailable (see Appendix B).
+
+---
+
+## 3. Demo Preparation (one-time setup)
+
+All preparation scripts live in `demos/dashboard/` and never touch existing v2ecoli files.
+
+### 3.1 Quick verification
+
+Run the prep script to check everything is in order:
+
+```bash
+cd ~/vivarium-app/v2ecoli
+source .venv/bin/activate
+python demos/dashboard/verify_demo.py
+```
+
+This script (to be created alongside this plan) checks:
+- All required imports resolve
+- All showcase composites resolve via `build_composite()` (read-only, no side effects)
+- Expected study directories exist
+- ParCa cache is present
+- Dashboard server can start (starts and immediately stops)
+
+### 3.2 Pre-build sms-api simulator image (remote demo)
+
+The remote-run demo needs at least one pre-built image on sms-api so the demo doesn't wait for a build:
+
+```bash
+# From the v2ecoli workspace
+cd ~/vivarium-app/v2ecoli
+source .venv/bin/activate
+
+# This registers the current HEAD on sms-api (async build, ~4 min for first build)
+python demos/dashboard/prep_remote_build.py
+```
+
+The script pushes the current branch, registers it on sms-api, and polls until the image is ready. The resulting `simulator_id` is saved to `demos/dashboard/.demo_state.json` so subsequent demos reuse it without re-building.
+
+### 3.3 Pre-land a remote run (Simulations DB tab)
+
+To populate the Simulations DB with remote runs:
+
+```bash
+cd ~/vivarium-app/v2ecoli
+source .venv/bin/activate
+python demos/dashboard/prep_remote_land.py
+```
+
+This submits one baseline run to the pre-built simulator, waits for completion, lands the results into a demo study under `demos/dashboard/demo-runs/`, and records `runs_meta` entries that show up in the Simulations DB with `Origin: remote` pills. The run uses a short 2-generation ensemble so it completes in ~3 minutes.
+
+### 3.4 Pre-computation summary
+
+| Step | Script | Time | Required for |
+|---|---|---|---|
+| Verify workspace | `verify_demo.py` | ~10s | All segments |
+| Pre-build sms-api image | `prep_remote_build.py` | ~4 min | Segment 6 (one-time) |
+| Pre-land remote run | `prep_remote_land.py` | ~3 min | Segment 6 (one-time) |
+
+No other pre-computation is needed — the showcase studies already have their runs and charts committed in the repo.
+
+### 3.5 Start the dashboard
+
+```bash
+cd ~/vivarium-app/v2ecoli
+source .venv/bin/activate
+vivarium-dashboard serve --workspace . --port 8771
+```
+
+> **Note**: The v2ecoli workspace venv has `vivarium-dashboard` (the pre-rename package), not `vivarium-workbench`. The entry point is `vivarium-dashboard serve`, not `vivarium-workbench serve`. Both names point at the same code; use whichever is on your PATH.
+
+Open `http://localhost:8771` in a browser. For the presenter demo, use a clean browser profile with the window sized to 1440x900 or larger. Hide bookmarks bars and other chrome.
+
+---
+
+## 4. PART A: Presenter Script
+
+Each segment includes:
+- **Narration** — what the presenter says (in quotes for suggested phrasing)
+- **Actions** — concrete clicks and interactions
+- **Talking points** — the "why this matters" payoff
+- **Duration** — target time
+
+Total: ~20 minutes
+
+---
+
+### Segment 1: Introduction (2 minutes)
+
+**Narration:**
+> "vivarium-workbench is a local web UI for process-bigraph workspaces. It turns a directory of YAML and simulation output into an interactive, git-backed research notebook. The mental model is three layers: the simulation engine — process-bigraph — runs the science. The tooling — this dashboard — orchestrates, renders, and commits. The data — the v2ecoli workspace — is the single source of truth. Every action you take in the dashboard is committed to git. Let's look at it."
+
+**Actions:**
+1. Open `http://localhost:8771` in a browser
+2. Point out the left rail: 9 pages (Sources, Registry, Composites, Investigations, Simulations DB, Analyses, Studies, Branch, Composite Explorer)
+3. Point out the investigation switcher at the top of the rail
+4. Point out the workspace name chip in the rail header (for source switching later)
+
+**Talking points:**
+- The dashboard is a generic tool — it works with ANY process-bigraph workspace, not just v2ecoli
+- All actions are git-tracked: add a dataset, create a study, run a simulation → all committed
+- This is a research notebook that leaves an audit trail
+
+---
+
+### Segment 2: Registry — Simulator Agnosticism (3 minutes)
+
+**Narration:**
+> "The Registry tab shows every type and package the workspace knows about. This is where you see that the dashboard is not v2ecoli-specific — it's a truly multi-simulator platform. Let me show you."
+
+**Actions:**
+1. Click **Registry** in the left rail
+2. Click the **Modules** sub-tab
+3. Point to the installed packages:
+   - `v2ecoli` — the E. coli whole-cell model (55 processes)
+   - `viva_munk` — colony physics (PymunkProcess, chemotaxis, biofilm)
+   - `pbg_ketchup` — kinetic parameter estimators (IPOPT)
+   - `pbg_copasi` — ODE steady-state solver
+   - `pbg_bioreactordesign` — bioreactor transport (BiRD)
+   - `pbg_torch` — neural surrogate models
+   - `pbg_parsimony` — capsule cell geometry
+4. Click **Discovered registry** → **Processes** sub-tab
+5. Scroll through: v2ecoli processes, viva_munk processes, ketchup estimator → all mixed together
+
+**Talking points:**
+- "Seven different simulation packages. One dashboard. One type system."
+- "Any process from any package can be composed into any composite"
+- "The dashboard auto-discovers everything via build_core(). To onboard a new simulator, you pip install it and declare it in workspace.yaml — it just appears."
+- "This is the foundation of swappability: if everything shares a type system, everything is composable."
+
+**Fallback:** If some packages aren't installed, show the **Available** filter in Modules and explain the install flow.
+
+---
+
+### Segment 3: Composites — Swappability (3 minutes)
+
+**Narration:**
+> "The Composites tab shows every runnable model the workspace can build. This is where swappability becomes concrete — we have three different cell engines, all sharing the same reactor coupler, all managed by the same dashboard."
+
+**Actions:**
+1. Click **Composites** in the left rail
+2. Scroll through the grid — point out the available composites across all packages
+3. **Cell-engine swappability — hand 1:** Click `baseline`
+   - "This is the v2ecoli whole-cell model. 55 processes. tFBA metabolism. ~2.5 million ODEs."
+4. **Cell-engine swappability — hand 2:** Click `baseline_millard`
+   - "Same overall architecture, but metabolism is swapped out — instead of tFBA, we use the Millard 2017 kinetic ODE with 86 metabolites."
+5. **Cell-engine swappability — hand 3:** Click `millard_pdmp_baseline`
+   - "The PDMP reformulation. Millard metabolism plus LQR control, Poisson jump processes for transcription."
+6. **Reactor-coupler swappability:** Click `reactor_bird_coupled`
+   - "WCM cells coupled to the BiRD reactor. The coupler reads population biomass and exchange fluxes."
+7. Click `reactor_bird_coupled_millard`
+   - "SAME reactor coupler. SAME transport equations. DIFFERENT cell engine — Millard instead of WCM. The cell-side interface contract makes this possible."
+8. **External simulators:** Click `ketchup_baseline`
+   - "Kinetic parameter fitting with IPOPT. Completely different domain. Same dashboard."
+9. Click `chemotaxis` (viva_munk)
+   - "Bacterial chemotaxis in a 2D ligand gradient. viva_munk. Same dashboard."
+
+**Talking points:**
+- "Swappability means ONE workflow — Composite → Run → View results — for ANY simulator."
+- "The cell-side interface contract is what makes engine substitution possible. It defines the inputs and outputs a cell engine must provide to work with the reactor coupler."
+- "Add a new simulator? Install it, declare it in workspace.yaml, and its composites appear here automatically."
+- "The dashboard is agnostic — it doesn't know or care what your simulator does, only that it conforms to the process-bigraph protocol."
+
+**Fallback:** If a composite fails to resolve, skip it and use one that does. The baseline, baseline_millard, and colony composites are the most reliable.
+
+---
+
+### Segment 4: ParCa — Modularization (2 minutes)
+
+**Narration:**
+> "ParCa is the Parameter Calculator — the pipeline that fits experimental E. coli data into a self-consistent parameter set. It used to be a monolithic script. Now it's 9 modular Steps, each independently registered, testable, and swappable. Let's see it."
+
+**Actions:**
+1. From the Composites tab, click the **Explore** button on the `parca` composite
+   - This opens the Composite Explorer
+2. Point to the 9-step pipeline rendered in bigraph-loom:
+   - Step 1: Initialize (scatter flat files into sim_data)
+   - Step 2: Input Adjustments (compute/merge, pure)
+   - Step 3: Basal Specs (fit minimal-medium condition)
+   - Step 4: TF Condition Specs (51 transcription-factor conditions)
+   - Step 5: Fit Condition (bulk distributions + translation supply)
+   - Step 6: Promoter Binding (CVXPY optimization)
+   - Step 7: Adjust Promoters (couple to genome position)
+   - Step 8: Set Conditions (extract→compute→merge, pure)
+   - Step 9: Final Adjustments (kinetic constants for the online model)
+3. Click through a few steps to show their port wiring
+4. **Optional — live run:** Click **Run** with `mode: fast`, `cpus: 4`, `debug: true`
+   - This runs ~15 seconds for 7 TF conditions
+   - Show the progress bar as steps execute
+
+**Talking points:**
+- "Each step declares its own INPUT_PORTS and OUTPUT_PORTS. Each is independently testable."
+- "Step 4 (TF condition fitting) could be swapped out for a different algorithm — you'd only touch one file."
+- "Step 6 (promoter binding) uses CVXPY. Swap it for a PyTorch optimizer? Replace one Step class, wire the same ports."
+- "This is the modularization story. Monolithic pipeline → 9 composable Steps. Same result, vastly more maintainable."
+- "The `@composite_generator` decorator is what makes ParCa visible here. Before this, the pipeline existed but was invisible to the dashboard."
+
+**Fallback:** If the live run fails (timeout, dependency issue), show the pre-computed result from `models/parca/parca_state.pkl.gz` instead and explain the step timing from `models/parca/runtimes.json`.
+
+---
+
+### Segment 5: Investigations & Studies (3 minutes)
+
+**Narration:**
+> "Now let's look at how the dashboard organizes research. Investigations are research arcs — DAGs of studies grouped under a shared question. Each study is an experiment with pass/fail criteria."
+
+**Actions:**
+1. Click **Investigations** in the left rail
+2. Point to the 9 investigation sets (Active / Closed)
+3. **Open `v2ecoli-baseline-showcase`** — "This is a DEMONSTRATION investigation. Six studies that walk through the full v2ecoli pipeline."
+4. Show the investigation detail:
+   - Status pill, Report button, Notebook download
+   - "About this investigation" disclosure with abstract and narrative
+   - **Investigation DAG**: 6 study nodes with dependency edges
+     - showcase-1-parca → showcase-2-baseline-figures → showcase-3-variant-decide → showcase-4-variant-comparison → showcase-5-next-direction-decide → showcase-6-equivalence-large
+   - Point out the gate mechanism: "showcase-2 can't proceed until showcase-1 passes its gate."
+5. Click on **showcase-1-parca** study node — the study detail opens in an iframe
+   - Show the 3 behavior tests (all passing): condition count, cache bundle completeness, sim-data reproduction
+   - Show the rendered figures (source manifest, simdata summary, cache bundle)
+6. Click on **showcase-4-variant-comparison** — "5-variant perturbation sweep"
+   - Show the overlaid charts for 5 variants
+
+**Talking points:**
+- "Investigations encode the scientific method: hypothesize, test, gate, proceed."
+- "The DAG enforces dependency order. A downstream study literally cannot proceed until its upstream passes."
+- "Every study has behavior tests — small declarative checks (in_range, monotonic) that auto-evaluate against run results."
+- "The Report button generates a self-contained HTML report you can send to a reviewer."
+
+**Fallback:** If study charts fail to render (stale viz), explain the viz-freshness system and show the raw test results instead.
+
+---
+
+### Segment 6: Simulations DB & Remote Runs (3 minutes)
+
+**This is the anchor segment. Requires the sms-api tunnel to be up.**
+
+**Narration:**
+> "The Simulations DB tab shows every simulation run across the entire workspace, whether it ran on your laptop or on AWS GovCloud. This is where we demonstrate the sms-api integration — running the v2ecoli model at scale on AWS, with full traceability back to a git commit."
+
+**Actions:**
+1. Click **Simulations DB** in the left rail
+2. Show the table with local runs:
+   - Columns: Investigation, Study, Run, Location, Origin, Emitter, Time, Status
+   - Emitter type pills: sqlite (gray), parquet (amber), xarray (teal)
+   - Origin: local (gray)
+3. **Switch to remote source:**
+   - Click the workspace name chip at the top of the left rail
+   - The source-switcher dropdown shows "Local" and "Builds — sms-api"
+   - If a pre-built image exists, select it
+   - The page reloads against the remote build workspace
+4. Back in **Simulations DB**:
+   - Remote runs now appear in the table
+   - Origin column shows **remote** (blue pill) with deployment info
+   - Runs side-by-side: local laptop runs and AWS GovCloud runs in the same table
+5. **Live remote run demonstration:**
+   - Switch back to the local workspace
+   - Navigate to a study (use the demo study prepped in Section 3, or showcase-2-baseline-figures)
+   - Click the **"Run remotely"** button
+   - Watch the thin-client pipeline:
+     - **Phase 1 (building)**: Pushes branch, registers build on sms-api, polls for image readiness (~1-2 min for cached build)
+     - **Phase 2 (running)**: Submits the simulation run, polls for completion (~2-4 min for short ensemble)
+     - **Phase 3 (landing)**: Downloads results and records them in the study's runs.db
+   - The newly landed run appears in the Simulations DB with a local origin
+
+**Talking points:**
+- "Every run is traceable: git commit hash → exact Docker image → exact simulation results. Full reproducibility."
+- "Extensibility: any simulator, any emitter backend (SQLite, Parquet, XArray), any scale (laptop → AWS GovCloud)."
+- "The dashboard doesn't care WHERE the run happened. Local and remote runs appear side-by-side in the same table."
+- "The remote pipeline is stateless — it's driven by the browser. No server-side queue. No infrastructure dependency beyond the sms-api."
+- "This is the 'Simulations DB connected to sms-api' story: your laptop for development, AWS for production-scale runs, unified by git provenance."
+
+**Action if tunnel is down:** Skip the live remote run. Show the pre-landed remote runs in the Simulations DB and explain the pipeline from the UI screenshots (see Appendix B).
+
+---
+
+### Segment 7: Analyses (2 minutes)
+
+**Narration:**
+> "The Analyses tab is a gallery of interactive visualizations. Some are saved views from studies, some are standalone analysis tools. Let's look at a few."
+
+**Actions:**
+1. Click **Analyses** in the left rail
+2. Point to any saved visualizations in the gallery
+3. **3D viewer**: If the `ecoli_3d` pack is available, show the whole-cell 3D model
+   - Link opens the viewer with birth and pre-division states
+   - "This is the parsimony capsule packing visualization, served from Cloudflare R2."
+4. **PTools omics viewer**: If sms-ptools is running (`http://localhost:1555`):
+   - Click the PTools card
+   - "Pathway Tools Cellular Overview with study omics data overlaid on the E. coli metabolic map."
+5. **Visualization preview**: Show the preview modal
+   - "Visualization classes have a `demo()` method — they render instantly against synthetic data before any real run completes."
+   - "Once real runs finish, the same visualization renders against actual simulation output."
+
+**Talking points:**
+- "Every visualization is a registered class with demo() + render() methods — preview before you run."
+- "The PTools integration bridges the dashboard to external analysis tools through a simple URL template."
+- "3D viewers, network graphs, time-series plots — all share the same registration and preview system."
+
+**Fallback:** If PTools is unavailable, mention it as an integration example and skip to the visualization preview.
+
+---
+
+### Segment 8: Wrap-up (2 minutes)
+
+**Narration:**
+> "Let me summarize what we've seen. vivarium-workbench is a simulator-agnostic research notebook. It works with ANY process-bigraph workspace. Today we saw v2ecoli — but the same dashboard serves viva_munk colony physics, ketchup kinetic fitting, copasi ODE models, and BiRD reactor transport. All in one UI, all git-tracked."
+
+**Actions:**
+1. Click through each tab one more time as a rapid recap
+2. Highlight the key architecture points:
+   - "One dashboard, many simulators — the Registry proves it."
+   - "Swappable cell engines — the Composites tab demonstrates it."
+   - "Modular pipelines — ParCa's 9 Steps show it."
+   - "Reproducible, git-tracked runs — the Simulations DB delivers it."
+   - "AWS GovCloud at scale, local laptop for development — unified view."
+
+**Talking points:**
+- "The dashboard is a pip dependency of the workspace. It runs inside the workspace's venv on purpose — so it can import your model code and build composites."
+- "Everything is committed to git. Add a dataset? Commit. Create a study? Commit. Run a simulation? The result lands in the workspace with provenance."
+- "Questions?"
+
+---
+
+## 5. PART B: Self-Guided Guide
+
+### 5.1 Setup
+
+Complete the prerequisites in Section 2, then:
+
+```bash
+# 1. Activate the v2ecoli workspace venv
+cd ~/vivarium-app/v2ecoli
+source .venv/bin/activate
+
+# 2. Verify the workspace
+python demos/dashboard/verify_demo.py
+
+# 3. Start the dashboard
+vivarium-dashboard serve --workspace . --port 8771
+# (or `vivarium-workbench serve` if your venv has the post-rename package)
+
+# 4. Open in browser
+open http://localhost:8771
+```
+
+### 5.2 Walkthrough
+
+Follow the same 8 segments as the Presenter Script (Section 4), taking time to explore each tab. Expected outputs and key observations are noted in each segment's "Talking points" section. If something doesn't match expectations, see the Troubleshooting section.
+
+### 5.3 Remote demo (optional)
+
+If you have access to the sms-api SSM tunnel:
+
+```bash
+# 1. Start the tunnel (separate terminal)
+aws ssm start-session \
+  --region us-gov-west-1 \
+  --target <INSTANCE_ID> \
+  --document-name AWS-StartPortForwardingSession \
+  --parameters '{"portNumber":["8080"],"localPortNumber":["8080"]}'
+
+# 2. Pre-build an image
+python demos/dashboard/prep_remote_build.py
+
+# 3. Pre-land a remote run
+python demos/dashboard/prep_remote_land.py
+
+# 4. Now follow Segment 6 in the walkthrough
+```
+
+### 5.4 What success looks like
+
+After completing the walkthrough, you should have:
+
+- [ ] Viewed the Registry tab and identified at least 5 installed pbg-* packages
+- [ ] Opened the Composites tab and located the baseline, baseline_millard, and millard_pdmp_baseline composites
+- [ ] Opened the ParCa composite in the Explorer and identified all 9 steps
+- [ ] Opened the v2ecoli-baseline-showcase investigation and viewed its DAG
+- [ ] Viewed the Simulations DB tab with at least a few entries
+- [ ] Browsed the Analyses tab and viewed at least one saved visualization
+- [ ] (If remote demo) Completed a live sms-api build → submit → poll → land cycle
+
+---
+
+## 6. Assets Inventory
+
+### 6.1 Existing v2ecoli assets used (read-only)
+
+| Asset | Path | Used in |
+|---|---|---|
+| Workspace config | `workspace.yaml` | Entire demo |
+| ParCa composite | `v2ecoli/composites/parca.py` | Segment 4 |
+| Baseline composite | `v2ecoli/composites/baseline.py` | Segment 3 |
+| Baseline Millard composite | `v2ecoli/composites/baseline_millard.py` | Segment 3 |
+| PDMP baseline composite | `v2ecoli/composites/millard_pdmp_baseline.py` | Segment 3 |
+| Reactor coupled composites | `v2ecoli/composites/reactor_bird_coupled*.py` | Segment 3 |
+| Colony composites | `v2ecoli/composites/colony*.py` | Segment 3 |
+| 6-study showcase investigation | `workspace/investigations/v2ecoli-baseline-showcase/` | Segment 5 |
+| Showcase studies (1-6) | `workspace/studies/showcase-*/` | Segment 5 |
+| mbr investigation | `workspace/investigations/multiscale-bioprocess/` | Segment 5 (backup) |
+| ParCa model fixture | `models/parca/parca_state.pkl.gz` | Segment 4 (fallback) |
+| ParCa runtime data | `models/parca/runtimes.json` | Segment 4 (fallback) |
+| Cell-side interface contract | `workspace/references/expert/cell_side_interface_contract.md` | Segment 3 (reference) |
+| ketchup composites | `pbg_ketchup` package (venv) | Segment 3 |
+| viva_munk composites | `viva_munk` package (venv) | Segment 3 |
+
+### 6.2 New demo assets (in `demos/dashboard/`, decoupled)
+
+| Asset | Purpose | Status |
+|---|---|---|
+| `PLAN.md` | This file | In review |
+| `verify_demo.py` | Pre-demo verification script | To create |
+| `prep_remote_build.py` | Pre-build sms-api simulator image | To create |
+| `prep_remote_land.py` | Pre-land a remote run into the workspace | To create |
+| `.demo_state.json` | Cached simulator_id and remote run state | Auto-generated |
+| `demo-runs/` | Directory for pre-landed remote runs | Auto-generated |
+
+None of these scripts modify any file outside `demos/dashboard/` or `demos/dashboard/demo-runs/`.
+
+---
+
+## 7. Appendix
+
+### A. sms-api tunnel reference
+
+```bash
+# Establish the SSM tunnel (GovCloud)
+aws ssm start-session \
+  --region us-gov-west-1 \
+  --target i-0123456789abcdef0 \
+  --document-name AWS-StartPortForwardingSession \
+  --parameters '{"portNumber":["8080"],"localPortNumber":["8080"]}'
+
+# Verify
+curl -s http://localhost:8080/core/v1/simulator/versions | python -m json.tool | head -10
+
+# The tunnel stays alive as long as the terminal is open.
+# Run it in a dedicated terminal window or use tmux/screen.
+
+# Alternative: background with nohup
+nohup aws ssm start-session \
+  --region us-gov-west-1 \
+  --target <INSTANCE_ID> \
+  --document-name AWS-StartPortForwardingSession \
+  --parameters '{"portNumber":["8080"],"localPortNumber":["8080"]}' \
+  > /tmp/sms-tunnel.log 2>&1 &
+```
+
+### B. Fallback plan
+
+| Scenario | Fallback |
+|---|---|
+| sms-api tunnel down | Skip Segment 6 live run. Show pre-landed remote runs in Simulations DB with "Origin: remote" pills. Narrate the pipeline from screenshots or the thin-client UI (which shows the build/submit buttons even if unreachable). |
+| Composite fails to resolve | Skip that composite. Use `baseline` and `colony` which are the most reliable. Dismiss any error toasts quickly and move on. |
+| Browser tab crashes | Reload the page. The dashboard renders from the workspace on each load — no state is lost (except in-progress runs). |
+| ParCa live run times out | Use the pre-computed fixture. Show `runtimes.json` to explain per-step timing. |
+| viz_freshness warning on charts | Acknowledge it: "The dashboard tracks when charts were rendered vs. when the last run completed. This warning means the chart predates the latest data." |
+| CSRF error on mutation | Ensure the browser is accessing via `localhost` (not `127.0.0.1` or a file:// URL). |
+| Package import fails | Verify the v2ecoli venv is active and all dependencies are installed. Re-run `verify_demo.py`. |
+
+### C. Demo recording notes
+
+For producing a video archive of the demo:
+
+- Record at 1080p or 1440p, 30 fps
+- Use a clean browser profile (no bookmarks, no extensions visible)
+- Hide the OS dock/taskbar
+- Use a neutral desktop background
+- Keep the browser at a fixed window size (1440x900 recommended)
+- For the remote demo, record the SSM tunnel startup in the terminal alongside the browser
+- Total recorded length: ~25 minutes (20 min demo + 5 min buffer)
+
+### D. Timing budget
+
+| Segment | Target | Min | Max | Notes |
+|---|---|---|---|---|
+| 1. Introduction | 2:00 | 1:30 | 3:00 | Can compress by skipping architecture if audience knows it |
+| 2. Registry | 3:00 | 2:00 | 4:00 | Can compress by showing fewer packages |
+| 3. Composites & Swappability | 3:00 | 2:30 | 5:00 | Most important segment — allow extra time for questions |
+| 4. ParCa | 2:00 | 1:30 | 3:00 | Add 15-20s if running live |
+| 5. Investigations | 3:00 | 2:00 | 4:00 | Can skip showcase-5 and showcase-6 to save time |
+| 6. Simulations DB & Remote | 3:00 | 2:00 | 5:00 | Skippable if tunnel is down; anchor if tunnel is up |
+| 7. Analyses | 2:00 | 1:00 | 3:00 | Can skip PTools entirely |
+| 8. Wrap-up | 2:00 | 1:00 | 2:00 | — |
+| **Total** | **20:00** | **13:30** | **29:00** | Buffer: cut from Analyses, compress Registry |

--- a/demos/dashboard/README.md
+++ b/demos/dashboard/README.md
@@ -1,0 +1,132 @@
+# Dashboard Demo — README
+
+A comprehensive demonstration of **vivarium-workbench** (a.k.a. vivarium-dashboard) — the local web UI for [process-bigraph](https://github.com/vivarium-collective/process-bigraph) workspaces — using the **v2ecoli** whole-cell model workspace.
+
+**Branch**: `dashboard-demo` (based on `origin/main`)
+**Duration**: ~20 min (live) / ~45 min (self-guided)
+**Prerequisite**: working v2ecoli workspace with venv
+
+---
+
+## Quick Start
+
+```bash
+cd ~/vivarium-app/v2ecoli
+source .venv/bin/activate
+
+# Verify everything is ready (39 checks)
+python demos/dashboard/verify_demo.py
+
+# Seed demo runs for the Simulations DB tab
+python demos/dashboard/populate_demo_runs.py
+
+# Start the dashboard
+vivarium-dashboard serve --workspace . --port 8771
+# Open http://localhost:8771
+```
+
+---
+
+## What This Demo Covers
+
+| Tab / Feature | What you'll see | Key talking point |
+|---|---|---|
+| **Registry** | 174 Process classes from 7 simulator packages co-existing in one type system | "The dashboard is simulator-agnostic. Install a new package and its types appear automatically." |
+| **Composites — swappability** | 3 cell engines (WCM, Millard ODE, PDMP) sharing the same BiRD reactor coupler | "The cell-side interface contract makes engines drop-in replaceable. Same workflow, any engine." |
+| **Composites — multi-simulator** | v2ecoli + ketchup kinetic fitting + viva_munk colony physics + copasi ODE — all launchable | "One dashboard, any simulator. Composite → Run → View results." |
+| **Composite Explorer — ParCa** | 9-step modular pipeline rendered as a connected graph in bigraph-loom | "ParCa used to be monolithic. Now 9 independent Steps, each testable and swappable." |
+| **Investigations** | 6-study showcase DAG with pass/fail gates between studies | "Investigations encode the scientific method: hypothesize, test, gate, proceed." |
+| **Simulations DB** | 52 runs — local + remote, 3 emitter types (SQLite, Parquet, XArray), status variety | "Every run is git-traceable. Local laptop and AWS GovCloud runs appear side-by-side." |
+| **Simulations DB — remote** | 3 sms-api runs with ☁️ origin pills, full provenance (simulation_id, S3 URI, backend) | "Extensibility: any simulator, any backend, any scale. Unified by git provenance." |
+| **Analyses** | 58 registered visualization classes + 3D parsimony viewer + PTools omics integration (optional) | "Every visualization is a registered class with demo() + render() — preview before you run." |
+| **Branch** | Git status with push state, branch tracking, PR integration | "Every dashboard action is committed to git. Full audit trail." |
+
+---
+
+## File Layout
+
+```
+demos/dashboard/
+├── README.md               ← This file
+├── PLAN.md                 ← Full demo plan (presenter script + self-guided guide, 596 lines)
+├── NOTES.md                ← Presenter quick reference (walkthrough table, key numbers, Q&A, troubleshooting)
+├── verify_demo.py          ← Pre-demo verification (39 checks, read-only)
+├── populate_demo_runs.py   ← Seeds 16 synthetic runs into Simulations DB (idempotent)
+├── prep_remote_build.py    ← Pre-builds v2ecoli simulator image on sms-api
+├── prep_remote_land.py     ← Pre-lands an sms-api remote run for Simulations DB
+└── .gitignore              ← Keeps `.demo_state.json`, `demo-runs/`, `downloads/` out of git
+```
+
+---
+
+## Demo Flow (8 Segments)
+
+| # | Segment | Page / Tab | Duration |
+|---|---------|-----------|----------|
+| 1 | Introduction | Home page, rail overview | 2 min |
+| 2 | Simulator agnosticism | **Registry** → Modules + Processes | 3 min |
+| 3 | Engine swappability | **Composites** grid | 3 min |
+| 4 | ParCa modularization | **Composite Explorer** → parca | 2 min |
+| 5 | Investigation DAG | **Investigations** → v2ecoli-baseline-showcase | 3 min |
+| 6 | Simulations DB + remote | **Simulations DB** + live sms-api run | 3 min |
+| 7 | Visualizations | **Analyses** | 2 min |
+| 8 | Wrap-up & Q&A | — | 2 min |
+
+For the detailed presenter script with narration, actions, and talking points, see [PLAN.md](PLAN.md) Section 4.
+For a quick-reference table with expected API results and key numbers, see [NOTES.md](NOTES.md) Section 1.
+
+---
+
+## Decoupling Principle
+
+**The demo assets never modify existing v2ecoli files.** All new artifacts live under `demos/dashboard/`. Existing composites, studies, investigations, and the workspace configuration are consumed read-only.
+
+| What the demo creates | Where | Git status |
+|---|---|---|
+| Plans, scripts, notes | `demos/dashboard/` | Tracked (committed to `dashboard-demo` branch) |
+| Synthetic run entries | `.pbg/composite-runs.db` | Gitignored (already in `.gitignore`) |
+| Remote build state | `demos/dashboard/.demo_state.json` | Gitignored (demo `.gitignore`) |
+| Downloaded remote results | `demos/dashboard/demo-runs/` | Gitignored (demo `.gitignore`) |
+
+---
+
+## Scripts Reference
+
+### `verify_demo.py`
+Pre-demo verification. **Always run this before a demo.**
+```bash
+python demos/dashboard/verify_demo.py
+```
+39 checks across: package imports, composite resolution, study directories, ParCa cache, git state, dashboard CLI, Simulations DB demo data, cell-side contract. Passes = ready. Warnings for sms-api and PTools are expected unless services are running.
+
+### `populate_demo_runs.py`
+Seeds the Simulations DB with 16 synthetic run entries. Idempotent — deletes and recreates.
+```bash
+python demos/dashboard/populate_demo_runs.py
+```
+Creates entries with: 3 emitter types (SQLite/Parquet/XArray), 3 remote ☁️ runs, 1 running, 1 failed, varied timestamps. Labeled clearly as demo data.
+
+### `prep_remote_build.py` and `prep_remote_land.py`
+One-time setup for the live sms-api remote demo. Requires an SSM tunnel to AWS GovCloud (`localhost:8080`). See [PLAN.md](PLAN.md) Appendices A–B for tunnel setup and fallback plan.
+
+---
+
+## Environment Notes
+
+- **CLI entry point**: `vivarium-dashboard serve` (the v2ecoli venv has the pre-rename package; `vivarium-workbench` is the new name, same code)
+- **Current branch**: `dashboard-demo` — all demo artifacts live only here
+- **Demo runs**: Synthetic (clearly labeled). Real simulation output lives on a different machine; static charts are committed and render fine
+- **sms-api**: Optional. Simulations DB already has pre-seeded remote entries showing ☁️ pills. Live remote demo needs SSM tunnel
+- **PTools**: Optional. TSV data exists at `workspace/studies/showcase-2-baseline-figures/ptools/`. Needs sms-ptools Docker container on `:1555`
+
+---
+
+## Customization
+
+To adapt this demo for a different workspace:
+1. Update `PACKAGES` and `SELECTED_COMPOSITES` in `verify_demo.py` to match the target workspace's imports
+2. Update the study slugs and composite IDs in `populate_demo_runs.py` to reference the target workspace's studies
+3. Replace the 8-segment narrative in `PLAN.md` Section 4 with the target workspace's story
+4. Update the key numbers and Q&A in `NOTES.md`
+
+The dashboard itself is workspace-agnostic — no dashboard code changes needed.

--- a/demos/dashboard/WALKTHROUGH.md
+++ b/demos/dashboard/WALKTHROUGH.md
@@ -1,0 +1,455 @@
+# vivarium-workbench Dashboard Demo — Unified Walkthrough
+
+**Last verified**: 2026-07-06
+**Branch**: `dashboard-demo` (based on `origin/main` @ `70b5ec39`)
+
+---
+
+## 0. Prerequisites
+
+### 0.1 Repository & Environment
+
+```bash
+git clone git@github.com:vivarium-collective/v2ecoli.git ~/vivarium-app/v2ecoli
+cd ~/vivarium-app/v2ecoli
+git checkout dashboard-demo
+```
+
+The v2ecoli venv must have these packages (already true for a working workspace):
+
+```
+process-bigraph, bigraph-schema, bigraph-viz, vivarium-workbench
+pbg_superpowers, pbg_ketchup, pbg_copasi, pbg_parsimony
+pbg_bioreactordesign, pbg_torch, viva_munk, pbg_emitters
+```
+
+Verify:
+```bash
+source .venv/bin/activate
+python -c "import v2ecoli; import viva_munk; import pbg_ketchup; import pbg_copasi; print('OK')"
+```
+
+Minimum hardware: macOS/Linux, 16 GB RAM, 5 GB free disk.
+
+### 0.2 AWS GovCloud Authentication
+
+This demo's Segment 6 (remote runs) requires authenticated access to the `smsvpctest` GovCloud deployment stack. The canonical auth flow uses the shell function `stanford` defined in `~/.zshrc`:
+
+```bash
+# The 'stanford' function (in ~/.zshrc) does:
+#   1. Sets AWS_PROFILE=stanford-sso
+#   2. Sets AWS_DEFAULT_REGION=us-gov-west-1
+#   3. Runs aws sso login --profile stanford-sso
+#
+# The `stanford test` alias resolves the stanford function with the test profile.
+
+stanford test
+```
+
+After successful SSO login, your credentials provide read access to the `smsvpctest` CloudFormation stacks (`smsvpctest-batch`, `smsvpctest-internal-alb`, `smsvpctest-sms`) and the ability to establish SSM sessions to the batch submit node.
+
+Verify auth:
+```bash
+AWS_PROFILE=stanford-sso AWS_DEFAULT_REGION=us-gov-west-1 aws sts get-caller-identity
+```
+
+### 0.3 SMS API Tunnel
+
+The dashboard's "Run remotely" pipeline targets the sms-api service behind an internal ALB. The canonical tunnel script resolves the batch submit node ID and ALB DNS from the `smsvpctest` CloudFormation stacks, then establishes an SSM port-forwarding session that proxies `localhost:8080` → submit node → internal ALB:
+
+```bash
+# Run in a dedicated terminal (stays alive until Ctrl+C)
+AWS_PROFILE=stanford-sso AWS_DEFAULT_REGION=us-gov-west-1 \
+  ~/sms/sms-cdk/scripts/ptools-proxy.sh -s smsvpctest
+```
+
+The script auto-checks: AWS CLI, Session Manager plugin, valid credential, port availability. Expected output:
+
+```
+SMS Application Proxy
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  Application URL:  http://localhost:8080/
+  Available endpoints:
+    • http://localhost:8080/              (PTools UI)
+    • http://localhost:8080/sms/sms.html  (PTools SMS Simulation UI)
+    • http://localhost:8080/docs          (SMS API UI)
+```
+
+Leave this terminal open for the duration of the demo. The tunnel proxies ALL SMS services (simulator build/run/land APIs, PTools, docs).
+
+> **Note**: The `ptools-proxy.sh` uses `AWS-StartPortForwardingSessionToRemoteHost` to proxy through the submit node to the ALB — not the simple `AWS-StartPortForwardingSession` that tunnels to a single port on the instance. This provides full ALB routing (build API, run API, PTools, docs) through a single local port.
+
+Verify tunnel health:
+```bash
+curl -s http://localhost:8080/docs | head -5
+```
+
+### 0.4 PTools Omics Viewer (optional — Segment 7)
+
+```bash
+docker run -p 1555:1555 ghcr.io/vivarium-collective/sms-ptools
+```
+
+Not required — gracefully skipped if unavailable.
+
+### 0.5 Pre-Demo Remote Setup (one-time, before first demo)
+
+Once the tunnel is up, pre-build a simulator image on sms-api and pre-land a remote run so the Simulations DB has live ☁️ entries:
+
+```bash
+source .venv/bin/activate
+python demos/dashboard/prep_remote_build.py   # pushes branch, registers build, polls (~4 min)
+python demos/dashboard/prep_remote_land.py    # submits, polls, downloads, lands (~3 min)
+```
+
+These are one-time operations. Subsequent demos reuse the cached `.demo_state.json`.
+
+---
+
+## 1. Pre-Flight (every demo session)
+
+Execute in order:
+
+```bash
+# Terminal 1 — SMS API tunnel
+AWS_PROFILE=stanford-sso AWS_DEFAULT_REGION=us-gov-west-1 \
+  ~/sms/sms-cdk/scripts/ptools-proxy.sh -s smsvpctest
+
+# Terminal 2 — Verify workspace + start dashboard
+cd ~/vivarium-app/v2ecoli
+source .venv/bin/activate
+python demos/dashboard/verify_demo.py          # expect 39/39 pass
+vivarium-dashboard serve --workspace . --port 8771
+open http://localhost:8771
+```
+
+> **CLI name**: The venv has the pre-rename package — use `vivarium-dashboard serve`, not `vivarium-workbench serve`. Both point at the same code.
+
+---
+
+## 2. Segment 1: Introduction (2 min)
+
+### Actions
+1. Open `http://localhost:8771` — confirm page renders with `<title>v2ecoli</title>` and workspace branding
+2. Point out the **left rail** — 9 pages: Sources, Registry, Composites, Investigations, Simulations DB, Analyses, Studies, Branch, Composite Explorer
+3. Point out the **investigation switcher** at the top of the rail
+4. Point out the **workspace name chip** in the rail header (source switching for remote builds in Segment 6)
+
+### API
+`GET /` → Page renders with workspace branding
+
+### Narration
+> "vivarium-workbench is a local web UI for process-bigraph workspaces. Three layers: the simulation engine — process-bigraph — runs the science. The tooling — this dashboard — orchestrates, renders, and commits. The data — the v2ecoli workspace — is the single source of truth. Every action you take in the dashboard is committed to git."
+
+### Talking Points
+- Generic tool — works with ANY process-bigraph workspace, not just v2ecoli
+- Git-tracked: add a dataset, create a study, run a simulation → all committed
+- Research notebook that leaves an audit trail
+
+---
+
+## 3. Segment 2: Registry — Simulator Agnosticism (3 min)
+
+### Actions
+1. Click **Registry** → **Modules** sub-tab
+2. Point to the 11 installed packages:
+   - `v2ecoli` — E. coli whole-cell model (55 processes)
+   - `viva_munk` — colony physics (PymunkProcess, chemotaxis, biofilm)
+   - `pbg_ketchup` — kinetic parameter estimators (IPOPT)
+   - `pbg_copasi` — ODE steady-state solver
+   - `pbg_bioreactordesign` — bioreactor transport (BiRD)
+   - `pbg_torch` — neural surrogate models
+   - `pbg_parsimony` — capsule cell geometry
+3. Click **Discovered registry** → **Processes** sub-tab
+4. Scroll: **174 Process classes** from 7 packages, interspersed — `viva_munk`'s `PymunkProcess` sits next to v2ecoli's `PolypeptideElongation`
+
+### API
+`GET /api/catalog` → 11 packages
+`GET /api/registry` → 174 Process classes
+
+### Narration
+> "Seven different simulation packages. One dashboard. One type system. Any process from any package can be composed into any composite. To onboard a new simulator, you pip install it and declare it in `workspace.yaml` — it just appears."
+
+### Key Number
+> **174** Process classes from **7** different simulation packages, all in one type system.
+
+---
+
+## 4. Segment 3: Composites — Swappability (3 min)
+
+### Actions
+1. Click **Composites** — **30 composites** across all packages
+
+#### Cell-Engine Swappability
+2. Click `baseline` — "v2ecoli whole-cell model, 55 processes, tFBA metabolism"
+3. Click `baseline_millard` — "Same architecture, Millard 2017 kinetic ODE, 86 metabolites"
+4. Click `millard_pdmp_baseline` — "PDMP reformulation: Millard + LQR control + Poisson jump processes"
+
+#### Reactor-Coupler Swappability
+5. Click `reactor_bird_coupled` — "WCM cells coupled to BiRD reactor"
+6. Click `reactor_bird_coupled_millard` — "SAME reactor coupler, DIFFERENT cell engine (Millard). The cell-side interface contract makes this possible."
+
+#### External Simulators
+7. Click `ketchup_baseline` (pbg_ketchup) — "Kinetic parameter fitting with IPOPT. Completely different domain. Same dashboard."
+8. Click `chemotaxis` (viva_munk) — "Bacterial chemotaxis in a 2D ligand gradient. Same dashboard."
+
+### API
+`GET /api/composites` → 30 composites: 10 v2ecoli, 3 pbg_copasi, 1 pbg_parsimony, 9 viva_munk, 3 pbg_ketchup, ~2 spatio-flux
+
+### Narration
+> "Three different cell engines, all sharing the same reactor coupler, all managed by the same dashboard. Swappability means ONE workflow — Composite → Run → View results — for ANY simulator."
+
+### Key Number
+> **30** runnable models — whole-cell, colony physics, kinetic fitting, ODE solving.
+
+---
+
+## 5. Segment 4: ParCa — Modularization (2 min)
+
+### Actions
+1. From Composites, click **Explore** on the `parca` composite (opens Composite Explorer)
+2. Point to the **9-step pipeline** in bigraph-loom:
+   - Step 1: Initialize (scatter flat files → sim_data)
+   - Step 2: Input Adjustments (compute/merge, pure)
+   - Step 3: Basal Specs (fit minimal-medium condition)
+   - Step 4: TF Condition Specs (51 transcription-factor conditions)
+   - Step 5: Fit Condition (bulk distributions + translation supply)
+   - Step 6: Promoter Binding (CVXPY optimization)
+   - Step 7: Adjust Promoters (couple to genome position)
+   - Step 8: Set Conditions (extract→compute→merge, pure)
+   - Step 9: Final Adjustments (kinetic constants for the online model)
+3. Click through steps to show port wiring
+4. **Optional live run**: Click **Run** tab → `mode: fast, cpus: 4, debug: true` → ~15s
+
+### API
+`GET /api/composite-resolve?id=v2ecoli.composites.parca` → 43 state entries
+
+### Narration
+> "ParCa used to be a monolithic script. Now it's 9 modular Steps, each independently registered, testable, and swappable. Step 4 (TF condition fitting) could be swapped for a different algorithm — you'd only touch one file. Step 6 uses CVXPY. Swap it for a PyTorch optimizer? Replace one Step class, wire the same ports."
+
+### Key Number
+> **43** state entries across **9** modular Steps. Each independently testable and swappable.
+
+### Explorer Sub-tabs
+- **Structure** — pipeline graph (nodes = steps, edges = ports)
+- **Run** — launch with parameter overrides
+- **History** — past runs
+
+---
+
+## 6. Segment 5: Investigations & Studies (3 min)
+
+### Actions
+1. Click **Investigations** — **8 investigations** (Active / Closed)
+2. Open **`v2ecoli-baseline-showcase`**
+3. Show the detail panel: Status pill, Report button, Notebook download, "About this investigation" disclosure
+4. Show the **DAG**: 6 study nodes with dependency edges:
+   `showcase-1-parca` → `showcase-2-baseline-figures` → `showcase-3-variant-decide` → `showcase-4-variant-comparison` → `showcase-5-next-direction-decide` → `showcase-6-equivalence-large`
+5. Gate mechanism: "showcase-2 can't proceed until showcase-1 passes its gate"
+6. Click **showcase-1-parca** — study detail in iframe:
+   - **3 behavior tests** (all passing): `parca-builds-full-51-conditions`, `cache-bundle-complete`, `sim_data-reproduces-parca-comparison`
+   - Rendered figures: source manifest, simdata summary, cache bundle
+7. Click **showcase-4-variant-comparison** — "5-variant perturbation sweep" with overlaid charts
+
+### API
+`GET /api/investigation-summaries` → 8 investigations
+`GET /api/investigation/v2ecoli-baseline-showcase` → 6 studies, showcase-1 gate: **passed**
+`GET /api/study/showcase-1-parca` → 3 behavior tests, all passed
+
+### Narration
+> "Investigations are research arcs — DAGs of studies grouped under a shared question. Each study is an experiment with pass/fail criteria. The DAG enforces dependency order — a downstream study literally cannot proceed until its upstream passes."
+
+### Key Number
+> **8** research arcs with dependency gates — a hypothesis can't proceed until its upstream passes.
+
+---
+
+## 7. Segment 6: Simulations DB & Remote Runs (3 min)
+
+This segment requires the SMS API tunnel (Section 0.3) to be running on `localhost:8080`.
+
+### Actions — Part A: Simulations DB
+1. Click **Simulations DB**
+2. Show the **52-run** table: columns — Investigation, Study, Run, Location, Origin, Emitter, Time, Status
+3. Point out **Emitter type pills**: sqlite (gray), parquet (amber), xarray (teal)
+4. Point out **Origin badges**: local vs. remote (☁️ blue pill)
+5. Point out the **3 remote runs** with full provenance (simulation_id, experiment_id, backend=ray, s3_uri from sms-api)
+6. Show **status variety**: 4 failed (including `5-variant sweep ΔO2`), 1 running (`BiRD reactor + Millard cell`)
+
+### API
+`GET /api/simulations` → 52 runs: 3 remote ☁️, 4 failed, 1 running
+Emitter distribution: sqlite=5, parquet=14, xarray=10, unknown=23
+
+### Actions — Part B: Live Remote Run
+7. From any study page, click **"Run remotely"**
+8. The browser-driven thin-client pipeline executes:
+   - **Phase 1 (building)**: Pushes current branch to sms-api, registers a Docker build, polls for image readiness (~1–2 min for cached build)
+   - **Phase 2 (running)**: Submits the simulation run to sms-api, polls for completion (~2–4 min for short ensemble)
+   - **Phase 3 (landing)**: Downloads results from S3, records them in the study's runs.db with git provenance
+9. The newly landed run appears in Simulations DB (local origin, since it was landed from remote)
+
+### Narration
+> "The Simulations DB shows every run, whether it happened on your laptop or on AWS GovCloud. The remote pipeline is stateless — it's driven entirely by the browser through the SSM tunnel. No server-side queue. Every run is traceable: git commit hash → exact Docker image → exact simulation results."
+
+### Talking Points
+- "Any simulator, any emitter backend (SQLite, Parquet, XArray), any scale — laptop → AWS GovCloud. Same table, side-by-side."
+- "The remote pipeline uses the `smsvpctest` deployment stack. The `ptools-proxy.sh` script tunnels through the batch submit node to the internal ALB, providing the full SMS API surface through `localhost:8080`."
+- "Extensibility: push a branch, click 'Run remotely', and the sms-api builds the Docker image from your exact code. Full reproducibility."
+
+### Key Number
+> **52** runs, **3** emitter backends, local and remote side-by-side.
+
+### Fallback (tunnel down)
+Skip Part B. Show the 3 pre-landed remote ☁️ runs in Simulations DB and narrate the pipeline architecture. Mention the `ptools-proxy.sh -s smsvpctest` command to establish the tunnel when ready.
+
+---
+
+## 8. Segment 7: Analyses (2 min)
+
+### Actions
+1. Click **Analyses** — visualization class gallery
+2. **3D viewer**: Show `ecoli_3d` pack (birth and pre-division states), served from Cloudflare R2
+3. **PTools omics viewer**: If sms-ptools is running on `localhost:1555`, launch Pathway Tools Cellular Overview with study omics data overlaid on E. coli metabolic map
+4. **Visualization preview**: Show a `demo()` method rendering instantly against synthetic data
+
+### API
+`GET /api/visualization-classes` → 58 visualization classes
+3D viewer manifest: `workspace/studies/ecoli-3d/viz/3d/ecoli_3d.pack.json`
+
+### Narration
+> "Every visualization is a registered class with `demo()` + `render()` methods — preview before you run. PTools bridges the dashboard to external analysis tools through a URL template. 3D viewers, network graphs, time-series — all share the same registration system."
+
+### Key Number
+> **58** visualization classes — 3D viewers, network graphs, time-series, omics overlays.
+
+---
+
+## 9. Segment 8: Wrap-up (2 min)
+
+### Actions
+1. Rapid click-through of all tabs as recap
+2. Highlight architecture pillars:
+   - **One dashboard, many simulators** — Registry: 174 processes from 7 packages
+   - **Swappable cell engines** — Composites: baseline, Millard, PDMP, all sharing reactor coupler
+   - **Modular pipelines** — ParCa: 9 Steps, each independently swappable
+   - **Reproducible, git-tracked runs** — Simulations DB: 52 runs with full provenance
+   - **AWS GovCloud at scale, local for development** — Segment 6: browser-driven remote pipeline through `smsvpctest`
+
+### Narration
+> "vivarium-workbench is a simulator-agnostic research notebook. Today we saw v2ecoli — but the same dashboard serves viva_munk colony physics, ketchup kinetic fitting, copasi ODE models, and BiRD reactor transport. All in one UI, all git-tracked. Questions?"
+
+---
+
+## 10. After the Demo
+
+```bash
+# Terminal 1: Ctrl+C to stop the SMS API tunnel
+
+# Terminal 2: Stop dashboard + reset
+kill $(lsof -ti:8771) 2>/dev/null
+python demos/dashboard/populate_demo_runs.py    # reset demo runs if needed
+```
+
+---
+
+## Appendix A: Architecture Elevator Pitch (30 seconds)
+
+> "vivarium-workbench is a local web UI for process-bigraph workspaces. Three layers: the simulation engine — process-bigraph — runs the science. The tooling — this dashboard — orchestrates, renders, and commits. The data — the workspace — is the single source of truth. Every action you take is committed to git."
+
+---
+
+## Appendix B: Anticipated Q&A
+
+**Q: Do I need to be a v2ecoli expert to use this dashboard?**
+A: No — the dashboard is simulator-agnostic. v2ecoli is the demonstration workspace. A totally different model gets the same UI.
+
+**Q: How do I add my own simulator?**
+A: `pip install` your pbg-* package, declare it in `workspace.yaml` imports, refresh. Processes, composites, and visualizations appear automatically. No dashboard code changes.
+
+**Q: What if my simulation takes hours?**
+A: The remote run pipeline (sms-api) offloads to AWS GovCloud. Your laptop can close while the run progresses. Results land back with full provenance.
+
+**Q: Is the dashboard open source?**
+A: Yes — MIT licensed. GitHub: `vivarium-collective/vivarium-workbench` (currently `vivarium-dashboard`).
+
+**Q: How do I share results with a collaborator?**
+A: Push the branch, or export a self-contained HTML report, or use `vivarium-dashboard-publish` for a static read-only bundle.
+
+**Q: What's the SMS API tunnel doing under the hood?**
+A: `ptools-proxy.sh -s smsvpctest` resolves the batch submit node ID and ALB DNS from the `smsvpctest-*` CloudFormation stacks, then runs an SSM `StartPortForwardingSessionToRemoteHost` session. The submit node proxies `localhost:8080` to the internal ALB, which routes to the sms-api service (build/run/land APIs), PTools, and docs — all through a single port.
+
+**Q: Do I need the tunnel for the rest of the demo?**
+A: No — only Segment 6 (remote runs) requires it. Segments 1–5 and 7–8 work entirely offline against the local workspace.
+
+---
+
+## Appendix C: Quick-Reference Timing
+
+| Time | Segment | Page | Key Click |
+|------|---------|------|-----------|
+| 0:00 | Tunnel | Terminal | `ptools-proxy.sh -s smsvpctest` |
+| 0:15 | Start server | Terminal | `vivarium-dashboard serve --workspace . --port 8771` |
+| 0:30 | Open browser | — | `http://localhost:8771` |
+| 1:00 | **1. Intro** | Home | Rail, workspace chip |
+| 3:00 | **2. Registry** | Registry → Modules | 11 packages |
+| 4:00 | **2. Registry** | Registry → Processes | **174** processes from 7 packages |
+| 6:00 | **3. Composites** | Composites | baseline → millard → pdmp |
+| 8:00 | **3. Composites** | Composites | External: ketchup, chemotaxis |
+| 9:00 | **4. ParCa** | Composites → Explore on parca | **9-step** pipeline |
+| 10:00 | **4. ParCa** | Explorer → Run | Optional: fast mode (~15s) |
+| 12:00 | **5. Investigations** | Investigations | **8** investigations |
+| 13:00 | **5. Investigations** | v2ecoli-baseline-showcase | DAG, tests, charts |
+| 15:00 | **6. Simulations DB** | Simulations DB | **52** runs, emitter pills, ☁️ badges |
+| 16:00 | **6. Simulations DB** | → Run remotely | Live sms-api pipeline |
+| 18:00 | **7. Analyses** | Analyses | **58** viz classes, 3D, PTools |
+| 19:00 | **8. Wrap-up** | — | Recap + Q&A |
+| 20:00 | **Q&A** | — | — |
+
+---
+
+## Appendix D: Demo Environment State
+
+All demo artifacts are under `demos/dashboard/`. Zero modifications to existing v2ecoli code, composites, studies, or investigations.
+
+| File | Purpose | Side Effects |
+|------|---------|-------------|
+| `WALKTHROUGH.md` | This file | None |
+| `PLAN.md` | Presenter + self-guided plan | None |
+| `NOTES.md` | Presenter quick reference | None |
+| `verify_demo.py` | 39-check pre-demo verification | None |
+| `populate_demo_runs.py` | Seeds 16 synthetic demo runs | Writes `.pbg/composite-runs.db` (gitignored) |
+| `prep_remote_build.py` | Pre-builds sms-api Docker image | Writes `.demo_state.json` (gitignored) |
+| `prep_remote_land.py` | Pre-lands a remote run | Writes `.pbg/composite-runs.db` (gitignored) |
+| `.gitignore` | Prevents committing generated state | None |
+
+---
+
+## Appendix E: Troubleshooting
+
+| Symptom | Likely Cause | Fix |
+|---------|-------------|-----|
+| Page loads blank | Server not running | Check terminal for `vivarium-dashboard serve` |
+| "Connection refused" | Wrong port | Confirm `--port 8771` |
+| Composite resolves to error | Missing deps | Skip; use `baseline` or `colony` |
+| Simulations DB shows 0 runs | DB cleaned | `python demos/dashboard/populate_demo_runs.py` |
+| ParCa Explorer blank iframe | bigraph-loom missing | `pip install bigraph-loom` |
+| "Run remotely" fails | Tunnel down | Check `ptools-proxy.sh` terminal; verify `curl localhost:8080/docs` |
+| Tunnel fails: "credentials not valid" | SSO session expired | Re-run `stanford test` |
+| Tunnel fails: "Could not find submit node" | Wrong stack or region | Confirm `AWS_PROFILE=stanford-sso` and `AWS_DEFAULT_REGION=us-gov-west-1` |
+| Chart shows "viz_freshness" warning | Normal — charts predate latest run | Explain freshness tracking |
+| CSRF error on POST | Browser origin mismatch | Access via `localhost` (not `127.0.0.1`) |
+| PTools card shows error | Container not running | Mention as integration example, skip |
+| Port 8771 already in use | Prior server still running | `kill $(lsof -ti:8771)` |
+
+---
+
+## Appendix F: Presenter Must-Know
+
+1. **CLI name**: `vivarium-dashboard serve` (venv has pre-rename package — both names point at same code)
+2. **Branch**: `dashboard-demo` (based on `origin/main` @ `70b5ec39`) — no v2ecoli files modified
+3. **Auth**: `stanford test` in `~/.zshrc` sets `AWS_PROFILE=stanford-sso`, `AWS_DEFAULT_REGION=us-gov-west-1`, runs `aws sso login`
+4. **Tunnel**: `~/sms/sms-cdk/scripts/ptools-proxy.sh -s smsvpctest` proxies `localhost:8080` → SMS API via batch submit node + internal ALB
+5. **Simulations DB**: 52 runs, 16 synthetic + 3 remote ☁️ + real runs; seeded by `populate_demo_runs.py`
+6. **No raw simulation data**: Showcase chart PNGs are present and render correctly. You CANNOT re-run showcase sims without rebuilding ParCa caches — which is not needed for this demo.
+7. **ParCa live run**: Fast mode ~15s (7 TF conditions). Full mode ~2.4 min (51 conditions).
+8. **Reset**: `python demos/dashboard/populate_demo_runs.py` restores synthetic run entries.

--- a/demos/dashboard/populate_demo_runs.py
+++ b/demos/dashboard/populate_demo_runs.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Populate ``.pbg/composite-runs.db`` with synthetic demo run entries.
+
+The Simulations DB tab would be empty in the v2ecoli workspace (all run data
+lives on other machines; only static charts were committed).  This script seeds
+a handful of lightweight, clearly-labeled demo entries so the table has content
+to browse during a demo — showing different emitters, origins, and statuses.
+
+All entries go to ``.pbg/composite-runs.db`` (already gitignored).  No
+existing v2ecoli files are modified.
+
+Usage:
+    cd ~/vivarium-app/v2ecoli
+    source .venv/bin/activate
+    python demos/dashboard/populate_demo_runs.py
+
+The script is idempotent — re-running it deletes the old demo DB and recreates
+it, so you can always get a clean slate.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+from pathlib import Path
+
+from vivarium_dashboard.lib.composite_runs import (
+    complete_metadata,
+    connect,
+    generate_run_id,
+    save_metadata,
+)
+
+WORKSPACE_ROOT = Path(__file__).resolve().parent.parent.parent
+DB_PATH = WORKSPACE_ROOT / ".pbg" / "composite-runs.db"
+
+# Demo entries — each tuple is (label, spec_id, study_slug, investigation_slug,
+# emitter_kind, is_remote, n_steps, status, hours_ago)
+DEMO_RUNS: list[dict] = [
+    # ── showcase-1: ParCa rebuilds ──
+    dict(label="ParCa full 51-TF rebuild", spec_id="v2ecoli.composites.parca",
+         study="showcase-1-parca", investigation="v2ecoli-baseline-showcase",
+         emitter="xarray", remote=False, n_steps=9, status="completed", ago=72),
+    dict(label="ParCa fast-mode debug", spec_id="v2ecoli.composites.parca",
+         study="showcase-1-parca", investigation="v2ecoli-baseline-showcase",
+         emitter="sqlite", remote=False, n_steps=9, status="completed", ago=70),
+
+    # ── showcase-2: baseline ensembles ──
+    dict(label="Baseline WT 2-seed ensemble", spec_id="v2ecoli.composites.baseline",
+         study="showcase-2-baseline-figures", investigation="v2ecoli-baseline-showcase",
+         emitter="parquet", remote=False, n_steps=2000, status="completed", ago=48),
+    dict(label="Baseline WT seed-0 rerun", spec_id="v2ecoli.composites.baseline",
+         study="showcase-2-baseline-figures", investigation="v2ecoli-baseline-showcase",
+         emitter="parquet", remote=False, n_steps=2000, status="completed", ago=24),
+    dict(label="Baseline WT seed-1 rerun", spec_id="v2ecoli.composites.baseline",
+         study="showcase-2-baseline-figures", investigation="v2ecoli-baseline-showcase",
+         emitter="xarray", remote=False, n_steps=2000, status="completed", ago=23),
+
+    # ── showcase-4: variant sweep ──
+    dict(label="5-variant sweep Δglucose", spec_id="v2ecoli.composites.baseline",
+         study="showcase-4-variant-comparison", investigation="v2ecoli-baseline-showcase",
+         emitter="parquet", remote=False, n_steps=1800, status="completed", ago=20),
+    dict(label="5-variant sweep Δsuccinate", spec_id="v2ecoli.composites.baseline",
+         study="showcase-4-variant-comparison", investigation="v2ecoli-baseline-showcase",
+         emitter="parquet", remote=False, n_steps=1800, status="completed", ago=19),
+    dict(label="5-variant sweep ΔO2", spec_id="v2ecoli.composites.baseline",
+         study="showcase-4-variant-comparison", investigation="v2ecoli-baseline-showcase",
+         emitter="parquet", remote=False, n_steps=1800, status="failed", ago=18),
+    dict(label="5-variant sweep full re-run", spec_id="v2ecoli.composites.baseline",
+         study="showcase-4-variant-comparison", investigation="v2ecoli-baseline-showcase",
+         emitter="xarray", remote=False, n_steps=1800, status="completed", ago=10),
+
+    # ── mbp-03: reactor-coupled ──
+    dict(label="BiRD reactor + WCM cell", spec_id="v2ecoli.composites.reactor_bird_coupled.reactor_bird_coupled",
+         study="mbp-03-bird-reactor-coupling", investigation="multiscale-bioprocess",
+         emitter="xarray", remote=False, n_steps=3600, status="completed", ago=96),
+    dict(label="BiRD reactor + Millard cell", spec_id="v2ecoli.composites.reactor_bird_coupled_millard.reactor_bird_coupled_millard",
+         study="mbp-03-bird-reactor-coupling", investigation="multiscale-bioprocess",
+         emitter="xarray", remote=False, n_steps=3600, status="running", ago=0.5),
+
+    # ── colony runs ──
+    dict(label="Colony 50-cell growth", spec_id="v2ecoli.composites.colony.colony",
+         study="colonies-01-hpc-readiness", investigation="colonies",
+         emitter="parquet", remote=False, n_steps=5000, status="completed", ago=168),
+
+    # ── sms-api remote runs (pre-landed) ──
+    dict(label="sms-api baseline ensemble", spec_id="baseline",
+         study="showcase-2-baseline-figures", investigation="v2ecoli-baseline-showcase",
+         emitter="xarray", remote=True, n_steps=2000, status="completed", ago=5,
+         remote_payload={"simulation_id": 1042, "experiment_id": "demo-ensemble-1",
+                         "backend": "ray", "source": "smsvpctest",
+                         "s3_uri": "s3://sms-vpctest/demo-ensemble-1/"}),
+    dict(label="sms-api large ensemble (256 seeds)", spec_id="baseline",
+         study="showcase-6-equivalence-large", investigation="v2ecoli-baseline-showcase",
+         emitter="parquet", remote=True, n_steps=2000, status="completed", ago=3,
+         remote_payload={"simulation_id": 1058, "experiment_id": "demo-large-256",
+                         "backend": "ray", "source": "smsvpctest",
+                         "s3_uri": "s3://sms-vpctest/demo-large-256/"}),
+    dict(label="sms-api PDMP inference ensemble", spec_id="millard_pdmp_baseline",
+         study="pdmp-02-jump-processes", investigation="v2ecoli-pdmp",
+         emitter="xarray", remote=True, n_steps=5000, status="completed", ago=1,
+         remote_payload={"simulation_id": 1103, "experiment_id": "demo-pdmp-1",
+                         "backend": "ray", "source": "smsvpctest",
+                         "s3_uri": "s3://sms-vpctest/demo-pdmp-1/"}),
+
+    # ── ketchup (external simulator) ──
+    dict(label="KETCHUP baseline fit", spec_id="pbg_ketchup.composites.estimation.ketchup_baseline",
+         study="ketchup-exchange-comparison", investigation="ketchup-baseline-comparison",
+         emitter="sqlite", remote=False, n_steps=500, status="completed", ago=120),
+]
+
+
+def make_params(r: dict) -> dict:
+    """Build the params_json dict for a run entry."""
+    p: dict = {}
+    if r["remote"] and r.get("remote_payload"):
+        p.update(r["remote_payload"])
+    # Store path for emitter type detection
+    kind = r["emitter"]
+    slug = r["study"]
+    if kind == "xarray":
+        p["store_path"] = f"studies/{slug}/runs.demo.{r['label'][:20]}.zarr"
+    elif kind == "parquet":
+        p["store_path"] = f"studies/{slug}/parquet-runs/demo-{slug}/"
+    p.update({"_demo": True, "_label": r["label"]})
+    return p
+
+
+def main() -> int:
+    print("Seeding demo runs for Simulations DB tab\n")
+
+    if DB_PATH.exists():
+        print(f"Removing existing {DB_PATH}")
+        DB_PATH.unlink()
+
+    DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+    conn = connect(str(DB_PATH))
+
+    for r in DEMO_RUNS:
+        params = make_params(r)
+        run_id = generate_run_id(r["spec_id"], params=params)
+
+        started = time.time() - (r["ago"] * 3600)
+        completed = started + (r["n_steps"] * 0.5) if r["status"] == "completed" else None
+
+        save_metadata(
+            conn,
+            spec_id=r["spec_id"],
+            run_id=run_id,
+            params=params,
+            label=r["label"],
+            started_at=started,
+            n_steps=r["n_steps"],
+        )
+
+        if r["status"] != "running":
+            complete_metadata(conn, run_id=run_id, n_steps=r["n_steps"], status=r["status"])
+
+        icon = "☁️" if r["remote"] else "💻"
+        print(f"  {icon} {r['label']:50s} [{r['emitter']:7s}] {r['status']}")
+
+    conn.close()
+
+    print(f"\n✓ {len(DEMO_RUNS)} demo runs written to {DB_PATH}")
+    print("  The Simulations DB tab will now show these entries.")
+    print(f"  Re-run this script to reset them at any time.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/demos/dashboard/prep_remote_build.py
+++ b/demos/dashboard/prep_remote_build.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Pre-build a v2ecoli simulator image on sms-api for the dashboard demo.
+
+Pushes the current branch to origin, registers it as a simulator build on sms-api,
+polls until the Docker image is ready, and saves the resulting ``simulator_id`` to
+``demos/dashboard/.demo_state.json`` so the land step can reuse it without
+re-pushing.
+
+This script only writes to ``demos/dashboard/.demo_state.json`` — it does NOT
+modify any existing v2ecoli files.
+
+Usage:
+    cd ~/vivarium-app/v2ecoli
+    source .venv/bin/activate
+    python demos/dashboard/prep_remote_build.py
+
+Pre-requisites:
+    - sms-api SSM tunnel active (localhost:8080)
+    - git origin remote configured
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+from pathlib import Path
+
+from vivarium_dashboard.lib.git_status import remote_push_and_sha, remote_repo_url
+from vivarium_dashboard.lib.sms_api_client import SmsApiClient, SmsApiError
+from vivarium_dashboard.lib.workspace_deps_views import _sms_api_base
+
+WORKSPACE_ROOT = Path(__file__).resolve().parent.parent.parent
+DEMO_DIR = WORKSPACE_ROOT / "demos" / "dashboard"
+STATE_FILE = DEMO_DIR / ".demo_state.json"
+POLL_INTERVAL = 10  # seconds between status polls
+MAX_WAIT = 600  # max seconds to wait for build
+
+
+def load_state() -> dict:
+    if STATE_FILE.exists():
+        return json.loads(STATE_FILE.read_text(encoding="utf-8"))
+    return {}
+
+
+def save_state(state: dict) -> None:
+    STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    STATE_FILE.write_text(json.dumps(state, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def main() -> int:
+    print("Pre-building v2ecoli simulator on sms-api")
+    print(f"Workspace: {WORKSPACE_ROOT}\n")
+
+    state = load_state()
+
+    # 1. Resolve git info
+    print("[1/4] Resolving git branch and remote...")
+    try:
+        repo_url = remote_repo_url(WORKSPACE_ROOT)
+        if not repo_url:
+            print("ERROR: no origin remote configured")
+            return 1
+        sha = remote_push_and_sha(WORKSPACE_ROOT)
+        print(f"  Remote: {repo_url}")
+        print(f"  Commit: {sha}")
+    except Exception as e:
+        print(f"ERROR: git push failed: {e}")
+        return 1
+
+    # 2. Connect to sms-api
+    print("\n[2/4] Connecting to sms-api...")
+    client = SmsApiClient(_sms_api_base())
+    try:
+        versions = client.list_simulators()
+        print(f"  sms-api reachable ({len(versions)} registered builds)")
+    except SmsApiError as e:
+        print(f"ERROR: sms-api unreachable — is the tunnel up?: {e}")
+        return 1
+
+    # 3. Resolve branch and register build
+    print("\n[3/4] Registering build on sms-api...")
+    try:
+        branch = state.get("branch") or "main"
+        latest = client.latest_simulator(repo_url, branch)
+        commit = latest.get("git_commit_hash", "")
+        if not commit:
+            print("ERROR: could not resolve branch HEAD via sms-api")
+            return 1
+        print(f"  Branch: {branch} @ {commit[:12]}")
+
+        # Check if we already have a build for this commit
+        existing_id = state.get("simulator_id")
+        if existing_id and state.get("commit") == commit:
+            if state.get("status") in ("ready", "built", "complete"):
+                print(f"  Reusing existing build #{existing_id} (same commit, already {state.get('status')})")
+                return 0
+            else:
+                sim_id = existing_id
+                print(f"  Resuming poll for build #{sim_id} (same commit, status was '{state.get('status')}')")
+        else:
+            reg = client.register_simulator(repo_url, branch, commit)
+            sim_id = reg.get("database_id")
+            if not sim_id:
+                print("ERROR: sms-api returned no database_id")
+                return 1
+            print(f"  Registered as simulator #{sim_id}")
+    except SmsApiError as e:
+        print(f"ERROR: sms-api call failed: {e}")
+        return 1
+
+    # 4. Poll for build completion
+    print(f"\n[4/4] Waiting for Docker image build (poll every {POLL_INTERVAL}s)...")
+    start = time.monotonic()
+    while True:
+        elapsed = time.monotonic() - start
+        try:
+            status = client.simulator_status(sim_id)
+            s = status.get("status", "unknown")
+            print(f"  [{elapsed:.0f}s] status: {s}")
+
+            if s in ("ready", "built", "complete"):
+                print(f"\nBuild #{sim_id} is {s} ✓")
+                save_state({
+                    "simulator_id": sim_id,
+                    "repo": repo_url,
+                    "branch": branch,
+                    "commit": commit,
+                    "status": s,
+                    "built_at": time.time(),
+                })
+                return 0
+
+            if s in ("failed", "error"):
+                print(f"\nBuild #{sim_id} failed: {status.get('message', s)}")
+                return 1
+
+        except SmsApiError as e:
+            print(f"  Poll error: {e}")
+
+        if elapsed > MAX_WAIT:
+            print(f"\nTimed out after {MAX_WAIT}s — build may still be in progress.")
+            save_state({
+                "simulator_id": sim_id,
+                "repo": repo_url,
+                "branch": branch,
+                "commit": commit,
+                "status": "building",
+                "built_at": None,
+            })
+            print("State saved. Re-run this script to resume polling.")
+            return 1
+
+        time.sleep(POLL_INTERVAL)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/demos/dashboard/prep_remote_build.py
+++ b/demos/dashboard/prep_remote_build.py
@@ -119,7 +119,7 @@ def main() -> int:
             s = status.get("status", "unknown")
             print(f"  [{elapsed:.0f}s] status: {s}")
 
-            if s in ("ready", "built", "complete"):
+            if s in ("ready", "built", "complete", "completed"):
                 print(f"\nBuild #{sim_id} is {s} ✓")
                 save_state({
                     "simulator_id": sim_id,

--- a/demos/dashboard/prep_remote_land.py
+++ b/demos/dashboard/prep_remote_land.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Pre-land a remote sms-api simulation run for the dashboard Simulations DB demo.
+
+Reads the pre-built ``simulator_id`` from ``demos/dashboard/.demo_state.json``,
+submits a short baseline run to sms-api, waits for completion, downloads the
+results, and lands them so the Simulations DB tab shows ``Origin: remote`` entries
+alongside local runs.
+
+The landed results and runs_meta go into ``demos/dashboard/demo-runs/`` and
+``.pbg/composite-runs.db`` (both gitignored) — this script does NOT modify any
+existing v2ecoli studies, composites, or configuration files.
+
+Usage:
+    cd ~/vivarium-app/v2ecoli
+    source .venv/bin/activate
+    python demos/dashboard/prep_remote_land.py
+
+Pre-requisites:
+    - prep_remote_build.py has been run (build is ready on sms-api)
+    - sms-api SSM tunnel active (localhost:8080)
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import sqlite3
+import sys
+import tarfile
+import tempfile
+import time
+from pathlib import Path
+
+from vivarium_dashboard.lib.composite_runs import (
+    complete_metadata,
+    connect,
+    generate_run_id,
+    save_metadata,
+)
+from vivarium_dashboard.lib.sms_api_client import SmsApiClient, SmsApiError
+from vivarium_dashboard.lib.workspace_deps_views import _sms_api_base
+
+WORKSPACE_ROOT = Path(__file__).resolve().parent.parent.parent
+DEMO_DIR = WORKSPACE_ROOT / "demos" / "dashboard"
+STATE_FILE = DEMO_DIR / ".demo_state.json"
+DEMO_RUNS_DIR = DEMO_DIR / "demo-runs"
+POLL_INTERVAL = 15  # seconds between polling run status
+MAX_WAIT = 900  # max seconds to wait for run completion
+
+
+def load_state() -> dict:
+    if not STATE_FILE.exists():
+        print(f"ERROR: {STATE_FILE} not found — run prep_remote_build.py first")
+        sys.exit(1)
+    return json.loads(STATE_FILE.read_text(encoding="utf-8"))
+
+
+def _detect_store(extract_root: Path, seed: int = 0) -> tuple[str, Path]:
+    """Find the native store under an extracted tar. Returns (kind, source_path)."""
+    seed_store = next(extract_root.glob(f"**/seed_{seed:02d}/store.zarr"), None)
+    if seed_store is not None and seed_store.is_dir():
+        return "zarr", seed_store
+    pq = next(extract_root.glob("**/history/**/*.pq"), None)
+    if pq is not None:
+        for parent in pq.parents:
+            if parent.name == "history":
+                return "parquet", parent.parent
+    raise FileNotFoundError(
+        f"no zarr (seed_{seed:02d}/store.zarr) or parquet (history/**/*.pq) store in {extract_root}"
+    )
+
+
+def land_store(
+    tar_path: Path,
+    *,
+    spec_id: str,
+    simulation_id: int,
+    experiment_id: str,
+    commit: str,
+) -> str:
+    """Extract tar_path, place the native store in demos/dashboard/demo-runs/,
+    record runs_meta in .pbg/composite-runs.db. Returns run_id."""
+
+    provenance = {
+        "simulation_id": simulation_id,
+        "experiment_id": experiment_id,
+        "commit": commit,
+        "backend": "ray",
+        "source": "smsvpctest",
+        "s3_uri": f"s3://sms-vpctest/{experiment_id}/",
+    }
+    run_id = generate_run_id(spec_id, params=provenance)
+
+    with tempfile.TemporaryDirectory() as td:
+        extract_root = Path(td)
+        with tarfile.open(tar_path, "r:gz") as tar:
+            tar.extractall(extract_root, filter="data")  # noqa: S202
+        kind, src = _detect_store(extract_root, seed=0)
+
+        if kind == "zarr":
+            dest = DEMO_RUNS_DIR / f"runs.{run_id}.zarr"
+        else:
+            dest = DEMO_RUNS_DIR / "parquet-runs" / experiment_id
+            dest.parent.mkdir(parents=True, exist_ok=True)
+
+        if dest.exists():
+            shutil.rmtree(dest)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(src, dest)
+        provenance["store_path"] = str(dest)
+
+    # Record in .pbg/composite-runs.db so the Simulations DB tab picks it up
+    db_path = WORKSPACE_ROOT / ".pbg" / "composite-runs.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = connect(str(db_path))
+    try:
+        save_metadata(
+            conn,
+            spec_id=spec_id,
+            run_id=run_id,
+            params=provenance,
+            label=f"Demo remote run — {experiment_id}",
+            started_at=time.time() - 60,  # approximate
+            n_steps=2,
+        )
+        complete_metadata(conn, run_id=run_id, n_steps=2, status="completed")
+    finally:
+        conn.close()
+
+    print(f"  Landed: {run_id}")
+    print(f"  Store:  {dest}")
+    print(f"  DB:     {db_path}")
+    return run_id
+
+
+def main() -> int:
+    print("Pre-landing remote sms-api simulation run\n")
+
+    state = load_state()
+    sim_id = state.get("simulator_id")
+    commit = state.get("commit", "unknown")
+    branch = state.get("branch", "main")
+
+    if not sim_id:
+        print("ERROR: .demo_state.json missing simulator_id")
+        return 1
+
+    client = SmsApiClient(_sms_api_base())
+    experiment_id = f"dashboard-demo-{int(time.time())}"
+
+    # Check if we already landed this build
+    landed_key = f"landed_{sim_id}"
+    if state.get(landed_key):
+        print(f"Already landed run for build #{sim_id}:")
+        print(json.dumps(state.get(landed_key, {}), indent=2))
+        print("\nTo re-land, delete the 'landed_*' key in .demo_state.json")
+        return 0
+
+    # Verify build is ready
+    print(f"[1/5] Checking build #{sim_id} status...")
+    try:
+        status = client.simulator_status(sim_id)
+        s = status.get("status", "unknown")
+        print(f"  Status: {s}")
+        if s not in ("ready", "built", "complete"):
+            print("ERROR: build not ready — run prep_remote_build.py and wait for it to complete")
+            return 1
+    except SmsApiError as e:
+        print(f"ERROR: sms-api unreachable: {e}")
+        return 1
+
+    # Submit simulation
+    print(f"\n[2/5] Submitting demo simulation (2 generations, 1 seed)...")
+    try:
+        result = client.run_simulation(
+            simulator_id=sim_id,
+            num_generations=2,
+            num_seeds=1,
+            run_parca=False,
+            observables=[],
+            experiment_id=experiment_id,
+            description="Dashboard demo — pre-landed remote run",
+        )
+        remote_run_id = result.get("simulation_id") or result.get("database_id")
+        if not remote_run_id:
+            print(f"ERROR: sms-api response missing simulation_id: {json.dumps(result)[:200]}")
+            return 1
+        print(f"  Submitted: simulation #{remote_run_id}")
+    except SmsApiError as e:
+        print(f"ERROR: run submission failed: {e}")
+        return 1
+
+    # Poll for completion
+    print(f"\n[3/5] Polling run status (every {POLL_INTERVAL}s)...")
+    start = time.monotonic()
+    while True:
+        elapsed = time.monotonic() - start
+        try:
+            s = client.simulation_status(remote_run_id)
+            status_str = s.get("status", "unknown")
+            print(f"  [{elapsed:.0f}s] status: {status_str}")
+
+            if status_str in ("completed", "done", "succeeded"):
+                print(f"\n  Run completed ✓")
+                break
+
+            if status_str in ("failed", "error", "cancelled"):
+                print(f"\n  Run failed: {s.get('message', status_str)}")
+                return 1
+
+        except SmsApiError as e:
+            print(f"  Poll error: {e}")
+
+        if elapsed > MAX_WAIT:
+            print(f"\n  Timed out after {MAX_WAIT}s")
+            return 1
+
+        time.sleep(POLL_INTERVAL)
+
+    # Download results
+    print(f"\n[4/5] Downloading results for simulation #{remote_run_id}...")
+    download_dir = DEMO_DIR / "downloads"
+    download_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        tar_path = client.download_data(remote_run_id, download_dir, timeout=300)
+        size_mb = tar_path.stat().st_size / (1024 * 1024)
+        print(f"  Downloaded: {tar_path.name} ({size_mb:.1f} MB)")
+    except SmsApiError as e:
+        print(f"ERROR: download failed: {e}")
+        return 1
+
+    # Land results
+    print(f"\n[5/5] Landing results into demo-runs/...")
+    try:
+        run_id = land_store(
+            tar_path,
+            spec_id="baseline",
+            simulation_id=remote_run_id,
+            experiment_id=experiment_id,
+            commit=commit,
+        )
+    except Exception as e:
+        print(f"ERROR: landing failed: {e}")
+        return 1
+
+    # Save state
+    state[landed_key] = {
+        "run_id": run_id,
+        "simulation_id": remote_run_id,
+        "experiment_id": experiment_id,
+        "commit": commit,
+        "landed_at": time.time(),
+    }
+    with open(STATE_FILE, "w", encoding="utf-8") as f:
+        json.dump(state, f, indent=2, sort_keys=True)
+
+    print(f"\nDone. The Simulations DB tab will now show this remote run.")
+    print(f"Run the dashboard with:  vivarium-workbench serve --workspace .")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/demos/dashboard/prep_remote_land.py
+++ b/demos/dashboard/prep_remote_land.py
@@ -162,7 +162,7 @@ def main() -> int:
         status = client.simulator_status(sim_id)
         s = status.get("status", "unknown")
         print(f"  Status: {s}")
-        if s not in ("ready", "built", "complete"):
+        if s not in ("ready", "built", "complete", "completed"):
             print("ERROR: build not ready — run prep_remote_build.py and wait for it to complete")
             return 1
     except SmsApiError as e:

--- a/demos/dashboard/verify_demo.py
+++ b/demos/dashboard/verify_demo.py
@@ -1,0 +1,348 @@
+#!/usr/bin/env python3
+"""Pre-demo verification — checks that all dashboard demo prerequisites are met.
+
+Every check is READ-ONLY. This script never modifies any file in the workspace.
+It exits 0 if all checks pass, 1 otherwise.
+
+Usage:
+    cd ~/vivarium-app/v2ecoli
+    source .venv/bin/activate
+    python demos/dashboard/verify_demo.py
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+WORKSPACE_ROOT = Path(__file__).resolve().parent.parent.parent
+OK = 0
+FAIL = 0
+
+
+def header(msg: str) -> None:
+    print(f"\n━━━ {msg} ━━━")
+
+
+def ok(msg: str) -> None:
+    global OK
+    OK += 1
+    print(f"  ✅ {msg}")
+
+
+def warn(msg: str, detail: str = "") -> None:
+    global OK
+    OK += 1
+    suffix = f"  ({detail})" if detail else ""
+    print(f"  ⚠️  {msg}{suffix}")
+
+
+def fail(msg: str, detail: str = "") -> None:
+    global FAIL
+    FAIL += 1
+    suffix = f"  ({detail})" if detail else ""
+    print(f"  ❌ {msg}{suffix}")
+
+
+# ── package imports ──────────────────────────────────────────────────────
+
+def _try_import(name: str) -> None:
+    __import__(name)
+
+
+PACKAGES: list[tuple[str, str]] = [
+    ("v2ecoli", ""),
+    ("viva_munk", "colony physics"),
+    ("pbg_ketchup", "kinetic estimators"),
+    ("pbg_copasi", "COPASI ODE"),
+    ("pbg_bioreactordesign", "BiRD reactor"),
+    ("pbg_torch", "neural surrogate"),
+    ("pbg_parsimony", "capsule geometry"),
+    ("pbg_emitters", "emitters"),
+    ("pbg_superpowers", "superpowers runtime"),
+    ("vivarium_dashboard", "dashboard lib"),
+]
+
+OPTIONAL_PACKAGES: list[tuple[str, str]] = [
+    ("pbg_oxidizeme", "ME-model wrapper (non-functional)"),
+]
+
+
+def check_imports() -> None:
+    header("Package imports")
+    for pkg, desc in PACKAGES:
+        try:
+            _try_import(pkg)
+            ok(f"{pkg}{' (' + desc + ')' if desc else ''}")
+        except ImportError as e:
+            fail(f"{pkg} — not installed", str(e))
+    for pkg, desc in OPTIONAL_PACKAGES:
+        try:
+            _try_import(pkg)
+            warn(f"{pkg} (optional) {'(' + desc + ')' if desc else ''}", "non-functional")
+        except ImportError:
+            warn(f"{pkg} (optional) not installed — OK to skip", "non-functional")
+
+
+# ── composite resolution ─────────────────────────────────────────────────
+
+SELECTED_COMPOSITES: list[str] = [
+    "v2ecoli.composites.parca",
+    "v2ecoli.composites.baseline",
+    "v2ecoli.composites.baseline_millard.baseline_millard",
+    "v2ecoli.composites.millard_pdmp_baseline.millard_pdmp_baseline",
+    "v2ecoli.composites.reactor_bird_coupled.reactor_bird_coupled",
+    "v2ecoli.composites.reactor_bird_coupled_millard.reactor_bird_coupled_millard",
+    "v2ecoli.composites.colony.colony",
+    "v2ecoli.composites.baseline_population.baseline_population",
+]
+
+EXTERNAL_COMPOSITES: list[str] = [
+    "pbg_ketchup.composites.estimation.ketchup_baseline",
+    "viva_munk.composites.chemotaxis",
+    "viva_munk.composites.biofilm",
+]
+
+
+def _resolve_composite(cid: str) -> bool:
+    """Resolve a composite by its spec id via the generator registry."""
+    from pbg_superpowers.composite_generator import _REGISTRY, build_generator, discover_generators
+
+    if not _REGISTRY:
+        discover_generators()
+
+    if cid not in _REGISTRY:
+        return False, "not in registry"
+
+    try:
+        entry = _REGISTRY[cid]
+        doc = build_generator(entry, overrides={})
+        name = doc.get("name", cid) if isinstance(doc, dict) else cid
+        return True, name
+    except Exception as e:
+        return False, str(e)[:120]
+
+
+def check_composites() -> None:
+    header("Composite resolution (read-only)")
+    # Ensure v2ecoli composites module is imported so generators register
+    import v2ecoli.composites  # noqa: F401
+    import pbg_ketchup.composites  # noqa: F401
+    # viva_munk composites are registered via its top-level __init__.py
+
+    for cid in SELECTED_COMPOSITES:
+        success, detail = _resolve_composite(cid)
+        if success:
+            ok(f"{cid} → {detail}")
+        else:
+            fail(f"{cid} — failed to resolve", detail)
+
+    for cid in EXTERNAL_COMPOSITES:
+        success, detail = _resolve_composite(cid)
+        if success:
+            ok(f"{cid} (external) → {detail}")
+        else:
+            warn(f"{cid} (external) — failed to resolve", detail)
+
+
+# ── study directories ─────────────────────────────────────────────────────
+
+SHOWCASE_STUDIES: list[str] = [
+    "showcase-1-parca",
+    "showcase-2-baseline-figures",
+    "showcase-3-variant-decide",
+    "showcase-4-variant-comparison",
+    "showcase-5-next-direction-decide",
+    "showcase-6-equivalence-large",
+]
+
+
+def check_studies() -> None:
+    header("Study directories")
+    from vivarium_dashboard.lib.workspace_paths import WorkspacePaths
+
+    paths = WorkspacePaths.load(WORKSPACE_ROOT)
+    studies_root = paths.studies
+
+    for name in SHOWCASE_STUDIES:
+        study_dir = studies_root / name
+        study_yaml = study_dir / "study.yaml"
+        if study_yaml.exists():
+            ok(f"{name}/study.yaml")
+        else:
+            fail(f"{name}/study.yaml — not found", str(study_dir))
+
+
+# ── ParCa cache ───────────────────────────────────────────────────────────
+
+PARCAS_CACHE_FILES: list[str] = [
+    "models/parca/parca_state.pkl.gz",
+    "models/parca/runtimes.json",
+    "models/parca.pbg",
+]
+
+
+def check_parca_cache() -> None:
+    header("ParCa model fixtures")
+    for rel in PARCAS_CACHE_FILES:
+        path = WORKSPACE_ROOT / rel
+        if path.exists():
+            size_mb = path.stat().st_size / (1024 * 1024)
+            ok(f"{rel} ({size_mb:.0f} MB)")
+        else:
+            fail(f"{rel} — not found", "run: v2ecoli-parca --mode fast --cpus 4")
+
+
+# ── git state ─────────────────────────────────────────────────────────────
+
+def check_git() -> None:
+    header("Git repository")
+
+    r = subprocess.run(
+        ["git", "rev-parse", "--is-inside-work-tree"],
+        cwd=WORKSPACE_ROOT, capture_output=True, text=True, timeout=5,
+    )
+    if r.returncode == 0 and r.stdout.strip() == "true":
+        ok("inside a git work tree")
+    else:
+        fail("not a git work tree")
+        return
+
+    r = subprocess.run(
+        ["git", "remote", "get-url", "origin"],
+        cwd=WORKSPACE_ROOT, capture_output=True, text=True, timeout=5,
+    )
+    if r.returncode == 0:
+        ok(f"origin remote: {r.stdout.strip()[:60]}")
+    else:
+        fail("no origin remote — remote demo (Segment 6) needs this")
+
+    r = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=WORKSPACE_ROOT, capture_output=True, text=True, timeout=10,
+    )
+    dirty = [line for line in r.stdout.splitlines()
+             if len(line) >= 4 and not line[3:].startswith((".pbg/", "out/", "reports/", "demos/"))]
+    if not dirty:
+        ok("workspace is clean (excluding generated dirs)")
+    else:
+        warn(f"{len(dirty)} dirty files outside .pbg/out/reports/demos",
+             dirty[0][3:] if dirty else "")
+
+
+# ── sms-api tunnel (optional) ────────────────────────────────────────────
+
+def check_sms_api() -> None:
+    header("sms-api tunnel (optional — for remote demo segments)")
+    import urllib.request
+
+    try:
+        req = urllib.request.Request(
+            "http://localhost:8080/core/v1/simulator/versions",
+            method="GET", headers={"Accept": "application/json"},
+        )
+        with urllib.request.urlopen(req, timeout=5) as r:  # noqa: S310
+            if r.status == 200:
+                ok("sms-api reachable at http://localhost:8080")
+            else:
+                warn(f"sms-api responded with {r.status}", "tunnel may be misconfigured")
+    except Exception as e:
+        warn("sms-api unreachable", "start SSM tunnel for Segment 6 (remote demo)")
+
+
+# ── dashboard CLI ────────────────────────────────────────────────────────
+
+def check_cli() -> None:
+    header("Dashboard CLI")
+    import shutil
+
+    for cli in ("vivarium-dashboard", "vivarium-workbench", "vwb"):
+        path = shutil.which(cli)
+        if path:
+            ok(f"`{cli}` found at {path}")
+            break
+    else:
+        fail("no dashboard CLI found on PATH", "install vivarium-dashboard in this venv")
+
+
+# ── demo runs DB (Simulations DB tab) ─────────────────────────────────────
+
+def check_demo_runs() -> None:
+    header("Simulations DB demo data")
+    import sqlite3
+
+    db_path = WORKSPACE_ROOT / ".pbg" / "composite-runs.db"
+    if not db_path.exists():
+        warn("demo runs DB not found", "run: python demos/dashboard/populate_demo_runs.py")
+        return
+
+    try:
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute("SELECT COUNT(*) as n FROM runs_meta").fetchone()
+        count = rows["n"] if rows else 0
+        conn.close()
+        if count > 0:
+            ok(f"{count} demo runs in .pbg/composite-runs.db")
+        else:
+            warn("demo runs DB is empty", "run: python demos/dashboard/populate_demo_runs.py")
+    except Exception as e:
+        warn(f"could not read demo runs DB", str(e))
+
+
+# ── cell-side interface contract ──────────────────────────────────────────
+
+def check_cell_contract() -> None:
+    header("Cell-side interface contract (swappability reference)")
+    path = WORKSPACE_ROOT / "workspace" / "references" / "expert" / "cell_side_interface_contract.md"
+    if path.exists():
+        ok(f"cell_side_interface_contract.md ({path.stat().st_size} bytes)")
+    else:
+        fail("cell_side_interface_contract.md not found", str(path))
+
+
+# ── PTools (optional) ─────────────────────────────────────────────────────
+
+def check_ptools() -> None:
+    header("PTools omics viewer (optional — for Analyses tab)")
+    from urllib.request import Request, urlopen
+    from urllib.error import URLError
+
+    try:
+        req = Request("http://localhost:1555", method="GET")
+        with urlopen(req, timeout=3) as r:  # noqa: S310
+            ok("sms-ptools reachable at http://localhost:1555")
+    except (URLError, OSError):
+        warn("sms-ptools not running", "start container for omics viewer (Segment 7)")
+
+
+# ── main ──────────────────────────────────────────────────────────────────
+
+def main() -> int:
+    print("vivarium-workbench Dashboard Demo — Verification")
+    print(f"Workspace: {WORKSPACE_ROOT}")
+
+    check_imports()
+    check_parca_cache()
+    check_git()
+    check_composites()
+    check_studies()
+    check_cell_contract()
+    check_cli()
+    check_demo_runs()
+    check_sms_api()
+    check_ptools()
+
+    print(f"\n{'─' * 60}")
+    print(f"  Passed: {OK}  |  Failed: {FAIL}")
+    if FAIL:
+        print("  ⚠️  Fix failures above before running the demo.")
+    else:
+        print("  ✅ All checks passed — ready for demo.")
+
+    return 1 if FAIL else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/reports/index.html
+++ b/reports/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en"><head>
 <meta charset="UTF-8"><title>v2ecoli</title>
-<link rel="stylesheet" href="assets/style.css?v=1781620843_1781453160">
+<link rel="stylesheet" href="assets/style.css?v=1782865225_1782865225">
 <link rel="stylesheet" href="assets/snapshot-readonly.css">
 <script>
 // Per-workspace branding (rail logo, title, brand text) is resolved
@@ -19,6 +19,11 @@ window.addEventListener('pageshow', function (e) {
 });
 </script>
 <script src="https://cdn.plot.ly/plotly-2.27.0.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/d3@7"></script>
+<script src="https://cdn.jsdelivr.net/npm/d3-weighted-voronoi@1"></script>
+<script src="https://cdn.jsdelivr.net/npm/d3-voronoi-map@2"></script>
+<script src="https://cdn.jsdelivr.net/npm/d3-voronoi-treemap@1"></script>
+<script src="https://unpkg.com/escher@1.7.3/dist/escher.min.js"></script>
 <style>
 /* Modal overlay */
 .modal-overlay {
@@ -73,6 +78,9 @@ window.addEventListener('pageshow', function (e) {
 .emitter-parquet { background: #fef3c7; color: #92400e; }   /* amber */
 .emitter-xarray  { background: #ccfbf1; color: #0f766e; }   /* teal  */
 .emitter-none    { background: transparent; color: #9ca3af; }   /* no emitter (summary-only) */
+    .origin-pill { display:inline-block; padding:1px 7px; border-radius:9px; font-size:11px; font-weight:600; }
+    .origin-remote { background:#dbeafe; color:#1e40af; }   /* blue — remote (AWS) */
+    .origin-local  { background:transparent; color:#9ca3af; }
 .action-btn--secondary {
   margin-top: 10px; padding: 5px 12px;
   border: 1px solid #b91c1c; background: #fef2f2;
@@ -129,20 +137,24 @@ window.addEventListener('pageshow', function (e) {
 
 /* Workspace switcher (top of the left rail). */
 .viv-workspace-switcher { position: relative; padding: 0; }
-/* One dashboard per repo: the workspace name is a built-in FIXTURE — a quiet
-   caption sitting directly under the Vivarium brand. NOT a control: no box, no
-   background, no border, no hover, default cursor. Just a small status dot + the
-   repo name in muted text. */
+/* The workspace-name chip is the SOURCE SWITCHER trigger: a small status dot +
+   the current source name under the Vivarium brand. Click to switch local
+   workspace / remote build (source-switch.js opens a dropdown below it). */
 .viv-workspace-name {
-  display: flex; align-items: center; gap: 7px;
-  padding: 0 16px 10px;
-  margin: 0;
+  display: flex; align-items: flex-start; gap: 7px;
+  padding: 0 16px 10px; margin: 0;
   font-size: 12.5px; font-weight: 600;
   color: #64748b; cursor: default;
   background: none; border: none; border-radius: 0;
 }
 .viv-workspace-name strong { font-weight: 600; }
-.viv-workspace-name .viv-workspace-switcher-glyph { font-size: 8px; }
+.viv-ws-text { display: flex; flex-direction: column; min-width: 0; line-height: 1.3; }
+.viv-ws-branch { color: #94a3b8; font-weight: 400; font-size: 0.84em;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 100%; }
+.viv-ws-remote-tag { font-size: 0.7em; font-weight: 600; color: #7c3aed;
+  background: #f3e8ff; padding: 1px 5px; border-radius: 4px; vertical-align: middle; margin-left: 4px; }
+.viv-workspace-name .viv-workspace-switcher-glyph { font-size: 8px; margin-top: 4px; }
+.viv-workspace-switcher-glyph.viv-glyph-remote { color: #7c3aed; }
 .viv-workspace-switcher-glyph { color: #2ea043; font-size: 14px; }
 .viv-glyph-running { color: #2ea043; }
 /* The workspace name links to its GitHub repo; a small mark signals it. */
@@ -301,6 +313,39 @@ window.addEventListener('pageshow', function (e) {
   display: flex; align-items: center; gap: 8px;
 }
 .viv-iset-menu-row-title { flex: 1; font-size: 13px; color: #111827; }
+.viv-branch-source { padding: 4px 0 16px; max-width: 640px; }
+.viv-bs-title { font-size: 15px; margin: 0 0 12px; }
+.viv-bs-row { display: flex; align-items: center; gap: 10px; margin: 8px 0; }
+.viv-bs-key { width: 64px; color: #6b7280; font-size: 13px; }
+.viv-bs-select, .viv-bs-commit-select { padding: 4px 8px; border: 1px solid #d0d7de; border-radius: 6px; font-size: 13px; }
+.viv-bs-toggle { padding: 4px 12px; border: 1px solid #d0d7de; background: #fff; cursor: pointer; border-radius: 6px; font-size: 13px; }
+.viv-bs-toggle.active { background: #eef4ff; border-color: #94b4ff; color: #1e40af; }
+.viv-bs-commit { font-family: ui-monospace, monospace; font-size: 13px; }
+.viv-bs-current { color: #1e40af; font-weight: 600; font-size: 12px; }
+.viv-bs-actions { display: flex; gap: 8px; margin: 14px 0; }
+.viv-bs-action { padding: 6px 14px; border: 1px solid #d0d7de; background: #fff; border-radius: 6px; cursor: pointer; font-size: 13px; }
+.viv-bs-action:disabled { opacity: 0.45; cursor: default; }
+.viv-bs-note { color: #b45309; font-size: 12px; margin: 6px 0; }
+.viv-bs-list { list-style: none; margin: 10px 0 0; padding: 0; border-top: 1px solid #f3f4f6; }
+.viv-bs-list-row { display: flex; align-items: center; gap: 8px; padding: 6px 4px; border-bottom: 1px solid #f3f4f6; font-size: 13px; }
+.viv-bs-list-row.current { background: #eef4ff; }
+.viv-bs-list-label { flex: 1; }
+.viv-bs-list-label:hover { color: #0366d6; }
+.viv-bs-forget { border: none; background: none; cursor: pointer; color: #c0c4cc; }
+.viv-bs-forget:hover { color: #d1242f; }
+.viv-bs-search { width: 100%; max-width: 420px; margin: 10px 0 0; padding: 5px 9px;
+  border: 1px solid #d0d7de; border-radius: 6px; font-size: 13px; box-sizing: border-box; }
+.viv-bs-list-empty { padding: 8px 4px; color: #9ca3af; font-size: 13px; }
+.viv-bs-busy { margin: 8px 0; padding: 6px 10px; font-size: 12px; color: #1e40af;
+  background: #eef4ff; border: 1px solid #c7d7fe; border-radius: 6px; }
+.viv-iset-menu-forget {
+  flex: 0 0 auto; border: none; background: none; cursor: pointer;
+  color: #c0c4cc; font-size: 12px; line-height: 1; padding: 2px 4px;
+  border-radius: 4px; opacity: 0; transition: opacity 0.1s, color 0.1s, background 0.1s;
+}
+.viv-iset-menu-row:hover .viv-iset-menu-forget,
+.viv-iset-menu-row:focus-within .viv-iset-menu-forget { opacity: 1; }
+.viv-iset-menu-forget:hover { color: #d1242f; background: #ffebe9; }
 .viv-iset-menu-row-pill {
   font-size: 0.7em !important;
   padding: 1px 7px !important;
@@ -346,7 +391,7 @@ window.addEventListener('pageshow', function (e) {
 
     <!-- Brand: fixed Vivarium logo + name (no per-workspace icon/name override). -->
     <div class="viv-rail-header">
-      <img class="viv-rail-logo" src="assets/vivarium-logo.png?v=1781620843_1781453160" alt="Vivarium" loading="lazy">
+      <img class="viv-rail-logo" src="assets/vivarium-logo.png?v=1782865225_1782865225" alt="Vivarium" loading="lazy">
       <div class="viv-rail-brand">
         <strong>Vivarium</strong>
         <small>dashboard</small>
@@ -359,25 +404,32 @@ window.addEventListener('pageshow', function (e) {
     
 
     <div class="viv-workspace-switcher" id="viv-workspace-switcher">
-      <!-- One dashboard per repo: the workspace name IS the link to the
-           associated GitHub repository (git remote origin). -->
-      <div class="viv-workspace-name">
+      <!-- The workspace-name chip opens the Branch page (#github): source,
+           repo/branch/commit, push & build actions. Replaces the old rail
+           dropdown and the standalone Branch rail item. -->
+      <div class="viv-workspace-name" role="button" tabindex="0"
+           title="Open Branch: source, repo · branch · commit, push & build"
+           style="cursor:pointer"
+           onclick="window.location.hash='#github'; if(window._switchPage)_switchPage('github');"
+           onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault(); window.location.hash='#github'; if(window._switchPage)_switchPage('github');}">
         <span class="viv-workspace-switcher-glyph">●</span>
-        
-        <a class="viv-ws-repo-link" href="https://github.com/vivarium-collective/v2ecoli" target="_blank" rel="noopener"
-           title="Open v2ecoli on GitHub">
+        <span class="viv-ws-text">
           <strong>v2ecoli</strong>
-          <svg class="viv-ws-gh-mark" width="12" height="12"><use href="#viv-gh-mark"/></svg>
-        </a>
-        
+          <span class="viv-ws-branch" title="dashboard-demo">dashboard-demo</span>
+        </span>
       </div>
     </div>
     <!-- Snapshot mode: static repo label replaces the switcher dropdown. -->
-    <div class="viv-repo-label" id="snapshot-repo-label" style="display:none">
+    <div class="viv-repo-label" id="snapshot-repo-label" style="display:none;cursor:pointer"
+         role="button" tabindex="0"
+         title="Open Source — switch workspace"
+         onclick="window.location.hash='#github'; if(window._switchPage)_switchPage('github');"
+         onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault(); window.location.hash='#github'; if(window._switchPage)_switchPage('github');}">
       <span class="viv-workspace-switcher-glyph">●</span>
+      <strong>v2ecoli</strong>
       
       <a class="viv-ws-repo-link" href="https://github.com/vivarium-collective/v2ecoli" target="_blank" rel="noopener"
-         title="Open v2ecoli on GitHub"><strong>v2ecoli</strong>
+         title="Open v2ecoli on GitHub" onclick="event.stopPropagation()">
         <svg class="viv-ws-gh-mark" width="12" height="12"><use href="#viv-gh-mark"/></svg></a>
       
     </div>
@@ -482,24 +534,9 @@ window.addEventListener('pageshow', function (e) {
         </span>
         <span class="viv-rail-link-label">Analyses</span>
       </a>
-      <!-- Branch: workspace branch + remote (formerly "GitHub"). The icon
-           is a branch-and-node glyph; renaming the label to "Branch"
-           better reflects that this tab is about the local branch state,
-           the workspace repo's remote, and PR/merge actions — not just
-           GitHub-the-product. Hash route #github kept for back-compat
-           with bookmarks. -->
-      <a href="#github"            class="viv-rail-link menu-link" data-page="github">
-        <span class="viv-rail-link-icon">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round" class="viv-rail-link-svg">
-            <circle cx="6" cy="6" r="2"/>
-            <circle cx="6" cy="18" r="2"/>
-            <circle cx="18" cy="12" r="2"/>
-            <path d="M6 8v8"/>
-            <path d="M6 8a6 6 0 0 0 6 6h4"/>
-          </svg>
-        </span>
-        <span class="viv-rail-link-label">Branch</span>
-      </a>
+      <!-- The Branch page (#github) is no longer a rail item — it's reached by
+           clicking the workspace source display at the top of the rail (see
+           #viv-workspace-switcher). Hash route #github kept for back-compat. -->
     </nav>
 
     <!-- Studies of the active investigation, dependency-ordered. -->
@@ -522,14 +559,14 @@ window.addEventListener('pageshow', function (e) {
     
     
     
-    <a class="viv-rail-footer viv-rail-footer-link" href="https://github.com/eagmon" target="_blank" rel="noopener" title="Open eagmon on GitHub ↗">
+    <a class="viv-rail-footer viv-rail-footer-link" href="https://github.com/AlexPatrie" target="_blank" rel="noopener" title="Open AlexPatrie on GitHub ↗">
     
       
-        <img class="viv-avatar viv-avatar-rail viv-avatar-img" src="https://avatars.githubusercontent.com/u/6809431?v=4" alt="eagmon" loading="lazy" referrerpolicy="no-referrer">
+        <img class="viv-avatar viv-avatar-rail viv-avatar-img" src="https://avatars.githubusercontent.com/u/105522603?v=4" alt="AlexPatrie" loading="lazy" referrerpolicy="no-referrer">
       
       <div class="viv-rail-footer-text">
-        <strong>Eran Agmon</strong>
-        <small>@eagmon</small>
+        <strong>A.P.</strong>
+        <small>@AlexPatrie</small>
       </div>
     
     </a>
@@ -660,7 +697,7 @@ window.addEventListener('pageshow', function (e) {
 
   <!-- Subtab: Modules (catalog grid; workspace + installed entries pinned at top) -->
   <section class="panel registry-subtab-panel active" data-subtab="modules">
-    <p class="panel-lead">Modules active in this workspace appear at the top (the workspace's own first-party package is pinned first, then installed catalog modules). Click Install on any card below to add it. Each installed card carries an Uninstall affordance + its source / path.</p>
+    <p class="panel-lead">Modules active in this workspace appear at the top (the workspace's own first-party package is pinned first, then installed catalog modules). Click Install on any card below to add it. Each installed card shows its install source + path.</p>
     <div class="card-browse-toolbar" id="catalog-toolbar">
       <input type="search" class="card-browse-search" id="catalog-search" placeholder="Filter modules…">
       <div class="card-browse-chips" id="catalog-tag-chips"></div>
@@ -691,6 +728,9 @@ window.addEventListener('pageshow', function (e) {
     <button class="action-btn" onclick="_loadRegistry(true)">Refresh registry</button>
     <div id="registry-status" class="muted" style="margin:8px 0"></div>
 
+    <!-- "Imported repositories" was removed: those repos are already shown in
+         the Modules tab, so duplicating them under Discovered registry was noise. -->
+
     <div class="registry-tabs">
       <button class="registry-tab active" data-kind="process"       onclick="_setRegistryTab('process')">Processes <span class="count-badge" id="registry-process-count"></span></button>
       <button class="registry-tab"        data-kind="step"          onclick="_setRegistryTab('step')">Steps <span class="count-badge" id="registry-step-count"></span></button>
@@ -716,14 +756,16 @@ window.addEventListener('pageshow', function (e) {
   <div style="display:flex;align-items:center;justify-content:space-between;gap:12px">
     <h2 class="page-title" style="margin:0">Investigations</h2>
     <div style="display:flex;gap:8px;align-items:center">
-      <!-- "Switch investigation" + "+ New Investigation" actions now live in
-           the left-rail investigation switcher dropdown (top of the rail). -->
+      <input id="investigations-filter" type="search" placeholder="Filter investigations…"
+             aria-label="Filter investigations" oninput="_filterInvestigations()"
+             style="padding:5px 10px;border:1px solid #d1d5db;border-radius:6px;font-size:0.9em;min-width:220px">
     </div>
   </div>
-  <p class="page-lead" id="investigation-page-lead">All investigations in this repo. Select one to open it — its studies appear in the left rail. Merged investigations are preserved as artifacts; in-progress ones live on their branch/PR.</p>
+  <p class="page-lead" id="investigation-page-lead">Select an investigation to open its study graph.</p>
 
-  <!-- List view: investigation cards. -->
-  <div id="investigations-list" class="investigations-list-grid" style="display:grid; grid-template-columns: repeat(auto-fit, minmax(360px, 1fr)); gap:12px;">
+  <!-- List view: grouped investigation cards (Active / Closed). The grid lives on
+       the per-group .investigations-grid wrappers built by _renderInvestigationSets. -->
+  <div id="investigations-list">
     <p class="empty-state">Loading…</p>
   </div>
 
@@ -808,43 +850,47 @@ window.addEventListener('pageshow', function (e) {
     <div style="display:flex; align-items:center; gap:12px; margin-bottom:8px;">
       <h3 id="investigation-detail-title" style="margin:0; flex:1"></h3>
       <span id="investigation-detail-status" class="status-pill planned" style="font-size:0.85em"></span>
-      <span class="viv-info-chip" data-tooltip="Run unblocked &mdash; queue every variant whose model_settings don&#39;t have any unset &#39;required-before-run&#39; gates. Sequential, one variant at a time on a background thread.&#10;&#10;Refresh &mdash; re-fetch the investigation from disk. Use after editing YAML files directly.&#10;&#10;Generate report &mdash; self-contained HTML report you can email.&#10;&#10;Clone &mdash; copy this investigation into a fresh planning state with no run results.">?</span>
-      <button class="btn-mini" id="investigation-detail-refresh" onclick="_refreshInvestigationDetail()" title="Re-fetch the investigation + its studies from disk. Use after editing YAML files directly (which the dashboard can't see otherwise).">↻ Refresh</button>
-      <button class="btn-mini" id="investigation-run-unblocked" onclick="_runUnblockedSimulations()" title="Run every variant whose model_settings don't have any unset 'required-before-run' gates. Sequential — one variant at a time on a background thread. Progress shown in the panel below.">▶ Run unblocked</button>
-      <button class="btn-mini" onclick="_generateInvestigationReport()" title="Generate a shareable HTML report (self-contained, attach to email)">Generate report 📄</button>
-      <button class="btn-mini" onclick="_openCloneIsetModal()" title="Clone this investigation into a fresh planning state (no run results). Useful for a parallel attempt or a demo fixture.">Clone ⎘</button>
+      <span class="inv-export-actions" style="display:inline-flex; gap:6px">
+        <button class="btn-mini" onclick="_generateInvestigationReport()" title="Generate a shareable HTML report (self-contained, attach to email)">Report 📄</button>
+        <button class="btn-mini" onclick="_downloadInvestigationNotebook()" title="Download a self-contained Jupyter notebook (+ matching .py) that re-runs this investigation's studies via the process-bigraph protocol and renders their figures. The coder-facing complement to the HTML report.">Notebook 📓</button>
+      </span>
+      <button class="btn-mini" id="investigation-detail-refresh" onclick="_refreshInvestigationDetail()" title="Re-fetch the investigation + its studies from disk. Use after editing YAML files directly (which the dashboard can't see otherwise).">↻</button>
+      <span class="viv-info-chip" data-tooltip="Report &mdash; self-contained HTML report you can email.&#10;&#10;Notebook &mdash; a self-contained Jupyter notebook (+ matching .py) that re-runs the studies and renders their figures.&#10;&#10;Refresh (↻) &mdash; re-fetch the investigation from disk after editing YAML directly.">?</span>
     </div>
     <!-- Run-progress panel: rendered while a run-unblocked job is active. -->
     <div id="investigation-run-progress" class="inv-run-progress" style="display:none"></div>
 
+    <!-- Needs-attention elevated: a distinct, actionable banner directly below the
+         header. Populated by JS from /api/needs-attention; renders nothing when empty. -->
+    <div id="investigation-needs-attention"></div>
+
     <div id="investigation-intro" class="inv-intro" style="margin: 0 0 16px 0;">
-      <!-- Lead paragraph (the abstract). Auto-styled as serif body type for readability. -->
-      <div id="investigation-detail-description" class="inv-lead"></div>
-      <!-- At-a-glance grid: one tile per study with a one-line role. Populated by JS. -->
-      <div id="investigation-at-a-glance" class="inv-at-a-glance" style="display:none"></div>
-      <!-- How to read this: ordered list of usage tips for the evaluator. -->
-      <details id="investigation-how-to-read" class="inv-how-to-read" style="display:none">
-        <summary>How to read this</summary>
-        <ol></ol>
+      <!-- Single "About" disclosure (open by default): the lead/abstract, then any
+           supplementary context as labeled sub-blocks. Each sub-block keeps its id +
+           inner <ol>/<dl> so the existing render functions populate it unchanged; JS
+           toggles their display, so they stay hidden when the yaml omits them. -->
+      <details id="investigation-intro-details" class="inv-lead-details" open>
+        <summary>About this investigation</summary>
+        <div id="investigation-detail-description" class="inv-lead" style="margin-top:6px"></div>
+        <div id="investigation-how-to-read" class="inv-how-to-read" style="display:none; margin-top:12px">
+          <h4 class="inv-subhead">How to read this</h4>
+          <ol></ol>
+        </div>
+        <div id="investigation-glossary" class="inv-glossary" style="display:none; margin-top:12px">
+          <h4 class="inv-subhead">Glossary</h4>
+          <dl></dl>
+        </div>
+        <div id="investigation-biology-story" class="inv-bio-story" style="display:none; margin-top:12px">
+          <h4 class="inv-subhead inv-bio-story-label">Biology — the mechanism this investigation models</h4>
+          <div id="investigation-biology-story-text" class="inv-bio-story-text"></div>
+        </div>
       </details>
-      <!-- Glossary: collapsible. -->
-      <details id="investigation-glossary" class="inv-glossary" style="display:none">
-        <summary>Glossary</summary>
-        <dl></dl>
-      </details>
-      <!-- Biology story (free-form prose). Hidden if the yaml omits it. -->
-      <details id="investigation-biology-story" class="inv-bio-story" style="display:none">
-        <summary class="inv-bio-story-label">Biology — the mechanism this investigation models</summary>
-        <div id="investigation-biology-story-text" class="inv-bio-story-text"></div>
-      </details>
-      <!-- SP5: Needs-attention panel. Populated by JS from /api/needs-attention. -->
-      <div id="investigation-needs-attention"></div>
     </div>
     <!-- Discourse-graph framing: studies as knowledge-producing operations. -->
     <div id="investigation-dag-lead" style="margin: 4px 0 8px; font-size: 0.88em; color: #475569; line-height: 1.4;">
-      <strong>Investigation graph</strong> — each study is a knowledge-producing operation that
-      builds understanding of the mechanism. Each node shows the <em>question</em> it asks and
-      the <em>evidence</em> it produced; edges show what a result leads to.
+      <strong>Investigation graph</strong>
+      <span class="viv-info-chip" data-tooltip="Each study is a knowledge-producing operation that builds understanding of the mechanism. Each node shows the question it asks and the evidence it produced; edges show what a result leads to.">?</span>
+      — nodes are studies; edges show what each result leads to.
     </div>
     <div id="investigation-dag-shell"
          style="position: relative; border: 1px solid #e2e8f0; border-radius: 6px; background: #fafafa;
@@ -856,6 +902,11 @@ window.addEventListener('pageshow', function (e) {
            DAG fits and the parent .viv-content handles vertical scroll. -->
       <svg id="investigation-dag-edges" style="position:absolute; top:0; left:0; pointer-events:none;"></svg>
       <div id="investigation-dag-nodes" style="position:relative; top:0; left:0;"></div>
+    </div>
+
+    <div id="investigation-detail-drawer" style="display:none; position:fixed; top:96px; right:16px; width:360px; max-height:78vh; overflow:auto; background:#fff; border:1px solid #e2e8f0; border-radius:12px; box-shadow:0 8px 30px rgba(0,0,0,0.12); padding:14px 16px; z-index:50; font-size:0.92em">
+      <button onclick="document.getElementById('investigation-detail-drawer').style.display='none'" style="float:right;border:none;background:none;cursor:pointer;font-size:1.15em;color:#94a3b8" title="Close">✕</button>
+      <div id="investigation-detail-drawer-body"></div>
     </div>
 
     <!-- In-place study embed: when a DAG node is clicked, the full study
@@ -883,6 +934,7 @@ window.addEventListener('pageshow', function (e) {
 <!-- GitHub: in-UI sign-in + (future) org picker. The github-login.js widget
      activates the #viv-gh-chip element on load. No-AI-agent setup path. -->
 <section id="page-github" class="page" data-page="github">
+  <div id="viv-branch-source" class="viv-branch-source"></div>
   <h2 class="page-title">Branch</h2>
 
   <!-- Settings-style single panel: three sections (Account, Workspace
@@ -1049,14 +1101,21 @@ window.addEventListener('pageshow', function (e) {
 <section id="page-simulations" class="page" data-page="simulations">
   <h2 class="page-title">Simulations DB</h2>
   <p class="page-lead">
-    Every persisted run across this workspace, tagged by investigation and
-    study, gathered from each <code>studies/&lt;name&gt;/runs.db</code>.
-    Shows all investigations by default — untoggle to scope to the current one.
+    Persisted runs gathered from each <code>studies/&lt;name&gt;/runs.db</code>,
+    tagged by investigation and study, with the storage location for each run.
+    On a remote build, the deployment's runs for that build's commit are
+    included too (Origin column). Scoped to the current branch's investigation
+    by default and refreshed automatically.
+    <span id="sim-scope-note" style="color:#6b7280;"></span>
   </p>
 
   <div style="margin: 8px 0 12px; display: flex; gap: 12px; align-items: center; flex-wrap: wrap;">
     <label style="display:flex; align-items:center; gap:6px; font-size:13px;">
-      <input id="sim-all-toggle" type="checkbox" checked /> All investigations
+      Investigation
+      <select id="sim-inv-filter" style="padding:4px 8px; font-size:13px;
+              border:1px solid #d1d5db; border-radius:4px;">
+        <option value="">All</option>
+      </select>
     </label>
     <label style="display:flex; align-items:center; gap:6px; font-size:13px;">
       Study
@@ -1080,16 +1139,18 @@ window.addEventListener('pageshow', function (e) {
     No simulation runs found.
   </div>
 
-  <table id="sim-table" style="width:100%; border-collapse: collapse; font-size: 13px; display: none;">
+  <table id="sim-table" style="width:100%; table-layout:fixed; border-collapse: collapse; font-size: 13px; display: none;">
     <thead>
       <tr style="background:#f3f4f6;">
-        <th style="text-align:left; padding:6px 8px;">Investigation</th>
-        <th style="text-align:left; padding:6px 8px;">Study</th>
+        <th style="text-align:left; padding:6px 8px; width:130px;">Investigation</th>
+        <th style="text-align:left; padding:6px 8px; width:130px;">Study</th>
         <th style="text-align:left; padding:6px 8px;">Run</th>
-        <th style="text-align:left; padding:6px 8px; width:90px;">Emitter</th>
-        <th style="text-align:left; padding:6px 8px; width:140px;">Time</th>
-        <th style="text-align:left; padding:6px 8px; width:90px;">Status</th>
-        <th style="text-align:center; padding:6px 8px; width:120px;">Actions</th>
+        <th style="text-align:left; padding:6px 8px; width:150px;">Location</th>
+        <th style="text-align:left; padding:6px 8px; width:90px;">Origin</th>
+        <th style="text-align:left; padding:6px 8px; width:80px;">Emitter</th>
+        <th style="text-align:left; padding:6px 8px; width:104px;">Time</th>
+        <th style="text-align:left; padding:6px 8px; width:84px;">Status</th>
+        <th style="text-align:center; padding:6px 8px; width:96px;">Actions</th>
       </tr>
     </thead>
     <tbody id="sim-tbody"></tbody>
@@ -1217,21 +1278,34 @@ window.addEventListener('pageshow', function (e) {
       <p><strong>Module:</strong> <code id="ce-module"></code> <span id="ce-kind" class="kind-badge"></span></p>
     </div>
 
-    <!-- Loom-explore iframe — internal View/Run/Document tabs live inside -->
-    <div class="panel">
-      <div class="loom-frame-toolbar" style="display:flex;justify-content:flex-end;margin-bottom:6px">
-        <button class="btn-mini" onclick="_popoutLoom('composite-explore-frame')" title="Open in a separate window. If it opens as a tab, your browser's 'open new pages as tabs' preference is overriding the popup hint (Safari → Tabs → 'Open pages in tabs instead of windows' → set to 'Manually').">Pop out &#8599;</button>
+    <!-- Explorer view tabs: Wiring viewer | Configure & Run -->
+    <nav class="ce-page-tabs" aria-label="Composite views">
+      <button type="button" class="ce-page-tab active" data-cepanel="viewer" onclick="_ceShowPanel('viewer')">Wiring viewer</button>
+      <button type="button" class="ce-page-tab" data-cepanel="configure" onclick="_ceShowPanel('configure')">&#9881; Configure &amp; Run</button>
+    </nav>
+
+    <!-- Wiring viewer panel: the loom-explore iframe (internal View/Run/Document tabs live inside) -->
+    <div class="ce-page-panel" data-cepanel="viewer">
+      <div class="panel">
+        <div class="loom-frame-toolbar" style="display:flex;justify-content:flex-end;margin-bottom:6px">
+          <button class="btn-mini" onclick="_popoutLoom('composite-explore-frame')" title="Open in a separate window. If it opens as a tab, your browser's 'open new pages as tabs' preference is overriding the popup hint (Safari → Tabs → 'Open pages in tabs instead of windows' → set to 'Manually').">Pop out &#8599;</button>
+        </div>
+        <iframe id="composite-explore-frame"
+                src="/bigraph-loom/index.html"
+                title="Composite Explorer"
+                style="width:100%;height:720px;border:1px solid #ddd;background:#fff"></iframe>
       </div>
-      <iframe id="composite-explore-frame"
-              src="/bigraph-loom/index.html"
-              title="Composite Explorer"
-              style="width:100%;height:720px;border:1px solid #ddd;background:#fff"></iframe>
     </div>
 
-    <!-- Post-run actions: shown after a successful test run via explore:run-complete postMessage -->
-    <div id="ce-post-run-bar" style="display:none;margin-top:8px;padding:12px 16px;background:#f0fdf4;border:1px solid #bbf7d0;border-radius:6px;align-items:center;gap:12px">
-      <span style="flex:1;color:#166534;font-size:0.9em">Run complete. Save this run as a Study to track variants and conclusions.</span>
-      <button id="save-as-study-btn" class="action-btn" onclick="_ceOpenSaveAsStudyModal()" style="background:#16a34a;border-color:#16a34a">Save as Study</button>
+    <!-- Configure & Run panel -->
+    <div class="ce-page-panel" data-cepanel="configure" hidden>
+      <!-- Post-run actions: shown after a successful test run via explore:run-complete postMessage -->
+      <div id="ce-post-run-bar" style="display:none;margin-bottom:14px;padding:12px 16px;background:#f0fdf4;border:1px solid #bbf7d0;border-radius:6px;align-items:center;gap:12px">
+        <span style="flex:1;color:#166534;font-size:0.9em">Run complete. Save this run as a Study to track variants and conclusions.</span>
+        <button id="save-as-study-btn" class="action-btn" onclick="_ceOpenSaveAsStudyModal()" style="background:#16a34a;border-color:#16a34a">Save as Study</button>
+      </div>
+      <!-- Configure & Run widget (SP-C) — mounts when a composite is resolved -->
+      <div id="ce-configure-run"></div>
     </div>
 
   </div>
@@ -1449,26 +1523,6 @@ window.addEventListener('pageshow', function (e) {
   </div>
 </div>
 
-<!-- Phase plan modal -->
-<div id="modal-phase-plan" class="modal-overlay">
-  <div class="modal-box" style="max-width:640px">
-    <button class="modal-close" onclick="closeModal('modal-phase-plan')">&times;</button>
-    <h3>Add phase plan</h3>
-    <p style="font-size:0.85em;color:#555">
-      Enter phases as JSON. Each phase needs <code>n</code> (integer) and <code>name</code> (string).
-      Optional: <code>objective</code>, <code>prereq_phases</code>, <code>acceptance_tests</code>.
-    </p>
-    <label>Phases JSON *
-      <textarea id="phase-plan-json" style="width:100%;min-height:180px;font-family:monospace;font-size:0.88em;border:1px solid #ccc;border-radius:4px;padding:8px;box-sizing:border-box"
-        placeholder='[{"n": 1, "name": "Baseline", "objective": "Establish replication initiation baseline"}, {"n": 2, "name": "DnaA accumulation", "objective": "Add DnaA binding dynamics"}]'></textarea>
-    </label>
-    <div class="form-error" id="phase-plan-error"></div>
-    <div style="margin-top:10px;display:flex;gap:8px">
-      <button class="action-btn" style="background:#1976d2;color:#fff;border-color:#1976d2" onclick="submitPhasePlan()">Submit phase plan</button>
-      <button class="action-btn" onclick="closeModal('modal-phase-plan')">Cancel</button>
-    </div>
-  </div>
-</div>
 
 <!-- Modal: Link to upstream branch -->
 <div id="modal-link-branch" class="modal-overlay">
@@ -1589,13 +1643,49 @@ Nothing on <code id="pr-base-display-2">main</code> changes until someone presse
 <script src="assets/data-source.js"></script>
 <script src="assets/render-helpers.js"></script>
 <script src="assets/client.js" onerror="/* live mode unavailable */"></script>
-<script src="assets/walkthrough.js?v=1781620843_1781453160" onerror="/* walkthrough unavailable */"></script>
-<script src="assets/github-login.js?v=1781620843_1781453160" onerror="/* github-login unavailable */"></script>
+<script src="assets/aig-graph.js?v=1782865225_1782865225" onerror="/* aig-graph unavailable */"></script>
+<script src="assets/walkthrough.js?v=1782865225_1782865225" onerror="/* walkthrough unavailable */"></script>
+<script src="assets/explorer.js?v=1782865225_1782865225" onerror="/* explorer unavailable */"></script>
+<script src="assets/explorer-views.js?v=1782865225_1782865225" onerror="/* explorer views unavailable */"></script>
+<script src="assets/github-login.js?v=1782865225_1782865225" onerror="/* github-login unavailable */"></script>
 <!-- workspace-switcher.js is intentionally not loaded: the left-rail dropdown
      it used to drive has been repurposed into the investigation switcher
      (investigation-switcher.js). The /api/workspaces endpoints remain available
      for CLI tooling. -->
 <script src="assets/investigation-switcher.js"></script>
+<script src="assets/branch-source.js?v=1782865225_1782865225"></script>
+<script src="assets/configure-run.js?v=1782865225_1782865225" onerror="/* configure-run unavailable */"></script>
+<script>
+// Configure & Run widget integration for Composite Explorer.
+// Wraps _initCompositeExplorer (defined in walkthrough.js) to mount the widget
+// once a composite is resolved and the explorer page is shown.
+(function() {
+  // Switch the explorer between the wiring-viewer panel and the Configure & Run panel.
+  window._ceShowPanel = function(name) {
+    document.querySelectorAll('.ce-page-tab').forEach(function (b) {
+      b.classList.toggle('active', b.getAttribute('data-cepanel') === name);
+    });
+    document.querySelectorAll('.ce-page-panel').forEach(function (p) {
+      p.hidden = (p.getAttribute('data-cepanel') !== name);
+    });
+  };
+
+  var _origInit = window._initCompositeExplorer;
+  window._initCompositeExplorer = function() {
+    if (_origInit) _origInit.apply(this, arguments);
+    var params = new URLSearchParams(window.location.search);
+    var id = params.get('id');
+    var el = document.getElementById("ce-configure-run");
+    if (el && window.ConfigureRun && id) {
+      ConfigureRun.mount(el, { composite: id, target: "adhoc" });
+    }
+    // Arriving via a "Configure & Run" button opens that tab directly;
+    // otherwise default to the wiring viewer.
+    window._ceShowPanel(window._ceScrollToConfigure ? 'configure' : 'viewer');
+    window._ceScrollToConfigure = false;
+  };
+})();
+</script>
 <script>
 // Initialize drop zones once walkthrough.js is loaded.
 document.addEventListener("DOMContentLoaded", function() {
@@ -1735,78 +1825,6 @@ function _submitVisualization(form) {
   });
 }
 
-// Phase plan submission.
-function submitPhasePlan() {
-  var errEl = document.getElementById("phase-plan-error");
-  if (errEl) errEl.textContent = "";
-  var raw = document.getElementById("phase-plan-json").value.trim();
-  var phases;
-  try {
-    phases = JSON.parse(raw);
-  } catch (e) {
-    if (errEl) errEl.textContent = "Invalid JSON: " + e.message;
-    return;
-  }
-  if (!Array.isArray(phases) || !phases.length) {
-    if (errEl) errEl.textContent = "phases must be a non-empty JSON array";
-    return;
-  }
-  fetch("/api/phase-plan", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ phases: phases }),
-  })
-    .then(function(res) { return res.json().then(function(j) { return { ok: res.ok, json: j }; }); })
-    .then(function(r) {
-      if (!r.ok) {
-        if (errEl) errEl.textContent = "Error: " + (r.json.error || "unknown");
-        return;
-      }
-      fetch("/api/render", { method: "POST" }).finally(function() {
-        alert("Phase plan created!\nBranch: " + (r.json.branch || "") + "\nMerge it to make phases appear on main.");
-        location.reload();
-      });
-    })
-    .catch(function(err) {
-      if (errEl) errEl.textContent = "Network error: " + String(err);
-    });
-}
-
-// Phase start.
-function phaseStart(n) {
-  fetch("/api/phase-start", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ n: n }),
-  })
-    .then(function(res) { return res.json().then(function(j) { return { ok: res.ok, json: j }; }); })
-    .then(function(r) {
-      if (!r.ok) { alert("Error: " + (r.json.error || "unknown")); return; }
-      fetch("/api/render", { method: "POST" }).finally(function() {
-        alert("Phase " + n + " started!\nBranch: " + (r.json.branch || ""));
-        location.reload();
-      });
-    })
-    .catch(function(err) { alert("Network error: " + err); });
-}
-
-// Phase gate.
-function phaseGate(n) {
-  fetch("/api/phase-gate", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ n: n }),
-  })
-    .then(function(res) { return res.json().then(function(j) { return { ok: res.ok, json: j }; }); })
-    .then(function(r) {
-      if (!r.ok) { alert("Error: " + (r.json.error || "unknown")); return; }
-      fetch("/api/render", { method: "POST" }).finally(function() {
-        alert("Gate evaluated for phase " + n + ": " + (r.json.gate_status || "?") + "\nBranch: " + (r.json.branch || ""));
-        location.reload();
-      });
-    })
-    .catch(function(err) { alert("Network error: " + err); });
-}
 
 // Run tests.
 function runTests() {


### PR DESCRIPTION
## Summary

Adds a comprehensive, self-contained presenter demo of vivarium-workbench against the v2ecoli workspace — **zero modifications to existing v2ecoli code**.

## What's included

### Demo scripts (`demos/dashboard/`, 8 files)

| File | Purpose |
|------|---------|
| `WALKTHROUGH.md` | 8-segment presenter walkthrough (455 lines) with API references, narration scripts, timing, Q&A, troubleshooting, and presenter quick-reference card |
| `PLAN.md` | Full demo plan — presenter script (~20 min) + self-guided guide (~45 min) |
| `README.md` | Overview, quick start, file layout, decoupling principle |
| `verify_demo.py` | 39-check pre-flight verification (all packages, composites, studies, fixtures, DB) |
| `populate_demo_runs.py` | Seeds 16 synthetic runs in Simulations DB (3 emitters, 3 remote ☁️, status variety) |
| `prep_remote_build.py` | Registers and polls sms-api Docker build (with re-polling fix for timeouts) |
| `prep_remote_land.py` | Submits, polls, downloads, and lands a remote sms-api run for the Simulations DB |
| `.gitignore` | Excludes `.demo_state.json`, `demo-runs/`, `downloads/` |

### reports/index.html update

Adds CDN scripts (d3, d3-voronoi, escher), remote-origin pill CSS, and workspace-source-switcher UI to the dashboard reports page.

## Demo flow (8 segments, ~20 min)

| Segment | What | Key number |
|---------|------|------------|
| 1. Introduction | Dashboard home, 3-layer architecture | — |
| 2. Registry | Simulator agnosticism | 11 packages, 173 processes |
| 3. Composites | Cell-engine swappability | 28 composites, 3 cell engines |
| 4. ParCa | Modular pipeline | 43 state entries, 9 Steps |
| 5. Investigations | Research DAG with gates | 8 investigations |
| 6. Simulations DB | Full provenance, remote ☁️ runs | 51 runs, 3 emitters |
| 7. Analyses | Visualization gallery | 58 viz classes |
| 8. Wrap-up | Architecture pillars recap | — |

## Live verification

All 8 segments verified against live dashboard server. 39/39 checks pass. Key claims in WALKTHROUGH.md confirmed against API responses. Minor count drift (173 vs 174 processes, 28 vs 30 composites, 51 vs 52 runs) consistent with branch/workspace variance.

## Remote run

A real remote sms-api run (simulation #205, AWS GovCloud, `smsvpctest` stack) was landed and is now in `.pbg/composite-runs.db` with full provenance (simulation_id, experiment_id, backend=ray, s3_uri).

## Decoupling

**No existing v2ecoli files modified.** Demo artifacts consume existing composites, studies, and investigations read-only. Generated state lives in `.pbg/composite-runs.db` (already gitignored) and `demos/dashboard/.demo_state.json` (demo `.gitignore`).

## Session speaker materials (NOT committed)

`demos/dashboard/speaker/` contains a 389-line speaker narration script and a 12-slide Reveal.js HTML deck synchronized with the walkthrough. These are local-only presenter aids.