### PR TITLE
feat(viz): wire single-cell visualizations into baseline

### DIFF
--- a/scripts/regenerate_viewers.py
+++ b/scripts/regenerate_viewers.py
@@ -11,6 +11,7 @@ Run locally (the ParCa cache must be on disk so heavy composites resolve):
     PYTHONPATH=. .venv/bin/python scripts/regenerate_viewers.py
 """
 import json
+import math
 import shutil
 import sys
 from dataclasses import dataclass
@@ -69,16 +70,101 @@ def trim_state_for_view(obj, *, max_list: int = 8):
     return obj
 
 
+# --- composite-state JSON serialization -------------------------------------
+# Inlined from the (now-removed) vivarium_workbench.lib.json_serialize so this
+# standalone script has NO workbench dependency — that package was dropped from
+# v2ecoli in 5d83d168 ("viewer moved to pbg-ptools"). This is a byte-for-byte
+# copy of that module's serializer: it turns numpy arrays/scalars, Path, and
+# sets into JSON-native values (composite states are full of numpy bulk-count
+# arrays), preserves structured-array field names, and replaces non-finite
+# floats (inf/nan) with null so a browser's JSON.parse accepts the output.
+
+
+def _structured_array_to_json(o: object) -> object | None:
+    """Serialize a NumPy structured array preserving its field names; else None.
+
+    An array with an ``id`` field (bulk molecules) becomes an ``{id: count}``
+    map (or ``{id: record}`` without a count field); otherwise a list of
+    field-keyed records. Returns None for anything that isn't a structured
+    array, so the caller falls through to its normal handling.
+    """
+    names = getattr(getattr(o, "dtype", None), "names", None)
+    if not names or getattr(o, "ndim", 0) < 1:
+        return None
+    try:
+        rows = o.tolist()  # type: ignore[attr-defined]  # list of per-row tuples
+        records = [dict(zip(names, row)) for row in rows]
+    except Exception:
+        return None
+    if "id" in names:
+        if "count" in names:
+            return {str(r["id"]): r["count"] for r in records}
+        return {str(r["id"]): {k: v for k, v in r.items() if k != "id"} for r in records}
+    return records
+
+
+def _json_default(o: object) -> object:
+    """JSON fallback for objects json.dumps can't handle: numpy structured
+    arrays (field names preserved), plain numpy arrays/scalars, sets, Path.
+    Falls back to repr() so a bad object surfaces a string, not a crash."""
+    structured = _structured_array_to_json(o)
+    if structured is not None:
+        return structured
+    # numpy duck-typing without importing numpy (cheaper boot)
+    tolist = getattr(o, "tolist", None)
+    if callable(tolist):
+        try:
+            return tolist()
+        except Exception:
+            pass
+    if hasattr(o, "item") and callable(o.item):
+        try:
+            return o.item()  # numpy scalar → python scalar
+        except Exception:
+            pass
+    if isinstance(o, (set, frozenset)):
+        return sorted(o, key=str)
+    if isinstance(o, Path):
+        return str(o)
+    return repr(o)
+
+
+def _json_sanitize(obj):
+    """Recursively replace non-finite floats (inf/-inf/nan) with None. Non-native
+    objects are normalized once through _json_default so inf/nan buried inside
+    them is caught too — but only when that yields a JSON-native value, else the
+    original is left for the final json.dumps(default=_json_default) pass (so we
+    don't recurse forever on e.g. a pint Quantity)."""
+    if obj is None or isinstance(obj, (int, str)):  # int covers bool
+        return obj
+    if isinstance(obj, float):
+        return obj if math.isfinite(obj) else None
+    if isinstance(obj, dict):
+        return {k: _json_sanitize(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [_json_sanitize(v) for v in obj]
+    converted = _json_default(obj)
+    if isinstance(converted, (dict, list, tuple, float, int, str)) or converted is None:
+        return _json_sanitize(converted)
+    return obj
+
+
+def _json_body(data) -> bytes:
+    """Serialize ``data`` to spec-compliant JSON bytes. Fast path dumps with
+    allow_nan=False; only on a non-finite float does it walk the structure to
+    replace inf/nan with null, so all-finite payloads pay nothing extra."""
+    try:
+        return json.dumps(data, default=_json_default, allow_nan=False).encode()
+    except ValueError:
+        return json.dumps(
+            _json_sanitize(data), default=_json_default, allow_nan=False
+        ).encode()
+
+
 def write_state(state: dict, slug: str, data_dir: Path) -> Path:
     data_dir.mkdir(parents=True, exist_ok=True)
     out = data_dir / f"{slug}.state.json"
-    # Serialize EXACTLY as the dashboard's /api/composite-state does, via its
-    # _json_body: _json_default turns numpy arrays/scalars, Path, and sets into
-    # JSON-native values (composite states are full of numpy bulk-count arrays),
-    # and allow_nan=False + the _json_sanitize fallback replaces inf/nan with
-    # null. Plain json.dumps chokes on the ndarrays. loom's ?stateUrl= reader
-    # expects the {"state": <bigraph-state>} wrapper.
-    from vivarium_workbench.lib.json_serialize import _json_body
+    # loom's ?stateUrl= reader expects the {"state": <bigraph-state>} wrapper.
     out.write_bytes(_json_body({"state": state}))
     return out
 

--- a/v2ecoli/composites/_helpers.py
+++ b/v2ecoli/composites/_helpers.py
@@ -144,15 +144,41 @@ ALL_PARTITIONED = list(PARTITIONED_PROCESSES.keys())
 # ``visualizations=v2ecoli_default_single_cell_visualizations()`` on the
 # specific @composite_generator call.
 #
-# Note: the cell-mass / cell-volume / growth-rate / absolute-mass-components /
-# mass-fold-change TimeSeriesPlots that previously lived here used a
-# `config.observable: '<short-name>'` convention that the dashboard's
-# build_viz_composite (vivarium-workbench, lib/investigations.py) does not yet
-# understand — it only honors `inputs_map` for port→observable wiring, so
-# those plots came out with empty y-data even though the emitter recorded
-# them. They will land back here once the dashboard grows a short-name /
-# leaf-name resolver for canonical viz wiring.
-DEFAULT_SINGLE_CELL_VISUALIZATIONS: list[dict] = []
+# The earlier port-wired TimeSeriesPlots came out with empty y-data because
+# build_viz_composite only honors `inputs_map` for port→observable wiring (no
+# short-name resolver). The specs below avoid that entirely by using
+# TimeSeriesFromObservables, which is SELF-CONTAINED — it reads runs.db directly
+# from `config.runs_db_path` (injected per-run by the dashboard's
+# _render_canonical_viz) and plots the named observables, so no port wiring is
+# needed. `observable_match` is a dashboard-side convenience: an empty
+# `observables` list resolves to all numeric observables, and an
+# `observable_match` substring selects a subset. Fold-changes (~1.0) and
+# fractions (0–1) are split so they don't share a y-axis. NetworkVisualization
+# renders the architecture diagram from the composite spec (no run data).
+DEFAULT_SINGLE_CELL_VISUALIZATIONS: list[dict] = [
+    {
+        'name': 'observables',
+        'address': 'local:TimeSeriesFromObservables',
+        'config': {'title': 'Observables over time'},
+    },
+    {
+        'name': 'mass_dynamics',
+        'address': 'local:TimeSeriesFromObservables',
+        'config': {'title': 'Cell mass (fold-change)',
+                   'observable_match': 'fold_change'},
+    },
+    {
+        'name': 'mass_composition',
+        'address': 'local:TimeSeriesFromObservables',
+        'config': {'title': 'Mass composition (fractions)',
+                   'observable_match': 'fraction'},
+    },
+    {
+        'name': 'topology',
+        'address': 'local:NetworkVisualization',
+        'config': {'title': 'Process topology'},
+    },
+]
 
 
 def v2ecoli_default_single_cell_visualizations() -> list[dict]:


### PR DESCRIPTION
## What
Populate `DEFAULT_SINGLE_CELL_VISUALIZATIONS` (shared by baseline + the millard/pdmp composites), which was an empty placeholder, so baseline actually produces figures:

- **Observables over time** — all numeric observables (`TimeSeriesFromObservables`).
- **Cell mass (fold-change)** — the mass fold-change series.
- **Mass composition (fractions)** — protein/RNA mass fractions (split from fold-changes so they don't share a y-axis).
- **Process topology** — `NetworkVisualization` architecture diagram.

## Why this avoids the old empty-y-data problem
The earlier port-wired TimeSeriesPlots came out empty because `build_viz_composite` only honors `inputs_map` for port→observable wiring. These specs use **`TimeSeriesFromObservables`**, which is self-contained — it reads `runs.db` directly via `runs_db_path` (injected per-run by the dashboard's `_render_canonical_viz`) and plots the named observables. Requires the paired vivarium-workbench + pbg-superpowers PRs.

Verified: all four render against a completed baseline run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)