### PR TITLE
chore: rename stale vivarium-dashboard references to vivarium-workbench

### DIFF
--- a/.github/workflows/publish-dashboard.yml
+++ b/.github/workflows/publish-dashboard.yml
@@ -68,7 +68,7 @@ jobs:
         # loom already satisfies the `@main` git spec), so the snapshot would
         # ship a stale loom UI. Force loom@main too.
         run: |
-          uv pip install --reinstall-package vivarium-workbench "vivarium-workbench @ git+https://github.com/vivarium-collective/vivarium-dashboard.git@main"
+          uv pip install --reinstall-package vivarium-workbench "vivarium-workbench @ git+https://github.com/vivarium-collective/vivarium-workbench.git@main"
           uv pip install --reinstall-package bigraph-loom "bigraph-loom @ git+https://github.com/vivarium-collective/bigraph-loom.git@main"
 
       - name: Build dashboard snapshot

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Two things follow from that:
 - **The repository is a pbg research workspace.** Alongside the model code live
   **investigations** (a research question) and **studies** (the simulations that
   answer it) — browsable and runnable in the
-  [vivarium-workbench](https://github.com/vivarium-collective/vivarium-dashboard).
+  [vivarium-workbench](https://github.com/vivarium-collective/vivarium-workbench).
   Investigations live under `workspace/investigations/` (baseline showcase,
   PDMP, colonies, and more), each publishing a self-contained
   [investigation report](#explore-v2ecoli).
@@ -60,7 +60,7 @@ There are **three** kinds of output, each from a different pipeline.
 **[→ vivarium-collective.github.io/v2ecoli/dashboard/](https://vivarium-collective.github.io/v2ecoli/dashboard/)**
 
 A read-only snapshot of the v2ecoli workspace in the
-[vivarium-workbench](https://github.com/vivarium-collective/vivarium-dashboard):
+[vivarium-workbench](https://github.com/vivarium-collective/vivarium-workbench):
 investigations & studies, the process/type **registry**, navigable **composite**
 wiring graphs (`baseline`, `parca`), and the **sources** bundle. Auto-rebuilt
 from `main` on every push. For the full interactive version (authoring, running
@@ -223,7 +223,7 @@ quantities at ports are `pint.Quantity`; the only place `Unum` survives is the
 upstream-interop bridge at `v2ecoli/library/unit_bridge.py`.
 
 **The `pbg_v2ecoli/` package** at the repo root is the *workspace* package the
-[vivarium-workbench](https://github.com/vivarium-collective/vivarium-dashboard)
+[vivarium-workbench](https://github.com/vivarium-collective/vivarium-workbench)
 uses. Its `build_core()` pre-registers the v2ecoli types **plus** the `EcoliWCM`
 bridge before composites are built (so the dashboard's subprocess runner can pass
 a fully-populated `core`). The model package (`v2ecoli/`) and the workspace
@@ -596,7 +596,7 @@ workspace.yaml     pbg workspace config
 - [bigraph-schema](https://github.com/vivarium-collective/bigraph-schema) — type system + auto-discovery
 - [pbg-superpowers](https://github.com/vivarium-collective/pbg-superpowers) — `@composite_generator`, `Visualization`
 - [pbg-emitters](https://github.com/vivarium-collective/pbg-emitters) — `ParquetEmitter`
-- [vivarium-workbench](https://github.com/vivarium-collective/vivarium-dashboard) — interactive workspace UI (reads `workspace.yaml` + `pbg_v2ecoli/`)
+- [vivarium-workbench](https://github.com/vivarium-collective/vivarium-workbench) — interactive workspace UI (reads `workspace.yaml` + `pbg_v2ecoli/`)
 - [vEcoli](https://github.com/CovertLab/vEcoli) — ParCa reference data & biology
 - [multi-cell](https://github.com/vivarium-collective/pymunk-process) — 2D colony physics
 - [3d-ecoli](https://github.com/vivarium-collective/3d-ecoli) — 3D structural model (imports v2ecoli + pbg-parsimony)

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -21,7 +21,7 @@ links into all three.
 **[→ vivarium-collective.github.io/v2ecoli/dashboard/](https://vivarium-collective.github.io/v2ecoli/dashboard/)**
 
 A **read-only** snapshot of the v2ecoli workspace rendered by the
-[vivarium-workbench](https://github.com/vivarium-collective/vivarium-dashboard)
+[vivarium-workbench](https://github.com/vivarium-collective/vivarium-workbench)
 SPA. Browse:
 
 - **Investigations & studies** — the research questions and the runs that answer
@@ -40,7 +40,7 @@ static server can host. The `publish-dashboard.yml` workflow rebuilds it from
 > The hosted version is **view-only**. For the full interactive dashboard —
 > authoring investigations, running studies, editing wiring — clone the repo and
 > run `vivarium-workbench serve` locally (see the
-> [vivarium-workbench README](https://github.com/vivarium-collective/vivarium-dashboard#readme)).
+> [vivarium-workbench README](https://github.com/vivarium-collective/vivarium-workbench#readme)).
 
 ---
 

--- a/workspace/studies/mbp-02-population-aggregation/study.yaml
+++ b/workspace/studies/mbp-02-population-aggregation/study.yaml
@@ -16,8 +16,8 @@ expert_review_status: not_requested
 
 # ─── Redesigned-v4 spine ───
 # Top-level question, conditions, and status are required by the
-# vivarium-dashboard "redesigned" v4 validator
-# (vivarium_dashboard/lib/investigations.py::_validate_study_v4_redesign).
+# vivarium-workbench "redesigned" v4 validator
+# (vivarium_workbench/lib/investigations.py::_validate_study_v4_redesign).
 # Their presence flips the loader away from the legacy "v3 + extras"
 # validator (which required `tests:` to be a mapping). Hybrid mirror
 # of the pdmp-* pattern: keep the rich v3 spec body intact + add the

--- a/workspace/studies/showcase-1-parca/study.yaml
+++ b/workspace/studies/showcase-1-parca/study.yaml
@@ -5,7 +5,7 @@ title: Rebuild the ParCa in full from the ecoli-sources flat files
 created: '2026-06-09'
 status: complete   # legacy back-compat; canonical axes below
 
-# v4 schema (vivarium_dashboard.lib.investigations._validate_study_v4_redesign):
+# v4 schema (vivarium_workbench.lib.investigations._validate_study_v4_redesign):
 #   REQUIRED top-level: schema_version, name, question, conditions, tests, status
 #   REQUIRED in conditions: baseline {composite, params}, variants [...], model_settings [...]
 # Missing any of these → dashboard marks study as "invalid".

--- a/workspace/studies/showcase-2-baseline-figures/study.yaml
+++ b/workspace/studies/showcase-2-baseline-figures/study.yaml
@@ -7,7 +7,7 @@ status: complete   # legacy back-compat; canonical axes below
 report_card_refs:
   vs_vecoli: docs/report_cards/v2ecoli-vecoli-comparison/basal/report_card_verdict.json
 
-# v4 schema (vivarium_dashboard.lib.investigations._validate_study_v4_redesign):
+# v4 schema (vivarium_workbench.lib.investigations._validate_study_v4_redesign):
 #   REQUIRED top-level: schema_version, name, question, conditions, tests, status
 #   REQUIRED in conditions: baseline {composite, params}, variants [...], model_settings [...]
 

--- a/workspace/studies/showcase-3-variant-decide/study.yaml
+++ b/workspace/studies/showcase-3-variant-decide/study.yaml
@@ -5,7 +5,7 @@ title: "Which perturbation best demonstrates v2ecoli's response — reviewers to
 created: '2026-06-09'
 status: design   # legacy back-compat; canonical axes below
 
-# v4 schema (vivarium_dashboard.lib.investigations._validate_study_v4_redesign):
+# v4 schema (vivarium_workbench.lib.investigations._validate_study_v4_redesign):
 #   REQUIRED top-level: schema_version, name, question, conditions, tests, status
 #   REQUIRED in conditions: baseline {composite, params}, variants [...], model_settings [...]
 

--- a/workspace/studies/showcase-4-variant-comparison/study.yaml
+++ b/workspace/studies/showcase-4-variant-comparison/study.yaml
@@ -5,7 +5,7 @@ title: "Five-variant perturbation sweep — which perturbation most clearly move
 created: '2026-06-12'
 status: complete   # legacy back-compat; canonical axes below
 
-# v4 schema (vivarium_dashboard.lib.investigations._validate_study_v4_redesign):
+# v4 schema (vivarium_workbench.lib.investigations._validate_study_v4_redesign):
 #   REQUIRED top-level: schema_version, name, question, conditions, tests, status
 #   REQUIRED in conditions: baseline {composite, params}, variants [...], model_settings [...]
 

--- a/workspace/studies/showcase-5-next-direction-decide/study.yaml
+++ b/workspace/studies/showcase-5-next-direction-decide/study.yaml
@@ -5,7 +5,7 @@ title: "Which direction next — deepen the strongest perturbation contrast (rev
 created: '2026-06-12'
 status: design   # legacy back-compat; canonical axes below
 
-# v4 schema (vivarium_dashboard.lib.investigations._validate_study_v4_redesign):
+# v4 schema (vivarium_workbench.lib.investigations._validate_study_v4_redesign):
 #   REQUIRED top-level: schema_version, name, question, conditions, tests, status
 #   REQUIRED in conditions: baseline {composite, params}, variants [...], model_settings [...]
 

--- a/workspace/studies/showcase-6-equivalence-large/study.yaml
+++ b/workspace/studies/showcase-6-equivalence-large/study.yaml
@@ -7,7 +7,7 @@ status: in_progress   # legacy back-compat; canonical axes below
 report_card_refs:
   vs_vecoli: docs/report_cards/v2ecoli-vecoli-comparison/basal_4x4/report_card_verdict.json
 
-# v4 schema (vivarium_dashboard.lib.investigations._validate_study_v4_redesign):
+# v4 schema (vivarium_workbench.lib.investigations._validate_study_v4_redesign):
 #   REQUIRED top-level: schema_version, name, question, conditions, tests, status
 #   REQUIRED in conditions: baseline {composite, params}, variants [...], model_settings [...]
 


### PR DESCRIPTION
Cosmetic rename hygiene after the repo rename (`vivarium-dashboard` → `vivarium-workbench`) and the decoupling in #338. **No functional or behavioral change.**

## Updated
- **README.md, docs/reports.md** — repo links now point at `github.com/vivarium-collective/vivarium-workbench` (the link *text* already said vivarium-workbench; only the URLs lagged).
- **.github/workflows/publish-dashboard.yml** — the workbench git-install URL → `vivarium-workbench.git` (canonical; the old URL only resolved via GitHub's rename redirect). The installed package name was already `vivarium-workbench`.
- **workspace/studies/*/study.yaml** (7 files) — comment module paths `vivarium_dashboard.lib.investigations._validate_study_v4_redesign` → `vivarium_workbench.lib.investigations...`. Same function, verified present under the new package name.

## Deliberately left (out of scope for a rename)
- `docs/dashboard/assets/*.js` + exported `*.html` — **generated** dashboard bundle; refreshed on the next publish, not hand-edited.
- `scripts/gen_explorer_demo_exchange.py` + `docs/superpowers/plans/2026-06-28-*.md` — hardcoded `/Users/eranagmon/...` local paths (a separate portability issue; the script points at a distinct *explorer* artifact, so renaming would mislead rather than help).

Ref: vivarium-workbench `docs/REFACTOR-PLAN.md` §4.F.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)