### PR TITLE
feat: investigation report-card summary generator + metabolism_redux study (build-phase)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,10 @@ reports/assets/*
 !reports/assets/.keep
 # pre-resolved composite states shipped to the read-only dashboard (tracked)
 !reports/composite-state/
+# investigation report-card summary generator (tracked source; generated
+# reports/summaries/*.html stays ignored)
+!reports/investigation_summary.py
+!reports/_summary/
 investigations/*/viz/
 .dashboard.log
 # Dashboard re-render targets (regenerated on demand by /api/render)

--- a/docs/superpowers/plans/2026-07-21-investigation-report-card-summary.md
+++ b/docs/superpowers/plans/2026-07-21-investigation-report-card-summary.md
@@ -1,0 +1,838 @@
+# Investigation Report-Card Summary Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a standalone generator that scans an investigation's studies, aggregates their report-card verdicts + rendered cards, and emits one self-contained HTML summary page.
+
+**Architecture:** Pure aggregation (`reports/_summary/aggregate.py`: filesystem → a plain dict) is separated from rendering (`reports/_summary/render.py`: dict → HTML string). A thin CLI (`reports/investigation_summary.py`) wires them and writes/opens the file. Reworks the removed `reports/compare_report.py` scaffold for a proper investigation structure.
+
+**Tech Stack:** Python 3.12, stdlib (`argparse`, `json`, `html`, `pathlib`, `webbrowser`), `pyyaml`, `pytest`.
+
+## Global Constraints
+
+- Output is **fully self-contained**: no external `<link href>` or `<script src>` to repo paths — all card HTML + CSS inlined.
+- **Read-only**: never run a simulation, never write into `workspace/`.
+- Default output path: `reports/summaries/<slug>_summary.html`.
+- Verdict vocabulary (verbatim): `within_tol`, `drift`, `mismatch`, `ungraded`.
+- Study order comes from `investigation.yaml`'s `studies:` list (already DAG-ordered); do not re-sort.
+- Canonical run result = the `runs[]` entry with `canonical: true` → its `result` (`PASS`/`PARTIAL`/`FAIL`); `None` if no canonical run.
+- All work on branch `feat/investigation-report-card-summary`.
+
+---
+
+## File Structure
+
+- **Create** `reports/_summary/__init__.py` — package marker (empty).
+- **Create** `reports/_summary/aggregate.py` — `aggregate(slug, workspace_root) -> dict`. Reads yaml + verdict.json + card html; returns the `InvestigationSummary` dict. No HTML.
+- **Create** `reports/_summary/render.py` — `render(summary, style_css) -> str`. Pure dict → HTML string. No filesystem reads.
+- **Create** `reports/investigation_summary.py` — CLI `main(argv=None)`.
+- **Create** `tests/test_investigation_summary.py` — tests for aggregate, matrix, render, CLI.
+
+### `InvestigationSummary` dict shape (produced by `aggregate`, consumed by `render`)
+
+```python
+{
+  "slug": str,
+  "title": str,
+  "question": str,
+  "studies": [
+    {
+      "slug": str,
+      "title": str,
+      "status": str | None,
+      "result": str | None,            # "PASS" | "PARTIAL" | "FAIL" | None
+      "prerequisites": list[str],
+      "finding": str | None,           # first findings[].statement
+      "cards": [
+        {
+          "name": str,                 # e.g. "standard", "config", "parca"
+          "overall": str | None,       # within_tol/drift/mismatch/ungraded/None
+          "graded": bool,              # overall not in (None, "ungraded")
+          "html": str,                 # inlined card markup ("" if missing)
+          "is_full_doc": bool,         # True if markup contains "<html"
+          "axes": list[dict],          # [{"label","verdict","value","meter"}], graded groups only
+          "missing": bool,             # True if html or verdict file absent
+        }, ...
+      ],
+    }, ...
+  ],
+  "rollup": {"PASS": int, "PARTIAL": int, "FAIL": int},
+  "matrix": {
+    "columns": list[str],              # union of graded axis labels, first-appearance order
+    "rows": [ {"study": str, "cells": {label: verdict_or_None}}, ... ],
+  },
+}
+```
+
+---
+
+### Task 1: Aggregate — study discovery + per-study metadata
+
+**Files:**
+- Create: `reports/_summary/__init__.py`
+- Create: `reports/_summary/aggregate.py`
+- Test: `tests/test_investigation_summary.py`
+
+**Interfaces:**
+- Produces: `aggregate(slug: str, workspace_root: str | Path) -> dict` returning the `InvestigationSummary` dict above. This task fills `slug`, `title`, `question`, `studies[]` (each with `slug`, `title`, `status`, `result`, `prerequisites`, `finding`, and a `cards[]` list where each card has `name`, `overall`, `graded`, `missing` populated — `html`/`is_full_doc`/`axes` are added in Task 3, default to `""`/`False`/`[]` here), and `rollup`. `matrix` is added in Task 2 (default `{"columns": [], "rows": []}` here).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_investigation_summary.py
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+WS = REPO / "workspace"
+SLUG = "v2ecoli-vecoli-comparison"
+
+
+def test_aggregate_discovers_studies_in_dag_order():
+    from reports._summary.aggregate import aggregate
+
+    summ = aggregate(SLUG, WS)
+    assert summ["slug"] == SLUG
+    assert summ["question"].startswith("Does v2ecoli reproduce vEcoli")
+    slugs = [s["slug"] for s in summ["studies"]]
+    assert slugs == [
+        "parca", "basal", "with_aa", "succinate",
+        "no_oxygen", "acetate", "statistical",
+    ]
+
+
+def test_aggregate_per_study_metadata_and_rollup():
+    from reports._summary.aggregate import aggregate
+
+    summ = aggregate(SLUG, WS)
+    by = {s["slug"]: s for s in summ["studies"]}
+    assert by["acetate"]["result"] == "FAIL"
+    assert by["parca"]["result"] == "PASS"
+    assert by["parca"]["prerequisites"] == []
+    assert by["acetate"]["prerequisites"] == ["parca"]
+    assert by["statistical"]["prerequisites"] == ["basal"]
+    assert "RNA mass" in (by["acetate"]["finding"] or "")
+    # config + standard cards discovered for acetate; parca card for parca
+    assert {c["name"] for c in by["acetate"]["cards"]} == {"config", "standard"}
+    assert {c["name"] for c in by["parca"]["cards"]} == {"parca"}
+    # config card is ungraded, standard is graded
+    acards = {c["name"]: c for c in by["acetate"]["cards"]}
+    assert acards["config"]["graded"] is False
+    assert acards["standard"]["graded"] is True
+    assert acards["standard"]["overall"] == "mismatch"
+    assert summ["rollup"] == {"PASS": 2, "PARTIAL": 3, "FAIL": 2}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/test_investigation_summary.py -q`
+Expected: FAIL with `ModuleNotFoundError: No module named 'reports._summary.aggregate'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# reports/_summary/__init__.py
+# (empty package marker)
+```
+
+```python
+# reports/_summary/aggregate.py
+"""Filesystem -> InvestigationSummary dict. No HTML, no sims, read-only."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_UNGRADED = "ungraded"
+
+
+def _load_yaml(path: Path) -> dict:
+    with path.open() as fh:
+        return yaml.safe_load(fh) or {}
+
+
+def _canonical_result(study: dict) -> str | None:
+    for run in study.get("runs", []) or []:
+        if run.get("canonical"):
+            return run.get("result")
+    return None
+
+
+def _first_finding(study: dict) -> str | None:
+    for f in study.get("findings", []) or []:
+        stmt = f.get("statement")
+        if stmt:
+            return " ".join(str(stmt).split())  # collapse folded-yaml whitespace
+    return None
+
+
+def _card_name(html_ref: str) -> str:
+    return Path(html_ref).stem  # "viz/report_card/standard.html" -> "standard"
+
+
+def _verdict_path(study_dir: Path, html_ref: str) -> Path:
+    return study_dir / html_ref.replace(".html", ".verdict.json")
+
+
+def _card_stub(study_dir: Path, html_ref: str) -> dict[str, Any]:
+    name = _card_name(html_ref)
+    vpath = _verdict_path(study_dir, html_ref)
+    hpath = study_dir / html_ref
+    overall = None
+    missing = not hpath.exists()
+    if vpath.exists():
+        try:
+            overall = json.loads(vpath.read_text()).get("overall")
+        except (json.JSONDecodeError, OSError):
+            overall = None
+    else:
+        missing = True
+    return {
+        "name": name,
+        "overall": overall,
+        "graded": overall not in (None, _UNGRADED),
+        "html": "",
+        "is_full_doc": False,
+        "axes": [],
+        "missing": missing,
+    }
+
+
+def aggregate(slug: str, workspace_root: str | Path) -> dict[str, Any]:
+    ws = Path(workspace_root)
+    inv_dir = ws / "investigations" / slug
+    inv = _load_yaml(inv_dir / "investigation.yaml")
+
+    studies: list[dict[str, Any]] = []
+    rollup = {"PASS": 0, "PARTIAL": 0, "FAIL": 0}
+    for study_slug in inv.get("studies", []) or []:
+        study_dir = inv_dir / "studies" / study_slug
+        study = _load_yaml(study_dir / "study.yaml")
+        result = _canonical_result(study)
+        if result in rollup:
+            rollup[result] += 1
+        cards = [_card_stub(study_dir, ref) for ref in study.get("report_cards", []) or []]
+        studies.append({
+            "slug": study_slug,
+            "title": study.get("title") or study.get("name") or study_slug,
+            "status": study.get("status"),
+            "result": result,
+            "prerequisites": (study.get("pipeline_gate", {}) or {}).get("prerequisites", []) or [],
+            "finding": _first_finding(study),
+            "cards": cards,
+        })
+
+    return {
+        "slug": slug,
+        "title": inv.get("title") or slug,
+        "question": inv.get("question") or "",
+        "studies": studies,
+        "rollup": rollup,
+        "matrix": {"columns": [], "rows": []},
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/pytest tests/test_investigation_summary.py -q`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add reports/_summary/__init__.py reports/_summary/aggregate.py tests/test_investigation_summary.py
+git commit -m "feat(summary): aggregate investigation studies + per-study metadata"
+```
+
+---
+
+### Task 2: Aggregate — verdict matrix
+
+**Files:**
+- Modify: `reports/_summary/aggregate.py`
+- Test: `tests/test_investigation_summary.py`
+
+**Interfaces:**
+- Consumes: the `studies[]` list and each card's `graded`/`overall` from Task 1, plus each card's `axes` (populated here by reading the verdict groups directly — Task 3 also reads axes for the render side; both read the same `verdict.json`, so factor axis extraction into a shared helper `_graded_axes(study_dir, html_ref) -> list[dict]`).
+- Produces: `summary["matrix"] = {"columns": [...], "rows": [...]}` per the shape above, and populates each card's `axes` list.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tests/test_investigation_summary.py
+def test_matrix_columns_lead_with_standard_observables():
+    from reports._summary.aggregate import aggregate
+
+    m = aggregate(SLUG, WS)["matrix"]
+    # standard-card observables appear first, in card order
+    assert m["columns"][:5] == [
+        "cell mass (fg)", "dry mass (fg)", "protein mass (fg)",
+        "RNA mass (fg)", "growth rate (1/s)",
+    ]
+
+
+def test_matrix_cell_verdicts_match_source_json():
+    import json
+    from reports._summary.aggregate import aggregate
+
+    m = aggregate(SLUG, WS)["matrix"]
+    rows = {r["study"]: r["cells"] for r in m["rows"]}
+    # acetate growth rate is a mismatch in the source verdict.json
+    src = json.loads(
+        (WS / "investigations" / SLUG / "studies" / "acetate"
+         / "viz" / "report_card" / "standard.verdict.json").read_text()
+    )
+    axis = {a["label"]: a["verdict"] for a in src["groups"]["standard"]["axes"]}
+    assert rows["acetate"]["growth rate (1/s)"] == axis["growth rate (1/s)"] == "mismatch"
+    assert rows["acetate"]["RNA mass (fg)"] == "drift"
+    # parca has cell mass within tolerance, no growth-rate column value
+    assert rows["parca"]["cell mass (fg)"] == "within_tol"
+    assert rows["parca"].get("growth rate (1/s)") is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/test_investigation_summary.py -k matrix -q`
+Expected: FAIL — `m["columns"]` is empty (`[]`).
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add the shared axis helper and matrix builder to `reports/_summary/aggregate.py`:
+
+```python
+def _graded_axes(study_dir: Path, html_ref: str) -> list[dict[str, Any]]:
+    """Flattened axes across graded groups of one card's verdict.json."""
+    vpath = _verdict_path(study_dir, html_ref)
+    if not vpath.exists():
+        return []
+    try:
+        data = json.loads(vpath.read_text())
+    except (json.JSONDecodeError, OSError):
+        return []
+    if data.get("overall") in (None, _UNGRADED):
+        return []
+    axes: list[dict[str, Any]] = []
+    for group in (data.get("groups") or {}).values():
+        for a in group.get("axes", []) or []:
+            axes.append({
+                "label": a.get("label"),
+                "verdict": a.get("verdict"),
+                "value": a.get("value"),
+                "meter": a.get("meter"),
+            })
+    return axes
+```
+
+In `aggregate()`, after building `cards`, attach axes and remember the html_ref so the matrix can be built. Change the card-building loop:
+
+```python
+        cards = []
+        for ref in study.get("report_cards", []) or []:
+            card = _card_stub(study_dir, ref)
+            card["axes"] = _graded_axes(study_dir, ref)
+            cards.append(card)
+```
+
+Then, before the final `return`, build the matrix from the assembled `studies`:
+
+```python
+    columns: list[str] = []
+    rows: list[dict[str, Any]] = []
+    for s in studies:
+        cells: dict[str, str | None] = {}
+        for card in s["cards"]:
+            for axis in card["axes"]:
+                label = axis["label"]
+                if label and label not in columns:
+                    columns.append(label)
+                if label:
+                    cells[label] = axis["verdict"]
+        rows.append({"study": s["slug"], "cells": cells})
+    matrix = {"columns": columns, "rows": rows}
+```
+
+And replace the placeholder `"matrix": {"columns": [], "rows": []}` in the returned dict with `"matrix": matrix`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/pytest tests/test_investigation_summary.py -q`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add reports/_summary/aggregate.py tests/test_investigation_summary.py
+git commit -m "feat(summary): build study x observable verdict matrix"
+```
+
+---
+
+### Task 3: Aggregate — inline card HTML + full-doc detection
+
+**Files:**
+- Modify: `reports/_summary/aggregate.py`
+- Test: `tests/test_investigation_summary.py`
+
+**Interfaces:**
+- Produces: each card's `html` (raw file contents, `""` if missing) and `is_full_doc` (`True` when the markup contains `<html`, case-insensitive) populated in `aggregate()`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tests/test_investigation_summary.py
+def test_card_html_inlined_and_full_doc_flagged():
+    from reports._summary.aggregate import aggregate
+
+    by = {s["slug"]: s for s in aggregate(SLUG, WS)["studies"]}
+    scards = {c["name"]: c for c in by["statistical"]["cards"]}
+    # statistical.html is a full <html> document -> flagged for iframe embedding
+    assert scards["statistical"]["is_full_doc"] is True
+    assert "<html" in scards["statistical"]["html"].lower()
+    # standard.html is a fragment (no <html>) -> inlined directly
+    acards = {c["name"]: c for c in by["acetate"]["cards"]}
+    assert acards["standard"]["is_full_doc"] is False
+    assert acards["standard"]["html"].strip() != ""
+    assert "<html" not in acards["standard"]["html"].lower()
+
+
+def test_missing_card_marked_not_crashing(tmp_path):
+    from reports._summary.aggregate import _card_stub
+
+    # a study dir with a declared card whose files don't exist
+    stub = _card_stub(tmp_path, "viz/report_card/ghost.html")
+    assert stub["missing"] is True
+    assert stub["html"] == ""
+    assert stub["graded"] is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/test_investigation_summary.py -k "full_doc or missing" -q`
+Expected: FAIL — `is_full_doc` is `False` for statistical and `html` is `""`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `reports/_summary/aggregate.py`, extend `_card_stub` to load the html and set `is_full_doc`:
+
+```python
+    html = ""
+    if hpath.exists():
+        try:
+            html = hpath.read_text()
+        except OSError:
+            html = ""
+            missing = True
+    return {
+        "name": name,
+        "overall": overall,
+        "graded": overall not in (None, _UNGRADED),
+        "html": html,
+        "is_full_doc": "<html" in html.lower(),
+        "axes": [],
+        "missing": missing,
+    }
+```
+
+(Remove the old hardcoded `"html": ""`/`"is_full_doc": False` from the returned dict; keep `"axes": []` — axes are attached in `aggregate()` per Task 2.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/pytest tests/test_investigation_summary.py -q`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add reports/_summary/aggregate.py tests/test_investigation_summary.py
+git commit -m "feat(summary): inline card HTML and flag full-document cards"
+```
+
+---
+
+### Task 4: Render — overview + verdict matrix HTML
+
+**Files:**
+- Create: `reports/_summary/render.py`
+- Test: `tests/test_investigation_summary.py`
+
+**Interfaces:**
+- Consumes: the `InvestigationSummary` dict from Tasks 1–3 and a `style_css` string.
+- Produces: `render(summary: dict, style_css: str = "") -> str` returning a full self-contained HTML document. Task 5 extends the same function with per-study sections; define it now to render `<head>` (with an inlined `<style>` block built from `style_css` + summary-specific rules), the overview header (title, question, rollup strip, pipeline DAG), and the verdict matrix table, and leave a clearly-marked insertion point (`# --- per-study sections (Task 5) ---`) before `</body>`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tests/test_investigation_summary.py
+def test_render_overview_and_matrix():
+    from reports._summary.aggregate import aggregate
+    from reports._summary.render import render
+
+    html = render(aggregate(SLUG, WS), style_css=":root{--x:1}")
+    assert "<!doctype html>" in html.lower()
+    assert "Does v2ecoli reproduce vEcoli" in html
+    # rollup counts present
+    assert "2 FAIL" in html and "3 PARTIAL" in html and "2 PASS" in html
+    # matrix header + a verdict-colored cell class
+    assert "growth rate (1/s)" in html
+    assert "verdict-mismatch" in html
+    # self-contained: no external stylesheet or script src
+    assert "<link " not in html.lower()
+    assert "script src" not in html.lower()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/test_investigation_summary.py -k render_overview -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'reports._summary.render'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# reports/_summary/render.py
+"""InvestigationSummary dict -> self-contained HTML string. No filesystem reads."""
+from __future__ import annotations
+
+import html as _html
+from typing import Any
+
+_VERDICTS = ("within_tol", "drift", "mismatch", "ungraded")
+
+_BASE_CSS = """
+body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+ margin:0;background:var(--bg,#fafafa);color:#1f2937;line-height:1.5}
+.wrap{max-width:1100px;margin:0 auto;padding:28px 24px 80px}
+h1{font-size:1.6em;margin:0 0 4px}
+.question{color:var(--gray,#666);font-size:1.05em;margin:0 0 18px}
+.rollup{display:flex;gap:10px;margin:0 0 18px;flex-wrap:wrap}
+.pill{border-radius:14px;padding:4px 12px;font-weight:600;font-size:0.9em;border:1px solid #0001}
+.pill.PASS{background:#d1fae5;color:#065f46}.pill.PARTIAL{background:#fef3c7;color:#92400e}
+.pill.FAIL{background:#fee2e2;color:#991b1b}
+.dag{font-family:ui-monospace,Menlo,monospace;font-size:0.85em;color:#475569;
+ background:#fff;border:1px solid var(--border,#e2e6eb);border-radius:8px;padding:10px 14px;margin:0 0 22px}
+table.matrix{border-collapse:collapse;width:100%;margin:0 0 30px;font-size:0.85em}
+table.matrix th,table.matrix td{border:1px solid var(--border,#e2e6eb);padding:6px 8px;text-align:center}
+table.matrix th.study,table.matrix td.study{text-align:left;font-weight:600;white-space:nowrap}
+td.verdict-within_tol{background:#d1fae5}td.verdict-drift{background:#fef3c7}
+td.verdict-mismatch{background:#fee2e2}td.verdict-none{background:#f8fafc;color:#cbd5e1}
+details.study{background:#fff;border:1px solid var(--border,#e2e6eb);border-radius:8px;margin:0 0 14px;padding:2px 14px}
+details.study>summary{cursor:pointer;font-weight:600;padding:10px 0;list-style:none}
+.badge{border-radius:10px;padding:1px 8px;font-size:0.78em;margin-left:8px}
+.badge.within_tol{background:#d1fae5;color:#065f46}.badge.drift{background:#fef3c7;color:#92400e}
+.badge.mismatch{background:#fee2e2;color:#991b1b}.badge.ungraded{background:#eef2f7;color:#475569}
+.finding{color:var(--gray,#666);font-weight:400;font-size:0.9em;margin-left:6px}
+.card-embed{margin:8px 0 14px;border-top:1px solid var(--border,#e2e6eb);padding-top:10px}
+iframe.card-frame{width:100%;border:0}
+.missing{color:#b91c1c;font-style:italic;font-size:0.9em}
+"""
+
+
+def _esc(s: Any) -> str:
+    return _html.escape(str(s if s is not None else ""))
+
+
+def _dag(summary: dict) -> str:
+    parts = []
+    for s in summary["studies"]:
+        prereq = s["prerequisites"]
+        arrow = f"{', '.join(prereq)} &rarr; " if prereq else ""
+        parts.append(f"{arrow}<b>{_esc(s['slug'])}</b>")
+    return "<br>".join(parts)
+
+
+def _matrix_table(summary: dict) -> str:
+    cols = summary["matrix"]["columns"]
+    if not cols:
+        return ""
+    head = "".join(f"<th>{_esc(c)}</th>" for c in cols)
+    body = []
+    for row in summary["matrix"]["rows"]:
+        cells = [f'<td class="study">{_esc(row["study"])}</td>']
+        for c in cols:
+            v = row["cells"].get(c)
+            klass = f"verdict-{v}" if v in _VERDICTS else "verdict-none"
+            cells.append(f'<td class="{klass}">{_esc(v or "")}</td>')
+        body.append(f"<tr>{''.join(cells)}</tr>")
+    return (
+        '<table class="matrix"><thead><tr><th class="study">study</th>'
+        f"{head}</tr></thead><tbody>{''.join(body)}</tbody></table>"
+    )
+
+
+def _rollup(summary: dict) -> str:
+    r = summary["rollup"]
+    order = [("FAIL", r["FAIL"]), ("PARTIAL", r["PARTIAL"]), ("PASS", r["PASS"])]
+    pills = [f'<span class="pill {k}">{n} {k}</span>' for k, n in order]
+    return f'<div class="rollup">{"".join(pills)}</div>'
+
+
+def render(summary: dict, style_css: str = "") -> str:
+    head = (
+        "<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\">"
+        f"<title>{_esc(summary['title'])} — report-card summary</title>"
+        f"<style>{style_css}\n{_BASE_CSS}</style></head><body><div class=\"wrap\">"
+    )
+    overview = (
+        f"<h1>{_esc(summary['title'])}</h1>"
+        f"<p class=\"question\">{_esc(summary['question'])}</p>"
+        f"{_rollup(summary)}"
+        f"<div class=\"dag\">{_dag(summary)}</div>"
+        f"{_matrix_table(summary)}"
+    )
+    sections = ""  # --- per-study sections (Task 5) ---
+    return head + overview + sections + "</div></body></html>"
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/pytest tests/test_investigation_summary.py -q`
+Expected: PASS (7 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add reports/_summary/render.py tests/test_investigation_summary.py
+git commit -m "feat(summary): render overview header + verdict matrix"
+```
+
+---
+
+### Task 5: Render — per-study sections + card embedding
+
+**Files:**
+- Modify: `reports/_summary/render.py`
+- Test: `tests/test_investigation_summary.py`
+
+**Interfaces:**
+- Consumes: each study's `cards[]` (with `html`, `is_full_doc`, `overall`, `graded`, `missing`) from Task 3.
+- Produces: `sections` HTML inserted at the Task 4 marker. Fragment cards inline directly; full-document cards embed via `<iframe srcdoc="...">` with an auto-height script. Graded cards render `<details open>`; ungraded (config) cards render collapsed.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tests/test_investigation_summary.py
+def test_render_per_study_sections_and_embedding():
+    from reports._summary.aggregate import aggregate
+    from reports._summary.render import render
+
+    html = render(aggregate(SLUG, WS))
+    # every study appears as a details section
+    for slug in ("parca", "acetate", "statistical"):
+        assert f'id="study-{slug}"' in html
+    # fragment card (acetate standard) inlined: its <h3 ... simulation runs heading present
+    assert "simulation runs" in html
+    # full-doc card (statistical) embedded via iframe srcdoc
+    assert "iframe" in html and "srcdoc=" in html
+    # auto-height shim present exactly once
+    assert html.count("scrollHeight") >= 1
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/test_investigation_summary.py -k per_study -q`
+Expected: FAIL — no `id="study-..."` sections and no `srcdoc=`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `reports/_summary/render.py`, add card + section renderers and an auto-height script, then wire them into `render()`:
+
+```python
+_IFRAME_JS = (
+    "<script>window.addEventListener('load',function(){"
+    "document.querySelectorAll('iframe.card-frame').forEach(function(f){"
+    "try{f.style.height=(f.contentDocument.body.scrollHeight+20)+'px';}catch(e){}"
+    "});});</script>"
+)
+
+
+def _card_html(card: dict) -> str:
+    if card["missing"]:
+        return f'<div class="missing">card &ldquo;{_esc(card["name"])}&rdquo; not rendered yet</div>'
+    if card["is_full_doc"]:
+        srcdoc = _html.escape(card["html"], quote=True)
+        return f'<iframe class="card-frame" srcdoc="{srcdoc}"></iframe>'
+    return card["html"]  # fragment: inline as-is (inline styles only, no collision)
+
+
+def _study_section(study: dict) -> str:
+    badge_verdict = None
+    for c in study["cards"]:
+        if c["graded"]:
+            badge_verdict = c["overall"]
+            break
+    badge = (
+        f'<span class="badge {badge_verdict}">{_esc(badge_verdict)}</span>'
+        if badge_verdict else ""
+    )
+    finding = f'<span class="finding">{_esc(study["finding"])}</span>' if study["finding"] else ""
+    embeds = []
+    for c in study["cards"]:
+        open_attr = " open" if c["graded"] else ""
+        embeds.append(
+            f'<details class="card-embed"{open_attr}>'
+            f'<summary>{_esc(c["name"])} card</summary>{_card_html(c)}</details>'
+        )
+    return (
+        f'<details class="study" id="study-{_esc(study["slug"])}" open>'
+        f'<summary>{_esc(study["title"])}{badge}{finding}</summary>'
+        f'{"".join(embeds)}</details>'
+    )
+```
+
+Then update `render()`:
+
+```python
+    sections = "".join(_study_section(s) for s in summary["studies"])
+    return head + overview + sections + _IFRAME_JS + "</div></body></html>"
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/pytest tests/test_investigation_summary.py -q`
+Expected: PASS (8 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add reports/_summary/render.py tests/test_investigation_summary.py
+git commit -m "feat(summary): per-study sections with inline + iframe card embeds"
+```
+
+---
+
+### Task 6: CLI + end-to-end generation
+
+**Files:**
+- Create: `reports/investigation_summary.py`
+- Test: `tests/test_investigation_summary.py`
+
+**Interfaces:**
+- Consumes: `aggregate()` and `render()`.
+- Produces: `main(argv: list[str] | None = None) -> int` and a `__main__` guard. Reads `reports/assets/style.css` (best-effort; empty string if absent), passes its `:root` block through to `render()`, writes to `reports/summaries/<slug>_summary.html` (or `--out`), opens in a browser unless `--no-open`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tests/test_investigation_summary.py
+def test_cli_writes_selfcontained_file(tmp_path):
+    from reports.investigation_summary import main
+
+    out = tmp_path / "summary.html"
+    rc = main(["--investigation", SLUG, "--out", str(out), "--no-open"])
+    assert rc == 0
+    text = out.read_text()
+    assert out.stat().st_size > 5000
+    # all 7 studies present, self-contained
+    for slug in ("parca", "basal", "with_aa", "succinate", "no_oxygen", "acetate", "statistical"):
+        assert f'id="study-{slug}"' in text
+    assert "<link " not in text.lower()
+    assert "script src" not in text.lower()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/test_investigation_summary.py -k cli -q`
+Expected: FAIL — `ModuleNotFoundError: No module named 'reports.investigation_summary'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```python
+# reports/investigation_summary.py
+"""Generate a self-contained report-card summary for an investigation.
+
+Usage:
+    python reports/investigation_summary.py --investigation <slug> [--out PATH] [--no-open]
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+import webbrowser
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from reports._summary.aggregate import aggregate  # noqa: E402
+from reports._summary.render import render  # noqa: E402
+
+_REPO = Path(__file__).resolve().parents[1]
+
+
+def _read_style() -> str:
+    css = _REPO / "reports" / "assets" / "style.css"
+    try:
+        text = css.read_text()
+    except OSError:
+        return ""
+    # keep only the :root{...} token block so the summary matches the report palette
+    start = text.find(":root{")
+    if start == -1:
+        return ""
+    end = text.find("}", start)
+    return text[start:end + 1] if end != -1 else ""
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Investigation report-card summary generator")
+    ap.add_argument("--investigation", required=True, help="investigation slug")
+    ap.add_argument("--out", default=None, help="output HTML path")
+    ap.add_argument("--no-open", action="store_true", help="do not open in a browser")
+    args = ap.parse_args(argv)
+
+    ws = _REPO / "workspace"
+    summary = aggregate(args.investigation, ws)
+    html = render(summary, style_css=_read_style())
+
+    out = Path(args.out) if args.out else (
+        _REPO / "reports" / "summaries" / f"{args.investigation}_summary.html"
+    )
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(html)
+    print(f"wrote {out} ({out.stat().st_size:,} bytes)")
+    if not args.no_open:
+        webbrowser.open(out.resolve().as_uri())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/pytest tests/test_investigation_summary.py -q`
+Expected: PASS (9 tests).
+
+- [ ] **Step 5: Generate the real summary and eyeball it**
+
+Run: `.venv/bin/python reports/investigation_summary.py --investigation v2ecoli-vecoli-comparison`
+Expected: prints `wrote reports/summaries/v2ecoli-vecoli-comparison_summary.html (...)` and opens the page. Verify: overview shows `2 FAIL · 3 PARTIAL · 2 PASS`, the matrix renders colored cells, and each study expands to show its embedded cards (statistical via iframe).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add reports/investigation_summary.py tests/test_investigation_summary.py
+git commit -m "feat(summary): CLI generator + end-to-end self-contained output"
+```
+
+Note: `reports/summaries/*.html` are generated artifacts. If the repo gitignores generated report output (check `.gitignore` for `reports/` render outputs, mirroring commit `459f69d4`), do **not** commit the generated HTML; otherwise leave it untracked.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Standalone generator + CLI + slug param → Task 6. ✓
+- Default output `reports/summaries/<slug>_summary.html`, fully self-contained → Task 6 + Global Constraints; tests assert no external `<link>`/`script src`. ✓
+- Data sources (investigation.yaml, study.yaml result/status/prereq/findings/report_cards, verdict.json, card html) → Tasks 1–3. ✓
+- Overview (title, question, rollup, DAG) → Task 4. ✓
+- Verdict matrix (union columns, first-appearance order, colored cells) → Task 2 (data) + Task 4 (render). ✓
+- Per-study collapsible sections; graded open, config collapsed; inline fragments + iframe full-doc + auto-height → Task 5. ✓
+- Missing-card placeholder rather than crash → Task 3 (`missing`) + Task 5 (`_card_html`). ✓
+- Pure aggregate / render split → module structure. ✓
+- Tests (7 studies, matrix matches source json, cards resolve) → Tasks 1–6. ✓
+
+**Placeholder scan:** No TBD/TODO; the one `# --- per-study sections (Task 5) ---` marker is an intentional insertion anchor filled in Task 5. ✓
+
+**Type consistency:** `aggregate(slug, workspace_root) -> dict` and `render(summary, style_css="") -> str` used identically across Tasks 4–6. Card keys (`name`, `overall`, `graded`, `html`, `is_full_doc`, `axes`, `missing`) match between aggregate (Tasks 1–3) and render (Tasks 4–5). Matrix keys (`columns`, `rows[].study`, `rows[].cells`) consistent between Task 2 and Task 4. ✓

--- a/docs/superpowers/plans/2026-07-21-metabolism-redux-study.md
+++ b/docs/superpowers/plans/2026-07-21-metabolism-redux-study.md
@@ -1,0 +1,68 @@
+# metabolism_redux Comparison Study — Design + Plan
+
+**Date:** 2026-07-21
+**Branch:** `feat/investigation-report-card-summary`
+**Decisions:** variant `ecoli-metabolism-redux`; condition `basal`; **both engines** run redux; wire now, run in background.
+
+## Goal
+Add a `metabolism_redux` study to the `v2ecoli-vecoli-comparison` investigation where BOTH engines swap FBA `Metabolism` → `MetabolismRedux`, testing whether v2ecoli reproduces vEcoli under the redux metabolism at the basal condition.
+
+## Why both engines
+The investigation's premise is "does v2ecoli reproduce vEcoli." Comparing v2ecoli-redux vs vEcoli-FBA would confound engine differences with metabolism-model differences. So the vEcoli reference must also run redux.
+
+## Mechanism (mostly existing)
+- vEcoli ships `configs/metabolism_redux.json`: `swap_processes: {"ecoli-metabolism":"ecoli-metabolism-redux"}` + a `flow` reorder + `exclude_processes:["exchange_data"]`.
+- `run_comparison_ensemble.py --from-vecoli-config <cfg>` already: (v2 side) resolves the config → `injected_processes` so v2 convert+injects redux (the `metabolism_redux` unit handling in `vivarium_bridge.py` exists for this).
+- **Gaps:** (a) the vEcoli-side wrapper `run_vivarium_ecoli_pbg_multigen` ignores `swap_processes`; (b) the study→runner path (`runner._run_engines`) never passes a config.
+
+## Work items
+
+### 1. vEcoli config for the study
+Create `<vEcoli fork>/configs/metabolism_redux_basal.json` (path passed as fork-relative `configs/metabolism_redux_basal.json`; `resolve_vecoli_config_local` also accepts absolute):
+```json
+{
+  "experiment_id": "metabolism_redux_basal",
+  "condition": "basal",
+  "swap_processes": {"ecoli-metabolism": "ecoli-metabolism-redux"},
+  "exclude_processes": ["exchange_data"],
+  "flow": { ...copied from configs/metabolism_redux.json... }
+}
+```
+Run shape (seeds/gens/steps) is driven by the runner CLI, not this config. Keep a tracked copy at `workspace/investigations/v2ecoli-vecoli-comparison/studies/metabolism_redux/metabolism_redux_basal.json` for provenance.
+
+### 2. Extend the vEcoli engine wrapper to honor the swap
+`v2ecoli/library/vivarium_ecoli_engine.py` — `run_vivarium_ecoli_pbg_multigen(...)`:
+- Add params `swap_processes: dict | None = None`, `flow: dict | None = None`.
+- After the existing `sim.config[...]` assignments, if `swap_processes`: `sim.config["swap_processes"] = dict(swap_processes)`; if `flow`: merge into `sim.config["flow"]`. EcoliSim natively applies these (same path metabolism_redux.json uses upstream).
+- Thread the same two params through the pbg `Process` wrapper (`config_schema` + `__init__` call site around lines 226–250) so both entrypoints support it.
+
+### 3. Pass the swap on the vEcoli side in the ensemble runner
+`scripts/run_comparison_ensemble.py` — `make_run_one`:
+- For `composite_kind == "vecoli"`, when `from_vecoli_config` is set, resolve it (reuse `resolve_vecoli_config_local`) and pass `swap_processes=resolved.get("swap_processes")`, `flow=resolved.get("flow")` into `run_vivarium_ecoli_pbg_multigen(...)`.
+- (v2 side already builds `injected_processes` from the same resolved config — unchanged.)
+
+### 4. Thread a config through the study runner
+- `scripts/_compare/study_spec.py`: add `from_vecoli_config: str = ""` to `StudySpec`; in `_spec_from_study` read `data.get("from_vecoli_config") or (comp.get("from_vecoli_config"))`.
+- `scripts/_compare/runner.py` `_run_engines`: when `spec.from_vecoli_config`, append `--from-vecoli-config <cfg>` to BOTH the v2ecoli and vecoli `run_comparison_ensemble.py` invocations.
+
+### 5. Author the study + register it
+- `workspace/investigations/v2ecoli-vecoli-comparison/studies/metabolism_redux/study.yaml`:
+  - `schema_version: 4`, `name: metabolism_redux`, `condition: basal`, `comparison: {seeds: 1, generations: 4}`, `from_vecoli_config: configs/metabolism_redux_basal.json`.
+  - `report_cards: [viz/report_card/config.html, viz/report_card/standard.html]`.
+  - `conditions.baseline`: `{composite: v2ecoli.composites.baseline.baseline, params: {condition: basal, swap: ecoli-metabolism-redux}}` (drives the summary's config-JSON display).
+  - `pipeline_gate.prerequisites: [parca]`, `depends_on: [parca]`, `status: build`, a hand-authored `question` + one placeholder `finding` (status: investigating) + `tests` (config + standard report_card, hand-written per the no-machine-projected-tests rule).
+- Add `metabolism_redux` to `investigation.yaml` `studies:` (after `basal`, before `statistical` reads fine; order is display/DAG only).
+
+### 6. Run (background) + report
+Env: `JAVA_HOME=/opt/homebrew/opt/openjdk@21/...`, vEcoli venv on PATH, `V2E_VECOLI_DIR=/Users/eranagmon/code/vEcoli`. Caches are MISSING → the run first builds v2 ParCa (`out/cache_full`) + vEcoli ParCa (`out/compare_harness/vecoli_parca`) — hours, fragile. Run via the study runner (`scripts/compare_run.py` or `run_study`) for just `metabolism_redux`. Monitor; report real verdict/cards or the actual failure.
+
+### 7. Regenerate the summary
+`reports/investigation_summary.py --investigation v2ecoli-vecoli-comparison` — the new study appears with its config JSON + graded card + matrix row + nav link.
+
+## Risks
+- ParCa builds (both engines) are the long pole and can fail; surfaced honestly.
+- EcoliSim swap under the pbg wrapper's config overrides (`generations=None`, `divide=False`) may interact with the redux `flow` reorder — validate the vEcoli side actually loads redux (log `n_processes` / process list) before trusting the comparison.
+- The redux bridge into v2 (`injected_processes`) has never run in a study before; the `vivarium_bridge.py` redux unit handling suggests it was prepared, but this is first real use.
+
+## Out of scope
+No changes to the summary generator (already done). No other conditions (basal only). No `redux-classic`.

--- a/docs/superpowers/specs/2026-07-21-investigation-report-card-summary-design.md
+++ b/docs/superpowers/specs/2026-07-21-investigation-report-card-summary-design.md
@@ -1,0 +1,142 @@
+# Investigation Report-Card Summary — Design
+
+**Date:** 2026-07-21
+**Branch:** `feat/investigation-report-card-summary`
+**Status:** Design (awaiting review → implementation plan)
+
+## Problem
+
+An investigation (e.g. `v2ecoli-vecoli-comparison`) groups several studies, each of
+which produces one or more **report cards** — a rendered `viz/report_card/<card>.html`
+plus a machine-readable `viz/report_card/<card>.verdict.json`
+(`report_card_verdict/v1`). Today the only investigation-level views are the
+workbench's **full** per-investigation report (`report_views.py`,
+`single_study_report.py`) and the live dashboard SPA. There is no lightweight,
+sendable, **high-level summary** that pulls every study's report cards together —
+an overview up front, an at-a-glance verdict matrix, and easy access to each card.
+
+The pre-investigation ancestor of this idea was `reports/compare_report.py` (removed
+in PR #117), a self-contained HTML report with a Summary/verdict box, section
+headers, an n-way divergence table, and iframe'd sub-views. We rework that scaffold
+into a proper investigation-structured generator.
+
+## Goal
+
+A standalone Python generator that scans **any** investigation whose studies carry
+`viz/report_card/*` artifacts and emits **one self-contained HTML page** summarizing
+the report cards: overview section in front, a study × observable verdict matrix, and
+per-study collapsible sections that inline-embed the rendered cards.
+
+Non-goal: re-running simulations, changing the dashboard/workbench, or standing up a
+server. Pure static generation over already-committed artifacts.
+
+## Interface
+
+```
+python reports/investigation_summary.py --investigation <slug> [--out PATH] [--no-open]
+  → reports/summaries/<slug>_summary.html   (auto-opens in browser unless --no-open)
+```
+
+- `--investigation <slug>` — required; resolves `workspace/investigations/<slug>/`.
+- `--out PATH` — optional override of the default output path.
+- Default output: `reports/summaries/<slug>_summary.html` (new folder, one file per
+  investigation).
+- Output is **fully self-contained**: all card HTML + styles inlined, so the file
+  works when emailed or moved anywhere with no repo present.
+
+## Data sources (read-only, no sims)
+
+- **`workspace/investigations/<slug>/investigation.yaml`** → `title`, `question`,
+  study order.
+- Each **`study.yaml`** → per-study `title`/`name`, `status`, canonical run `result`
+  (PASS / PARTIAL / FAIL), `pipeline_gate.prerequisites` (for the DAG), the
+  `report_cards:` list, and top-line `findings[].statement`.
+- Each **`viz/report_card/<card>.verdict.json`** (`report_card_verdict/v1`) →
+  `overall` (`within_tol` / `drift` / `mismatch` / `ungraded`) and
+  `groups[<g>].axes[]` with `label`, `verdict`, `value`, `meter`. Drives the roll-up
+  counts and the observable matrix.
+- Each rendered **`viz/report_card/<card>.html`** → embedded per study.
+
+If a study declares a card in `report_cards:` whose `.html` or `.verdict.json` is
+missing, the generator records it as a "missing card" placeholder rather than
+crashing (renders a muted note in that study's section).
+
+## Page structure
+
+1. **Overview (front)**
+   - Investigation title + question.
+   - Roll-up strip: verdict-colored counts (e.g. `2 FAIL · 3 PARTIAL · 2 PASS`),
+     derived from each study's canonical `result`.
+   - Pipeline DAG rendered from `pipeline_gate.prerequisites`
+     (`parca → {basal, with_aa, succinate, no_oxygen, acetate} → statistical`).
+   - Sticky in-page nav linking to each study section.
+
+2. **Verdict matrix**
+   - Rows = studies (DAG order); columns = the **union of axis labels** across all
+     studies' graded cards (`overall != ungraded`), ordered by first appearance in
+     DAG order (so `standard`-card observables — `cell mass (fg)`, `dry mass (fg)`,
+     `protein mass (fg)`, `RNA mass (fg)`, `growth rate` — lead, and any
+     `parca`/`statistical`-only axes append after). Cross-card axes with identical
+     labels collapse into one column.
+   - Each cell colored `within_tol` / `drift` / `mismatch` from that study's matching
+     axis `verdict`; rendered empty (muted) when the study has no axis with that
+     label. Config cards (`ungraded`) contribute no columns.
+   - Cells anchor-link to the owning study's section. This is the "everything at a
+     glance" table (the n-way-divergence-table analog).
+
+3. **Per-study sections** (ordered by the DAG)
+   - One collapsible `<details>` per study. Header: study title + overall verdict
+     badge + one-line finding statement.
+   - Body inline-embeds each rendered report card. Config cards
+     (`overall: ungraded`, config-diff) collapsed by default; graded cards open.
+
+## Card embedding
+
+Rendered cards are HTML **fragments** using only inline styles + inline SVG (no
+`<style>`/`<script>`, so no CSS/JS collision when inlined) — **except**
+`statistical.html`, which is a full `<html>` document with its own `<style>`.
+
+- Fragment cards: inline the markup directly into the study section.
+- Full-document cards: embed via `<iframe srcdoc="...">` for style isolation
+  (matches the original `compare_report.py` iframe idiom; `srcdoc` keeps the output
+  self-contained). A small auto-height script sizes the iframe to its content.
+
+Styling: reuse `reports/assets/style.css` tokens inlined into a `<style>` block so
+the page matches the report family while remaining a single portable file.
+
+## Module structure
+
+- `reports/investigation_summary.py` — thin CLI (argparse → aggregate → render →
+  write/open).
+- `reports/_summary/aggregate.py` — **pure** function: filesystem → a plain
+  `InvestigationSummary` dict (`{investigation, question, studies[], matrix, rollup}`).
+  No rendering, no I/O beyond reads. Independently testable and reusable (could later
+  back a dashboard view).
+- `reports/_summary/render.py` — pure function: `InvestigationSummary` dict → HTML
+  string. No filesystem reads except pulling the referenced card HTML/CSS to inline.
+
+Each unit has one purpose and a well-defined interface (dict boundary between
+aggregate and render), so aggregation logic can be tested without HTML assertions.
+
+## Testing
+
+`tests/test_investigation_summary.py`:
+
+1. Run `aggregate()` on `v2ecoli-vecoli-comparison`; assert all 7 studies discovered
+   in DAG order (`parca` first, `statistical` last).
+2. Assert the matrix cell verdicts equal the values read directly from the source
+   `verdict.json` axes (no transformation drift).
+3. Assert the roll-up counts equal the studies' canonical `result` tallies.
+4. Assert every declared card resolves to an existing file, and a synthetic
+   missing-card study yields a "missing card" placeholder rather than an exception.
+5. Smoke: `render()` on the aggregated dict returns a non-empty string containing
+   each study `name` and is a single self-contained document (no external `<link>`
+   / `<script src>` to repo paths).
+
+## Out of scope (YAGNI)
+
+- Re-running any simulation.
+- Dashboard / workbench (`vivarium_workbench`) changes.
+- A live server or interactivity beyond native `<details>` collapse and the iframe
+  auto-height shim.
+- Cross-investigation index pages.

--- a/reports/_summary/aggregate.py
+++ b/reports/_summary/aggregate.py
@@ -60,12 +60,18 @@ def _card_stub(study_dir: Path, html_ref: str) -> dict[str, Any]:
             html = ""
             missing = True
 
+    _low = html.lower()
+    # Route any card carrying page-level markup (full doc OR a bare
+    # <style>/<script>/<link> block) through the iframe-isolation path so a
+    # fragment's styles/scripts can't bleed into the summary page.
+    is_full_doc = any(tok in _low for tok in ("<html", "<style", "<script", "<link"))
+
     return {
         "name": name,
         "overall": overall,
         "graded": overall not in (None, _UNGRADED),
         "html": html,
-        "is_full_doc": "<html" in html.lower(),
+        "is_full_doc": is_full_doc,
         "axes": [],
         "missing": missing,
     }

--- a/reports/_summary/aggregate.py
+++ b/reports/_summary/aggregate.py
@@ -11,7 +11,7 @@ _UNGRADED = "ungraded"
 
 
 def _load_yaml(path: Path) -> dict:
-    with path.open() as fh:
+    with path.open(encoding='utf-8') as fh:
         return yaml.safe_load(fh) or {}
 
 
@@ -46,7 +46,7 @@ def _card_stub(study_dir: Path, html_ref: str) -> dict[str, Any]:
     missing = not hpath.exists()
     if vpath.exists():
         try:
-            overall = json.loads(vpath.read_text()).get("overall")
+            overall = json.loads(vpath.read_text(encoding='utf-8')).get("overall")
         except (json.JSONDecodeError, OSError):
             overall = None
     else:
@@ -55,7 +55,7 @@ def _card_stub(study_dir: Path, html_ref: str) -> dict[str, Any]:
     html = ""
     if hpath.exists():
         try:
-            html = hpath.read_text()
+            html = hpath.read_text(encoding='utf-8')
         except OSError:
             html = ""
             missing = True
@@ -83,7 +83,7 @@ def _graded_axes(study_dir: Path, html_ref: str) -> list[dict[str, Any]]:
     if not vpath.exists():
         return []
     try:
-        data = json.loads(vpath.read_text())
+        data = json.loads(vpath.read_text(encoding='utf-8'))
     except (json.JSONDecodeError, OSError):
         return []
     if data.get("overall") in (None, _UNGRADED):

--- a/reports/_summary/aggregate.py
+++ b/reports/_summary/aggregate.py
@@ -1,0 +1,96 @@
+"""Filesystem -> InvestigationSummary dict. No HTML, no sims, read-only."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_UNGRADED = "ungraded"
+
+
+def _load_yaml(path: Path) -> dict:
+    with path.open() as fh:
+        return yaml.safe_load(fh) or {}
+
+
+def _canonical_result(study: dict) -> str | None:
+    for run in study.get("runs", []) or []:
+        if run.get("canonical"):
+            return run.get("result")
+    return None
+
+
+def _first_finding(study: dict) -> str | None:
+    for f in study.get("findings", []) or []:
+        stmt = f.get("statement")
+        if stmt:
+            return " ".join(str(stmt).split())  # collapse folded-yaml whitespace
+    return None
+
+
+def _card_name(html_ref: str) -> str:
+    return Path(html_ref).stem  # "viz/report_card/standard.html" -> "standard"
+
+
+def _verdict_path(study_dir: Path, html_ref: str) -> Path:
+    return study_dir / html_ref.replace(".html", ".verdict.json")
+
+
+def _card_stub(study_dir: Path, html_ref: str) -> dict[str, Any]:
+    name = _card_name(html_ref)
+    vpath = _verdict_path(study_dir, html_ref)
+    hpath = study_dir / html_ref
+    overall = None
+    missing = not hpath.exists()
+    if vpath.exists():
+        try:
+            overall = json.loads(vpath.read_text()).get("overall")
+        except (json.JSONDecodeError, OSError):
+            overall = None
+    else:
+        missing = True
+    return {
+        "name": name,
+        "overall": overall,
+        "graded": overall not in (None, _UNGRADED),
+        "html": "",
+        "is_full_doc": False,
+        "axes": [],
+        "missing": missing,
+    }
+
+
+def aggregate(slug: str, workspace_root: str | Path) -> dict[str, Any]:
+    ws = Path(workspace_root)
+    inv_dir = ws / "investigations" / slug
+    inv = _load_yaml(inv_dir / "investigation.yaml")
+
+    studies: list[dict[str, Any]] = []
+    rollup = {"PASS": 0, "PARTIAL": 0, "FAIL": 0}
+    for study_slug in inv.get("studies", []) or []:
+        study_dir = inv_dir / "studies" / study_slug
+        study = _load_yaml(study_dir / "study.yaml")
+        result = _canonical_result(study)
+        if result in rollup:
+            rollup[result] += 1
+        cards = [_card_stub(study_dir, ref) for ref in study.get("report_cards", []) or []]
+        studies.append({
+            "slug": study_slug,
+            "title": study.get("title") or study.get("name") or study_slug,
+            "status": study.get("status"),
+            "result": result,
+            "prerequisites": (study.get("pipeline_gate", {}) or {}).get("prerequisites", []) or [],
+            "finding": _first_finding(study),
+            "cards": cards,
+        })
+
+    return {
+        "slug": slug,
+        "title": inv.get("title") or slug,
+        "question": inv.get("question") or "",
+        "studies": studies,
+        "rollup": rollup,
+        "matrix": {"columns": [], "rows": []},
+    }

--- a/reports/_summary/aggregate.py
+++ b/reports/_summary/aggregate.py
@@ -100,6 +100,28 @@ def _graded_axes(study_dir: Path, html_ref: str) -> list[dict[str, Any]]:
     return axes
 
 
+def _config_json(study: dict) -> dict[str, Any]:
+    """The study's real baseline config: the composite that drives the run
+    (from conditions.baseline) plus the comparison run settings.
+
+    Only non-null keys are included, so studies that omit a field (e.g. a
+    ParCa study with no comparison block) get a clean object rather than a
+    spray of nulls.
+    """
+    baseline = (study.get("conditions", {}) or {}).get("baseline", {}) or {}
+    comparison = study.get("comparison", {}) or {}
+    cfg: dict[str, Any] = {}
+    if baseline.get("composite"):
+        cfg["composite"] = baseline["composite"]
+    if baseline.get("params"):
+        cfg["params"] = baseline["params"]
+    if comparison.get("seeds") is not None:
+        cfg["seeds"] = comparison["seeds"]
+    if comparison.get("generations") is not None:
+        cfg["generations"] = comparison["generations"]
+    return cfg
+
+
 def aggregate(slug: str, workspace_root: str | Path) -> dict[str, Any]:
     ws = Path(workspace_root)
     inv_dir = ws / "investigations" / slug
@@ -126,6 +148,7 @@ def aggregate(slug: str, workspace_root: str | Path) -> dict[str, Any]:
             "prerequisites": (study.get("pipeline_gate", {}) or {}).get("prerequisites", []) or [],
             "finding": _first_finding(study),
             "cards": cards,
+            "config_json": _config_json(study),
         })
 
     # Build the verdict matrix

--- a/reports/_summary/aggregate.py
+++ b/reports/_summary/aggregate.py
@@ -62,6 +62,29 @@ def _card_stub(study_dir: Path, html_ref: str) -> dict[str, Any]:
     }
 
 
+def _graded_axes(study_dir: Path, html_ref: str) -> list[dict[str, Any]]:
+    """Flattened axes across graded groups of one card's verdict.json."""
+    vpath = _verdict_path(study_dir, html_ref)
+    if not vpath.exists():
+        return []
+    try:
+        data = json.loads(vpath.read_text())
+    except (json.JSONDecodeError, OSError):
+        return []
+    if data.get("overall") in (None, _UNGRADED):
+        return []
+    axes: list[dict[str, Any]] = []
+    for group in (data.get("groups") or {}).values():
+        for a in group.get("axes", []) or []:
+            axes.append({
+                "label": a.get("label"),
+                "verdict": a.get("verdict"),
+                "value": a.get("value"),
+                "meter": a.get("meter"),
+            })
+    return axes
+
+
 def aggregate(slug: str, workspace_root: str | Path) -> dict[str, Any]:
     ws = Path(workspace_root)
     inv_dir = ws / "investigations" / slug
@@ -75,7 +98,11 @@ def aggregate(slug: str, workspace_root: str | Path) -> dict[str, Any]:
         result = _canonical_result(study)
         if result in rollup:
             rollup[result] += 1
-        cards = [_card_stub(study_dir, ref) for ref in study.get("report_cards", []) or []]
+        cards = []
+        for ref in study.get("report_cards", []) or []:
+            card = _card_stub(study_dir, ref)
+            card["axes"] = _graded_axes(study_dir, ref)
+            cards.append(card)
         studies.append({
             "slug": study_slug,
             "title": study.get("title") or study.get("name") or study_slug,
@@ -86,11 +113,26 @@ def aggregate(slug: str, workspace_root: str | Path) -> dict[str, Any]:
             "cards": cards,
         })
 
+    # Build the verdict matrix
+    columns: list[str] = []
+    rows: list[dict[str, Any]] = []
+    for s in studies:
+        cells: dict[str, str | None] = {}
+        for card in s["cards"]:
+            for axis in card["axes"]:
+                label = axis["label"]
+                if label and label not in columns:
+                    columns.append(label)
+                if label:
+                    cells[label] = axis["verdict"]
+        rows.append({"study": s["slug"], "cells": cells})
+    matrix = {"columns": columns, "rows": rows}
+
     return {
         "slug": slug,
         "title": inv.get("title") or slug,
         "question": inv.get("question") or "",
         "studies": studies,
         "rollup": rollup,
-        "matrix": {"columns": [], "rows": []},
+        "matrix": matrix,
     }

--- a/reports/_summary/aggregate.py
+++ b/reports/_summary/aggregate.py
@@ -51,12 +51,21 @@ def _card_stub(study_dir: Path, html_ref: str) -> dict[str, Any]:
             overall = None
     else:
         missing = True
+
+    html = ""
+    if hpath.exists():
+        try:
+            html = hpath.read_text()
+        except OSError:
+            html = ""
+            missing = True
+
     return {
         "name": name,
         "overall": overall,
         "graded": overall not in (None, _UNGRADED),
-        "html": "",
-        "is_full_doc": False,
+        "html": html,
+        "is_full_doc": "<html" in html.lower(),
         "axes": [],
         "missing": missing,
     }

--- a/reports/_summary/render.py
+++ b/reports/_summary/render.py
@@ -74,6 +74,48 @@ def _rollup(summary: dict) -> str:
     return f'<div class="rollup">{"".join(pills)}</div>'
 
 
+_IFRAME_JS = (
+    "<script>window.addEventListener('load',function(){"
+    "document.querySelectorAll('iframe.card-frame').forEach(function(f){"
+    "try{f.style.height=(f.contentDocument.body.scrollHeight+20)+'px';}catch(e){}"
+    "});});</script>"
+)
+
+
+def _card_html(card: dict) -> str:
+    if card["missing"]:
+        return f'<div class="missing">card &ldquo;{_esc(card["name"])}&rdquo; not rendered yet</div>'
+    if card["is_full_doc"]:
+        srcdoc = _html.escape(card["html"], quote=True)
+        return f'<iframe class="card-frame" srcdoc="{srcdoc}"></iframe>'
+    return card["html"]  # fragment: inline as-is (inline styles only, no collision)
+
+
+def _study_section(study: dict) -> str:
+    badge_verdict = None
+    for c in study["cards"]:
+        if c["graded"]:
+            badge_verdict = c["overall"]
+            break
+    badge = (
+        f'<span class="badge {badge_verdict}">{_esc(badge_verdict)}</span>'
+        if badge_verdict else ""
+    )
+    finding = f'<span class="finding">{_esc(study["finding"])}</span>' if study["finding"] else ""
+    embeds = []
+    for c in study["cards"]:
+        open_attr = " open" if c["graded"] else ""
+        embeds.append(
+            f'<details class="card-embed"{open_attr}>'
+            f'<summary>{_esc(c["name"])} card</summary>{_card_html(c)}</details>'
+        )
+    return (
+        f'<details class="study" id="study-{_esc(study["slug"])}" open>'
+        f'<summary>{_esc(study["title"])}{badge}{finding}</summary>'
+        f'{"".join(embeds)}</details>'
+    )
+
+
 def render(summary: dict, style_css: str = "") -> str:
     head = (
         "<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\">"
@@ -87,5 +129,5 @@ def render(summary: dict, style_css: str = "") -> str:
         f"<div class=\"dag\">{_dag(summary)}</div>"
         f"{_matrix_table(summary)}"
     )
-    sections = ""  # --- per-study sections (Task 5) ---
-    return head + overview + sections + "</div></body></html>"
+    sections = "".join(_study_section(s) for s in summary["studies"])
+    return head + overview + sections + _IFRAME_JS + "</div></body></html>"

--- a/reports/_summary/render.py
+++ b/reports/_summary/render.py
@@ -1,0 +1,91 @@
+"""InvestigationSummary dict -> self-contained HTML string. No filesystem reads."""
+from __future__ import annotations
+
+import html as _html
+from typing import Any
+
+_VERDICTS = ("within_tol", "drift", "mismatch", "ungraded")
+
+_BASE_CSS = """
+body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+ margin:0;background:var(--bg,#fafafa);color:#1f2937;line-height:1.5}
+.wrap{max-width:1100px;margin:0 auto;padding:28px 24px 80px}
+h1{font-size:1.6em;margin:0 0 4px}
+.question{color:var(--gray,#666);font-size:1.05em;margin:0 0 18px}
+.rollup{display:flex;gap:10px;margin:0 0 18px;flex-wrap:wrap}
+.pill{border-radius:14px;padding:4px 12px;font-weight:600;font-size:0.9em;border:1px solid #0001}
+.pill.PASS{background:#d1fae5;color:#065f46}.pill.PARTIAL{background:#fef3c7;color:#92400e}
+.pill.FAIL{background:#fee2e2;color:#991b1b}
+.dag{font-family:ui-monospace,Menlo,monospace;font-size:0.85em;color:#475569;
+ background:#fff;border:1px solid var(--border,#e2e6eb);border-radius:8px;padding:10px 14px;margin:0 0 22px}
+table.matrix{border-collapse:collapse;width:100%;margin:0 0 30px;font-size:0.85em}
+table.matrix th,table.matrix td{border:1px solid var(--border,#e2e6eb);padding:6px 8px;text-align:center}
+table.matrix th.study,table.matrix td.study{text-align:left;font-weight:600;white-space:nowrap}
+td.verdict-within_tol{background:#d1fae5}td.verdict-drift{background:#fef3c7}
+td.verdict-mismatch{background:#fee2e2}td.verdict-none{background:#f8fafc;color:#cbd5e1}
+details.study{background:#fff;border:1px solid var(--border,#e2e6eb);border-radius:8px;margin:0 0 14px;padding:2px 14px}
+details.study>summary{cursor:pointer;font-weight:600;padding:10px 0;list-style:none}
+.badge{border-radius:10px;padding:1px 8px;font-size:0.78em;margin-left:8px}
+.badge.within_tol{background:#d1fae5;color:#065f46}.badge.drift{background:#fef3c7;color:#92400e}
+.badge.mismatch{background:#fee2e2;color:#991b1b}.badge.ungraded{background:#eef2f7;color:#475569}
+.finding{color:var(--gray,#666);font-weight:400;font-size:0.9em;margin-left:6px}
+.card-embed{margin:8px 0 14px;border-top:1px solid var(--border,#e2e6eb);padding-top:10px}
+iframe.card-frame{width:100%;border:0}
+.missing{color:#b91c1c;font-style:italic;font-size:0.9em}
+"""
+
+
+def _esc(s: Any) -> str:
+    return _html.escape(str(s if s is not None else ""))
+
+
+def _dag(summary: dict) -> str:
+    parts = []
+    for s in summary["studies"]:
+        prereq = s["prerequisites"]
+        arrow = f"{', '.join(_esc(p) for p in prereq)} &rarr; " if prereq else ""
+        parts.append(f"{arrow}<b>{_esc(s['slug'])}</b>")
+    return "<br>".join(parts)
+
+
+def _matrix_table(summary: dict) -> str:
+    cols = summary["matrix"]["columns"]
+    if not cols:
+        return ""
+    head = "".join(f"<th>{_esc(c)}</th>" for c in cols)
+    body = []
+    for row in summary["matrix"]["rows"]:
+        cells = [f'<td class="study">{_esc(row["study"])}</td>']
+        for c in cols:
+            v = row["cells"].get(c)
+            klass = f"verdict-{v}" if v in _VERDICTS else "verdict-none"
+            cells.append(f'<td class="{klass}">{_esc(v or "")}</td>')
+        body.append(f"<tr>{''.join(cells)}</tr>")
+    return (
+        '<table class="matrix"><thead><tr><th class="study">study</th>'
+        f"{head}</tr></thead><tbody>{''.join(body)}</tbody></table>"
+    )
+
+
+def _rollup(summary: dict) -> str:
+    r = summary["rollup"]
+    order = [("FAIL", r["FAIL"]), ("PARTIAL", r["PARTIAL"]), ("PASS", r["PASS"])]
+    pills = [f'<span class="pill {k}">{n} {k}</span>' for k, n in order]
+    return f'<div class="rollup">{"".join(pills)}</div>'
+
+
+def render(summary: dict, style_css: str = "") -> str:
+    head = (
+        "<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\">"
+        f"<title>{_esc(summary['title'])} — report-card summary</title>"
+        f"<style>{style_css}\n{_BASE_CSS}</style></head><body><div class=\"wrap\">"
+    )
+    overview = (
+        f"<h1>{_esc(summary['title'])}</h1>"
+        f"<p class=\"question\">{_esc(summary['question'])}</p>"
+        f"{_rollup(summary)}"
+        f"<div class=\"dag\">{_dag(summary)}</div>"
+        f"{_matrix_table(summary)}"
+    )
+    sections = ""  # --- per-study sections (Task 5) ---
+    return head + overview + sections + "</div></body></html>"

--- a/reports/_summary/render.py
+++ b/reports/_summary/render.py
@@ -97,8 +97,9 @@ def _study_section(study: dict) -> str:
         if c["graded"]:
             badge_verdict = c["overall"]
             break
+    badge_cls = badge_verdict if badge_verdict in _VERDICTS else ""
     badge = (
-        f'<span class="badge {badge_verdict}">{_esc(badge_verdict)}</span>'
+        f'<span class="badge {badge_cls}">{_esc(badge_verdict)}</span>'
         if badge_verdict else ""
     )
     finding = f'<span class="finding">{_esc(study["finding"])}</span>' if study["finding"] else ""

--- a/reports/_summary/render.py
+++ b/reports/_summary/render.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import html as _html
+import json as _json
 from typing import Any
 
 _VERDICTS = ("within_tol", "drift", "mismatch", "ungraded")
@@ -32,6 +33,17 @@ details.study>summary{cursor:pointer;font-weight:600;padding:10px 0;list-style:n
 .card-embed{margin:8px 0 14px;border-top:1px solid var(--border,#e2e6eb);padding-top:10px}
 iframe.card-frame{width:100%;border:0}
 .missing{color:#b91c1c;font-style:italic;font-size:0.9em}
+nav.topnav{position:sticky;top:0;z-index:10;display:flex;gap:4px;flex-wrap:wrap;
+ align-items:center;padding:8px 24px;margin:0 0 0;background:var(--panel,#fff);
+ border-bottom:1px solid var(--border,#e2e6eb);box-shadow:0 1px 3px #0000000f;overflow-x:auto}
+nav.topnav a{text-decoration:none;font-size:0.82em;color:#475569;padding:3px 9px;
+ border-radius:12px;border:1px solid var(--border,#e2e6eb);white-space:nowrap}
+nav.topnav a:hover{background:var(--bg,#f1f5f9);color:#111}
+nav.topnav a.home{font-weight:700;color:#111;border-color:transparent}
+details.config-json{margin:8px 0 6px;border-top:1px solid var(--border,#e2e6eb);padding-top:10px}
+details.config-json>summary{cursor:pointer;font-weight:600;font-size:0.9em;color:#374151}
+pre.config{background:#f9fafb;border:1px solid #e5e7eb;border-radius:6px;padding:10px;
+ font-size:12px;line-height:1.4;max-height:420px;overflow:auto;white-space:pre;margin:8px 0 0}
 """
 
 
@@ -82,6 +94,28 @@ _IFRAME_JS = (
 )
 
 
+def _topnav(summary: dict) -> str:
+    """Sticky top menu: Overview + one link per study, anchoring to each
+    study section's id."""
+    links = [f'<a class="home" href="#top">{_esc(summary["slug"])}</a>']
+    for s in summary["studies"]:
+        links.append(f'<a href="#study-{_esc(s["slug"])}">{_esc(s["slug"])}</a>')
+    return f'<nav class="topnav">{"".join(links)}</nav>'
+
+
+def _config_block(study: dict) -> str:
+    """Render the study's real baseline config as a JSON block (replaces the
+    config report card)."""
+    cfg = study.get("config_json") or {}
+    if not cfg:
+        return ""
+    pretty = _json.dumps(cfg, indent=2, sort_keys=True)
+    return (
+        '<details class="config-json" open><summary>config (JSON)</summary>'
+        f'<pre class="config">{_esc(pretty)}</pre></details>'
+    )
+
+
 def _card_html(card: dict) -> str:
     if card["missing"]:
         return f'<div class="missing">card &ldquo;{_esc(card["name"])}&rdquo; not rendered yet</div>'
@@ -103,8 +137,11 @@ def _study_section(study: dict) -> str:
         if badge_verdict else ""
     )
     finding = f'<span class="finding">{_esc(study["finding"])}</span>' if study["finding"] else ""
-    embeds = []
+    # The config report card is replaced by the actual baseline config JSON.
+    embeds = [_config_block(study)]
     for c in study["cards"]:
+        if c["name"] == "config":
+            continue
         open_attr = " open" if c["graded"] else ""
         embeds.append(
             f'<details class="card-embed"{open_attr}>'
@@ -121,7 +158,8 @@ def render(summary: dict, style_css: str = "") -> str:
     head = (
         "<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\">"
         f"<title>{_esc(summary['title'])} — report-card summary</title>"
-        f"<style>{style_css}\n{_BASE_CSS}</style></head><body><div class=\"wrap\">"
+        f"<style>{style_css}\n{_BASE_CSS}</style></head><body>"
+        f"{_topnav(summary)}<div class=\"wrap\" id=\"top\">"
     )
     overview = (
         f"<h1>{_esc(summary['title'])}</h1>"

--- a/reports/investigation_summary.py
+++ b/reports/investigation_summary.py
@@ -40,6 +40,10 @@ def main(argv: list[str] | None = None) -> int:
     args = ap.parse_args(argv)
 
     ws = _REPO / "workspace"
+    inv_yaml = ws / "investigations" / args.investigation / "investigation.yaml"
+    if not inv_yaml.exists():
+        print(f"error: investigation {args.investigation!r} not found ({inv_yaml})", file=sys.stderr)
+        return 2
     summary = aggregate(args.investigation, ws)
     html = render(summary, style_css=_read_style())
 
@@ -50,7 +54,10 @@ def main(argv: list[str] | None = None) -> int:
     out.write_text(html)
     print(f"wrote {out} ({out.stat().st_size:,} bytes)")
     if not args.no_open:
-        webbrowser.open(out.resolve().as_uri())
+        try:
+            webbrowser.open(out.resolve().as_uri())
+        except webbrowser.Error:
+            pass
     return 0
 
 

--- a/reports/investigation_summary.py
+++ b/reports/investigation_summary.py
@@ -1,0 +1,58 @@
+"""Generate a self-contained report-card summary for an investigation.
+
+Usage:
+    python reports/investigation_summary.py --investigation <slug> [--out PATH] [--no-open]
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+import webbrowser
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from reports._summary.aggregate import aggregate  # noqa: E402
+from reports._summary.render import render  # noqa: E402
+
+_REPO = Path(__file__).resolve().parents[1]
+
+
+def _read_style() -> str:
+    css = _REPO / "reports" / "assets" / "style.css"
+    try:
+        text = css.read_text()
+    except OSError:
+        return ""
+    # keep only the :root{...} token block so the summary matches the report palette
+    start = text.find(":root{")
+    if start == -1:
+        return ""
+    end = text.find("}", start)
+    return text[start:end + 1] if end != -1 else ""
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="Investigation report-card summary generator")
+    ap.add_argument("--investigation", required=True, help="investigation slug")
+    ap.add_argument("--out", default=None, help="output HTML path")
+    ap.add_argument("--no-open", action="store_true", help="do not open in a browser")
+    args = ap.parse_args(argv)
+
+    ws = _REPO / "workspace"
+    summary = aggregate(args.investigation, ws)
+    html = render(summary, style_css=_read_style())
+
+    out = Path(args.out) if args.out else (
+        _REPO / "reports" / "summaries" / f"{args.investigation}_summary.html"
+    )
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(html)
+    print(f"wrote {out} ({out.stat().st_size:,} bytes)")
+    if not args.no_open:
+        webbrowser.open(out.resolve().as_uri())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/reports/investigation_summary.py
+++ b/reports/investigation_summary.py
@@ -21,7 +21,7 @@ _REPO = Path(__file__).resolve().parents[1]
 def _read_style() -> str:
     css = _REPO / "reports" / "assets" / "style.css"
     try:
-        text = css.read_text()
+        text = css.read_text(encoding='utf-8')
     except OSError:
         return ""
     # keep only the :root{...} token block so the summary matches the report palette
@@ -51,7 +51,7 @@ def main(argv: list[str] | None = None) -> int:
         _REPO / "reports" / "summaries" / f"{args.investigation}_summary.html"
     )
     out.parent.mkdir(parents=True, exist_ok=True)
-    out.write_text(html)
+    out.write_text(html, encoding='utf-8')
     print(f"wrote {out} ({out.stat().st_size:,} bytes)")
     if not args.no_open:
         try:

--- a/scripts/_compare/runner.py
+++ b/scripts/_compare/runner.py
@@ -24,12 +24,18 @@ def _run_engines(spec, out: str, mode: str) -> None:
     out_c = f"{out}/{spec.name}"
     ref_sd = f"{spec.ve_cache}/simData.cPickle"
     v2_cap = str(spec.gens * PER_GEN_STEPS)
+    # A study may drive a process swap on BOTH engines from a fork-relative vEcoli
+    # config (e.g. metabolism_redux): the v2 side convert+injects it, the vecoli
+    # side applies it natively via EcoliSim. "" = plain baseline comparison.
+    swap_flags = (["--from-vecoli-config", spec.from_vecoli_config]
+                  if spec.from_vecoli_config else [])
     subprocess.run([PY, "scripts/run_comparison_ensemble.py",
                     "--composite", "v2ecoli", "--condition", spec.condition,
                     "--cache-dir", spec.v2_cache, "--n-seeds", str(spec.seeds),
                     "--max-generations", str(spec.gens), "--max-steps", v2_cap,
                     "--chunk", "60", "--mode", mode,
                     "--match-initial-state", "--match-vecoli-simdata", ref_sd,
+                    *swap_flags,
                     "--out-root", out_c], cwd=REPO, check=True)
     subprocess.run([PY, "scripts/run_comparison_ensemble.py",
                     "--composite", "vecoli", "--condition", spec.condition,
@@ -37,6 +43,7 @@ def _run_engines(spec, out: str, mode: str) -> None:
                     "--max-generations", str(spec.gens), "--max-steps",
                     str(PER_GEN_STEPS), "--chunk", "60", "--mode", mode,
                     "--vecoli-source", "vivarium-process",
+                    *swap_flags,
                     "--out-root", out_c], cwd=REPO, check=True)
 
 

--- a/scripts/_compare/runner.py
+++ b/scripts/_compare/runner.py
@@ -23,7 +23,8 @@ def _run_engines(spec, out: str, mode: str) -> None:
     --max-steps as a TOTAL across gens; vEcoli interprets it PER-generation."""
     out_c = f"{out}/{spec.name}"
     ref_sd = f"{spec.ve_cache}/simData.cPickle"
-    v2_cap = str(spec.gens * PER_GEN_STEPS)
+    per_gen = spec.max_steps_per_gen        # study-overridable (default 15000)
+    v2_cap = str(spec.gens * per_gen)
     # A study may drive a process swap on BOTH engines from a fork-relative vEcoli
     # config (e.g. metabolism_redux): the v2 side convert+injects it, the vecoli
     # side applies it natively via EcoliSim. "" = plain baseline comparison.
@@ -41,7 +42,7 @@ def _run_engines(spec, out: str, mode: str) -> None:
                     "--composite", "vecoli", "--condition", spec.condition,
                     "--cache-dir", spec.ve_cache, "--n-seeds", str(spec.seeds),
                     "--max-generations", str(spec.gens), "--max-steps",
-                    str(PER_GEN_STEPS), "--chunk", "60", "--mode", mode,
+                    str(per_gen), "--chunk", "60", "--mode", mode,
                     "--vecoli-source", "vivarium-process",
                     *swap_flags,
                     "--out-root", out_c], cwd=REPO, check=True)

--- a/scripts/_compare/study_spec.py
+++ b/scripts/_compare/study_spec.py
@@ -35,6 +35,9 @@ class StudySpec:
     ve_cache: str
     fork: str                 # V2E_VECOLI_DIR value ("" if unset)
     study_path: str
+    from_vecoli_config: str = ""   # fork-relative vEcoli config driving a process
+                                   # swap on BOTH engines (e.g. metabolism_redux);
+                                   # "" = no swap (plain baseline comparison)
 
     @property
     def graded_cards(self) -> list:
@@ -95,6 +98,8 @@ def _spec_from_study(study_path: Path, ctx: dict) -> StudySpec:
         ve_cache=ctx["ve_cache"],
         fork=ctx["fork"],
         study_path=str(study_path),
+        from_vecoli_config=(data.get("from_vecoli_config")
+                            or comp.get("from_vecoli_config") or ""),
     )
 
 

--- a/scripts/_compare/study_spec.py
+++ b/scripts/_compare/study_spec.py
@@ -38,6 +38,9 @@ class StudySpec:
     from_vecoli_config: str = ""   # fork-relative vEcoli config driving a process
                                    # swap on BOTH engines (e.g. metabolism_redux);
                                    # "" = no swap (plain baseline comparison)
+    max_steps_per_gen: int = 15000  # per-generation tick budget; lower it for a
+                                    # short-horizon run of an expensive swap (e.g.
+                                    # MetabolismRedux solves an LP per tick)
 
     @property
     def graded_cards(self) -> list:
@@ -100,6 +103,7 @@ def _spec_from_study(study_path: Path, ctx: dict) -> StudySpec:
         study_path=str(study_path),
         from_vecoli_config=(data.get("from_vecoli_config")
                             or comp.get("from_vecoli_config") or ""),
+        max_steps_per_gen=int(comp.get("max_steps_per_gen") or 15000),
     )
 
 

--- a/scripts/run_comparison_ensemble.py
+++ b/scripts/run_comparison_ensemble.py
@@ -509,6 +509,27 @@ def make_run_one(*, composite_kind: str, condition: str, cache_dir: str,
         except Exception as e:  # noqa: BLE001
             print(f"[warn] from-vecoli-config resolve failed: {type(e).__name__} {e}")
 
+    # vEcoli side: resolve the fork config's process SWAP so the genuine vEcoli
+    # run applies it too (e.g. FBA metabolism -> MetabolismRedux). Without this,
+    # --from-vecoli-config would swap only the v2ecoli side (via injected_processes)
+    # and the comparison would confound the engine with the metabolism model.
+    ve_swap_processes: dict | None = None
+    ve_flow: dict | None = None
+    if from_vecoli_config and composite_kind == "vecoli":
+        try:
+            from scripts._compare.config_adapter import resolve_vecoli_config_local
+            fork_dir = vecoli_dir or os.environ.get(
+                "V2E_VECOLI_DIR", str(REPO_ROOT.parent / "vEcoli"))
+            resolved_ve = resolve_vecoli_config_local(from_vecoli_config, fork_dir)
+            ve_swap_processes = resolved_ve.get("swap_processes") or None
+            ve_flow = resolved_ve.get("flow") or None
+            if ve_swap_processes:
+                print(f"[from-vecoli-config] vecoli side applies swap_processes="
+                      f"{ve_swap_processes}")
+        except Exception as e:  # noqa: BLE001
+            print(f"[warn] vecoli from-vecoli-config swap resolve failed: "
+                  f"{type(e).__name__} {e}")
+
     # Legacy opt-in: translate the vEcoli config into baseline overrides ONCE
     # (only when --from-vecoli-config did not already populate them).
     if (composite_kind == "v2ecoli" and translate_config and vecoli_config
@@ -542,6 +563,7 @@ def make_run_one(*, composite_kind: str, condition: str, cache_dir: str,
                 store_path=store_path, sim_data_path=sim_data_path, condition=condition,
                 seed=seed, max_generations=max_generations, max_steps_per_gen=max_steps,
                 chunk=chunk, exclude_processes=["monomer_counts_listener"],
+                swap_processes=ve_swap_processes, flow=ve_flow,
                 fork_dir=os.environ.get("V2E_VECOLI_DIR"),
                 experiment_id=f"cmp-vecoli-{condition}-seed{seed:02d}",
                 variant=0, lineage_seed=seed)

--- a/tests/test_investigation_summary.py
+++ b/tests/test_investigation_summary.py
@@ -196,3 +196,42 @@ def test_cli_unknown_investigation_returns_error():
 
     rc = main(["--investigation", "no-such-inv", "--no-open"])
     assert rc == 2
+
+
+def test_aggregate_config_json_is_real_baseline_config():
+    from reports._summary.aggregate import aggregate
+
+    by = {s["slug"]: s for s in aggregate(SLUG, WS)["studies"]}
+    cfg = by["acetate"]["config_json"]
+    assert cfg["composite"] == "v2ecoli.composites.baseline.baseline"
+    assert cfg["params"] == {"condition": "acetate"}
+    # comparison run settings folded in
+    assert cfg["seeds"] == 1
+    assert cfg["generations"] == 4
+
+
+def test_topnav_links_every_study():
+    from reports._summary.aggregate import aggregate
+    from reports._summary.render import render
+
+    html = render(aggregate(SLUG, WS))
+    assert '<nav class="topnav">' in html
+    assert 'href="#top"' in html  # overview / home link
+    for slug in ("parca", "basal", "with_aa", "succinate",
+                 "no_oxygen", "acetate", "statistical"):
+        assert f'href="#study-{slug}"' in html
+
+
+def test_config_json_replaces_config_card():
+    from reports._summary.aggregate import aggregate
+    from reports._summary.render import render
+
+    html = render(aggregate(SLUG, WS))
+    # the actual baseline config JSON is shown (HTML-escaped inside <pre>)...
+    assert "config (JSON)" in html
+    assert "v2ecoli.composites.baseline.baseline" in html
+    assert "&quot;composite&quot;" in html  # JSON keys escaped, not raw-injected
+    # ...and the config *report card* is no longer embedded as a card block
+    assert "config card" not in html
+    # graded cards still embedded
+    assert "standard card" in html

--- a/tests/test_investigation_summary.py
+++ b/tests/test_investigation_summary.py
@@ -110,3 +110,19 @@ def test_render_overview_and_matrix():
     # self-contained: no external stylesheet or script src
     assert "<link " not in html.lower()
     assert "script src" not in html.lower()
+
+
+def test_render_per_study_sections_and_embedding():
+    from reports._summary.aggregate import aggregate
+    from reports._summary.render import render
+
+    html = render(aggregate(SLUG, WS))
+    # every study appears as a details section
+    for slug in ("parca", "acetate", "statistical"):
+        assert f'id="study-{slug}"' in html
+    # fragment card (acetate standard) inlined: its <h3 ... simulation runs heading present
+    assert "simulation runs" in html
+    # full-doc card (statistical) embedded via iframe srcdoc
+    assert "iframe" in html and "srcdoc=" in html
+    # auto-height shim present exactly once
+    assert html.count("scrollHeight") >= 1

--- a/tests/test_investigation_summary.py
+++ b/tests/test_investigation_summary.py
@@ -126,3 +126,18 @@ def test_render_per_study_sections_and_embedding():
     assert "iframe" in html and "srcdoc=" in html
     # auto-height shim present exactly once
     assert html.count("scrollHeight") >= 1
+
+
+def test_cli_writes_selfcontained_file(tmp_path):
+    from reports.investigation_summary import main
+
+    out = tmp_path / "summary.html"
+    rc = main(["--investigation", SLUG, "--out", str(out), "--no-open"])
+    assert rc == 0
+    text = out.read_text()
+    assert out.stat().st_size > 5000
+    # all 7 studies present, self-contained
+    for slug in ("parca", "basal", "with_aa", "succinate", "no_oxygen", "acetate", "statistical"):
+        assert f'id="study-{slug}"' in text
+    assert "<link " not in text.lower()
+    assert "script src" not in text.lower()

--- a/tests/test_investigation_summary.py
+++ b/tests/test_investigation_summary.py
@@ -13,7 +13,7 @@ def test_aggregate_discovers_studies_in_dag_order():
     assert summ["question"].startswith("Does v2ecoli reproduce vEcoli")
     slugs = [s["slug"] for s in summ["studies"]]
     assert slugs == [
-        "parca", "basal", "with_aa", "succinate",
+        "parca", "basal", "metabolism_redux", "with_aa", "succinate",
         "no_oxygen", "acetate", "statistical",
     ]
 

--- a/tests/test_investigation_summary.py
+++ b/tests/test_investigation_summary.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+WS = REPO / "workspace"
+SLUG = "v2ecoli-vecoli-comparison"
+
+
+def test_aggregate_discovers_studies_in_dag_order():
+    from reports._summary.aggregate import aggregate
+
+    summ = aggregate(SLUG, WS)
+    assert summ["slug"] == SLUG
+    assert summ["question"].startswith("Does v2ecoli reproduce vEcoli")
+    slugs = [s["slug"] for s in summ["studies"]]
+    assert slugs == [
+        "parca", "basal", "with_aa", "succinate",
+        "no_oxygen", "acetate", "statistical",
+    ]
+
+
+def test_aggregate_per_study_metadata_and_rollup():
+    from reports._summary.aggregate import aggregate
+
+    summ = aggregate(SLUG, WS)
+    by = {s["slug"]: s for s in summ["studies"]}
+    assert by["acetate"]["result"] == "FAIL"
+    assert by["parca"]["result"] == "PASS"
+    assert by["parca"]["prerequisites"] == []
+    assert by["acetate"]["prerequisites"] == ["parca"]
+    assert by["statistical"]["prerequisites"] == ["basal"]
+    assert "RNA mass" in (by["acetate"]["finding"] or "")
+    # config + standard cards discovered for acetate; parca card for parca
+    assert {c["name"] for c in by["acetate"]["cards"]} == {"config", "standard"}
+    assert {c["name"] for c in by["parca"]["cards"]} == {"parca"}
+    # config card is ungraded, standard is graded
+    acards = {c["name"]: c for c in by["acetate"]["cards"]}
+    assert acards["config"]["graded"] is False
+    assert acards["standard"]["graded"] is True
+    assert acards["standard"]["overall"] == "mismatch"
+    assert summ["rollup"] == {"PASS": 2, "PARTIAL": 3, "FAIL": 2}

--- a/tests/test_investigation_summary.py
+++ b/tests/test_investigation_summary.py
@@ -168,7 +168,13 @@ def test_badge_class_whitelisted():
     }
     bad_html = render(summary)
     assert 'class="badge "><x"' not in bad_html
-    assert '"><x' not in bad_html.split("class=")[1].split(">")[0]
+    # the badge span's own class attribute must be a safe whitelisted value,
+    # not the attacker string (anchor on the badge span, not the page shell)
+    import re
+    badge_cls = re.search(r'<span class="badge ([^"]*)">', bad_html).group(1)
+    assert badge_cls in ("", "within_tol", "drift", "mismatch")
+    # ...but the value is still shown as text, HTML-escaped
+    assert "&gt;&lt;x" in bad_html
 
 
 def test_fragment_with_style_block_is_isolated(tmp_path):

--- a/tests/test_investigation_summary.py
+++ b/tests/test_investigation_summary.py
@@ -93,3 +93,20 @@ def test_missing_card_marked_not_crashing(tmp_path):
     assert stub["missing"] is True
     assert stub["html"] == ""
     assert stub["graded"] is False
+
+
+def test_render_overview_and_matrix():
+    from reports._summary.aggregate import aggregate
+    from reports._summary.render import render
+
+    html = render(aggregate(SLUG, WS), style_css=":root{--x:1}")
+    assert "<!doctype html>" in html.lower()
+    assert "Does v2ecoli reproduce vEcoli" in html
+    # rollup counts present
+    assert "2 FAIL" in html and "3 PARTIAL" in html and "2 PASS" in html
+    # matrix header + a verdict-colored cell class
+    assert "growth rate (1/s)" in html
+    assert "verdict-mismatch" in html
+    # self-contained: no external stylesheet or script src
+    assert "<link " not in html.lower()
+    assert "script src" not in html.lower()

--- a/tests/test_investigation_summary.py
+++ b/tests/test_investigation_summary.py
@@ -68,3 +68,28 @@ def test_matrix_cell_verdicts_match_source_json():
     # parca has cell mass within tolerance, no growth-rate column value
     assert rows["parca"]["cell mass (fg)"] == "within_tol"
     assert rows["parca"].get("growth rate (1/s)") is None
+
+
+def test_card_html_inlined_and_full_doc_flagged():
+    from reports._summary.aggregate import aggregate
+
+    by = {s["slug"]: s for s in aggregate(SLUG, WS)["studies"]}
+    scards = {c["name"]: c for c in by["statistical"]["cards"]}
+    # statistical.html is a full <html> document -> flagged for iframe embedding
+    assert scards["statistical"]["is_full_doc"] is True
+    assert "<html" in scards["statistical"]["html"].lower()
+    # standard.html is a fragment (no <html>) -> inlined directly
+    acards = {c["name"]: c for c in by["acetate"]["cards"]}
+    assert acards["standard"]["is_full_doc"] is False
+    assert acards["standard"]["html"].strip() != ""
+    assert "<html" not in acards["standard"]["html"].lower()
+
+
+def test_missing_card_marked_not_crashing(tmp_path):
+    from reports._summary.aggregate import _card_stub
+
+    # a study dir with a declared card whose files don't exist
+    stub = _card_stub(tmp_path, "viz/report_card/ghost.html")
+    assert stub["missing"] is True
+    assert stub["html"] == ""
+    assert stub["graded"] is False

--- a/tests/test_investigation_summary.py
+++ b/tests/test_investigation_summary.py
@@ -141,3 +141,52 @@ def test_cli_writes_selfcontained_file(tmp_path):
         assert f'id="study-{slug}"' in text
     assert "<link " not in text.lower()
     assert "script src" not in text.lower()
+
+
+def test_badge_class_whitelisted():
+    from reports._summary.aggregate import aggregate
+    from reports._summary.render import render
+
+    # real graded study produces a legitimate badge class
+    html = render(aggregate(SLUG, WS))
+    assert "badge mismatch" in html
+
+    # synthetic: an attacker-controlled overall value must not land in the
+    # class attribute unescaped, even though it's still shown (escaped) as text
+    summary = {
+        "slug": "x", "title": "x", "question": "",
+        "rollup": {"PASS": 0, "PARTIAL": 0, "FAIL": 0},
+        "matrix": {"columns": [], "rows": []},
+        "studies": [{
+            "slug": "s1", "title": "S1", "finding": None,
+            "prerequisites": [],
+            "cards": [{
+                "name": "c1", "graded": True, "overall": '"><x',
+                "html": "frag", "is_full_doc": False, "missing": False, "axes": [],
+            }],
+        }],
+    }
+    bad_html = render(summary)
+    assert 'class="badge "><x"' not in bad_html
+    assert '"><x' not in bad_html.split("class=")[1].split(">")[0]
+
+
+def test_fragment_with_style_block_is_isolated(tmp_path):
+    from reports._summary.aggregate import _card_stub
+
+    card_path = tmp_path / "viz" / "report_card" / "frag.html"
+    card_path.parent.mkdir(parents=True)
+    card_path.write_text("<style>.x{color:red}</style><div>hi</div>")
+    verdict_path = tmp_path / "viz" / "report_card" / "frag.verdict.json"
+    verdict_path.write_text('{"overall": "within_tol"}')
+
+    stub = _card_stub(tmp_path, "viz/report_card/frag.html")
+    assert stub["is_full_doc"] is True
+    assert "<html" not in stub["html"].lower()
+
+
+def test_cli_unknown_investigation_returns_error():
+    from reports.investigation_summary import main
+
+    rc = main(["--investigation", "no-such-inv", "--no-open"])
+    assert rc == 2

--- a/tests/test_investigation_summary.py
+++ b/tests/test_investigation_summary.py
@@ -60,7 +60,7 @@ def test_matrix_cell_verdicts_match_source_json():
     # acetate growth rate is a mismatch in the source verdict.json
     src = json.loads(
         (WS / "investigations" / SLUG / "studies" / "acetate"
-         / "viz" / "report_card" / "standard.verdict.json").read_text()
+         / "viz" / "report_card" / "standard.verdict.json").read_text(encoding='utf-8')
     )
     axis = {a["label"]: a["verdict"] for a in src["groups"]["standard"]["axes"]}
     assert rows["acetate"]["growth rate (1/s)"] == axis["growth rate (1/s)"] == "mismatch"
@@ -134,7 +134,7 @@ def test_cli_writes_selfcontained_file(tmp_path):
     out = tmp_path / "summary.html"
     rc = main(["--investigation", SLUG, "--out", str(out), "--no-open"])
     assert rc == 0
-    text = out.read_text()
+    text = out.read_text(encoding='utf-8')
     assert out.stat().st_size > 5000
     # all 7 studies present, self-contained
     for slug in ("parca", "basal", "with_aa", "succinate", "no_oxygen", "acetate", "statistical"):

--- a/tests/test_investigation_summary.py
+++ b/tests/test_investigation_summary.py
@@ -38,3 +38,33 @@ def test_aggregate_per_study_metadata_and_rollup():
     assert acards["standard"]["graded"] is True
     assert acards["standard"]["overall"] == "mismatch"
     assert summ["rollup"] == {"PASS": 2, "PARTIAL": 3, "FAIL": 2}
+
+
+def test_matrix_columns_lead_with_standard_observables():
+    from reports._summary.aggregate import aggregate
+
+    m = aggregate(SLUG, WS)["matrix"]
+    # standard-card observables appear first, in card order
+    assert m["columns"][:5] == [
+        "cell mass (fg)", "dry mass (fg)", "protein mass (fg)",
+        "RNA mass (fg)", "growth rate (1/s)",
+    ]
+
+
+def test_matrix_cell_verdicts_match_source_json():
+    import json
+    from reports._summary.aggregate import aggregate
+
+    m = aggregate(SLUG, WS)["matrix"]
+    rows = {r["study"]: r["cells"] for r in m["rows"]}
+    # acetate growth rate is a mismatch in the source verdict.json
+    src = json.loads(
+        (WS / "investigations" / SLUG / "studies" / "acetate"
+         / "viz" / "report_card" / "standard.verdict.json").read_text()
+    )
+    axis = {a["label"]: a["verdict"] for a in src["groups"]["standard"]["axes"]}
+    assert rows["acetate"]["growth rate (1/s)"] == axis["growth rate (1/s)"] == "mismatch"
+    assert rows["acetate"]["RNA mass (fg)"] == "drift"
+    # parca has cell mass within tolerance, no growth-rate column value
+    assert rows["parca"]["cell mass (fg)"] == "within_tol"
+    assert rows["parca"].get("growth rate (1/s)") is None

--- a/tests/test_regenerate_viewers.py
+++ b/tests/test_regenerate_viewers.py
@@ -2,6 +2,13 @@ import json
 from pathlib import Path
 import importlib.util
 
+import pytest
+
+# regenerate_viewers.py resolves composites via vivarium_workbench, which the
+# fast-tests CI job omits (--no-install-package vivarium-workbench). Skip the
+# whole module when it is absent instead of failing on ModuleNotFoundError.
+pytest.importorskip("vivarium_workbench")
+
 SCRIPT = Path(__file__).parent.parent / "scripts" / "regenerate_viewers.py"
 
 def _load_mod():

--- a/tests/test_regenerate_viewers.py
+++ b/tests/test_regenerate_viewers.py
@@ -2,13 +2,6 @@ import json
 from pathlib import Path
 import importlib.util
 
-import pytest
-
-# regenerate_viewers.py resolves composites via vivarium_workbench, which the
-# fast-tests CI job omits (--no-install-package vivarium-workbench). Skip the
-# whole module when it is absent instead of failing on ModuleNotFoundError.
-pytest.importorskip("vivarium_workbench")
-
 SCRIPT = Path(__file__).parent.parent / "scripts" / "regenerate_viewers.py"
 
 def _load_mod():

--- a/v2ecoli/library/vivarium_ecoli_engine.py
+++ b/v2ecoli/library/vivarium_ecoli_engine.py
@@ -55,6 +55,8 @@ def build_vivarium_ecoli(
     seed: int = 0,
     time_step: float = 1.0,
     exclude_processes: list | None = None,
+    swap_processes: dict | None = None,
+    flow: dict | None = None,
     fork_dir: str | None = None,
     initial_overlay: dict | None = None,
 ) -> EngineHandle:
@@ -111,6 +113,19 @@ def build_vivarium_ecoli(
     if exclude_processes:
         existing = list(sim.config.get("exclude_processes", []) or [])
         sim.config["exclude_processes"] = existing + list(exclude_processes)
+    # Process swap (e.g. FBA metabolism -> MetabolismRedux): EcoliSim applies
+    # ``swap_processes`` natively at build_ecoli() the same way vEcoli's own
+    # configs/metabolism_redux.json does, and ``flow`` reorders the swapped
+    # process's dependents. Merge so a caller-supplied swap composes with any
+    # config default rather than clobbering it.
+    if swap_processes:
+        merged_swap = dict(sim.config.get("swap_processes", {}) or {})
+        merged_swap.update(swap_processes)
+        sim.config["swap_processes"] = merged_swap
+    if flow:
+        merged_flow = dict(sim.config.get("flow", {}) or {})
+        merged_flow.update(flow)
+        sim.config["flow"] = merged_flow
 
     # Capture the per-media expectedDryMassIncreaseDict (drives the division
     # threshold) the same way upstream_division does — via the composer's sim_data.
@@ -294,6 +309,8 @@ def build_vivarium_ecoli_composite(
     seed: int = 0,
     time_step: float = 1.0,
     exclude_processes: list | None = None,
+    swap_processes: dict | None = None,
+    flow: dict | None = None,
     fork_dir: str | None = None,
     core=None,
     agent_id: str = "0",
@@ -317,6 +334,7 @@ def build_vivarium_ecoli_composite(
     VivariumEcoliProcess._PENDING_HANDLE = build_vivarium_ecoli(
         sim_data_path=sim_data_path, condition=condition, seed=int(seed),
         time_step=float(time_step), exclude_processes=list(exclude_processes or []) or None,
+        swap_processes=swap_processes or None, flow=flow or None,
         fork_dir=fork_dir or None, initial_overlay=initial_overlay)
     proc = VivariumEcoliProcess(config={
         "sim_data_path": sim_data_path, "condition": condition, "seed": int(seed),
@@ -431,6 +449,8 @@ def run_vivarium_ecoli_pbg_multigen(
     time_step: float = 1.0,
     chunk: int = 20,
     exclude_processes: list | None = None,
+    swap_processes: dict | None = None,
+    flow: dict | None = None,
     fork_dir: str | None = None,
     mass_multiplier: float = 1.0,
     core=None,
@@ -486,6 +506,7 @@ def run_vivarium_ecoli_pbg_multigen(
         comp, info = build_vivarium_ecoli_composite(
             sim_data_path=sim_data_path, condition=condition, seed=seed + gen,
             time_step=time_step, exclude_processes=exclude_processes,
+            swap_processes=swap_processes, flow=flow,
             fork_dir=fork_dir, core=core, agent_id=composite_agent_id,
             initial_overlay=overlay)
         proc = info["process"]

--- a/workspace/investigations/v2ecoli-vecoli-comparison/investigation.yaml
+++ b/workspace/investigations/v2ecoli-vecoli-comparison/investigation.yaml
@@ -19,6 +19,7 @@ comparison:
 studies:
 - parca
 - basal
+- metabolism_redux
 - with_aa
 - succinate
 - no_oxygen

--- a/workspace/investigations/v2ecoli-vecoli-comparison/studies/metabolism_redux/metabolism_redux_basal.json
+++ b/workspace/investigations/v2ecoli-vecoli-comparison/studies/metabolism_redux/metabolism_redux_basal.json
@@ -1,0 +1,21 @@
+{
+    "experiment_id": "metabolism_redux_basal",
+    "condition": "basal",
+    "swap_processes": {
+        "ecoli-metabolism": "ecoli-metabolism-redux"
+    },
+    "exclude_processes": ["exchange_data"],
+    "flow": {
+        "ecoli-metabolism-redux": [["ecoli-chromosome-structure"]],
+        "ecoli-mass-listener": [["ecoli-metabolism-redux"]],
+        "RNA_counts_listener": [["ecoli-metabolism-redux"]],
+        "rna_synth_prob_listener": [["ecoli-metabolism-redux"]],
+        "monomer_counts_listener": [["ecoli-metabolism-redux"]],
+        "dna_supercoiling_listener": [["ecoli-metabolism-redux"]],
+        "replication_data_listener": [["ecoli-metabolism-redux"]],
+        "rnap_data_listener": [["ecoli-metabolism-redux"]],
+        "unique_molecule_counts": [["ecoli-metabolism-redux"]],
+        "ribosome_data_listener": [["ecoli-metabolism-redux"]]
+    },
+    "raw_output": false
+}

--- a/workspace/investigations/v2ecoli-vecoli-comparison/studies/metabolism_redux/metabolism_redux_basal.json
+++ b/workspace/investigations/v2ecoli-vecoli-comparison/studies/metabolism_redux/metabolism_redux_basal.json
@@ -69,5 +69,14 @@
         "ecoli-metabolism-redux": {
             "boundary": "mM"
         }
+    },
+    "output_ports": {
+        "ecoli-metabolism-redux": [
+            "bulk",
+            "environment",
+            "listeners",
+            "next_update_time",
+            "polypeptide_elongation"
+        ]
     }
 }

--- a/workspace/investigations/v2ecoli-vecoli-comparison/studies/metabolism_redux/metabolism_redux_basal.json
+++ b/workspace/investigations/v2ecoli-vecoli-comparison/studies/metabolism_redux/metabolism_redux_basal.json
@@ -4,18 +4,70 @@
     "swap_processes": {
         "ecoli-metabolism": "ecoli-metabolism-redux"
     },
-    "exclude_processes": ["exchange_data"],
+    "exclude_processes": [
+        "exchange_data"
+    ],
     "flow": {
-        "ecoli-metabolism-redux": [["ecoli-chromosome-structure"]],
-        "ecoli-mass-listener": [["ecoli-metabolism-redux"]],
-        "RNA_counts_listener": [["ecoli-metabolism-redux"]],
-        "rna_synth_prob_listener": [["ecoli-metabolism-redux"]],
-        "monomer_counts_listener": [["ecoli-metabolism-redux"]],
-        "dna_supercoiling_listener": [["ecoli-metabolism-redux"]],
-        "replication_data_listener": [["ecoli-metabolism-redux"]],
-        "rnap_data_listener": [["ecoli-metabolism-redux"]],
-        "unique_molecule_counts": [["ecoli-metabolism-redux"]],
-        "ribosome_data_listener": [["ecoli-metabolism-redux"]]
+        "ecoli-metabolism-redux": [
+            [
+                "ecoli-chromosome-structure"
+            ]
+        ],
+        "ecoli-mass-listener": [
+            [
+                "ecoli-metabolism-redux"
+            ]
+        ],
+        "RNA_counts_listener": [
+            [
+                "ecoli-metabolism-redux"
+            ]
+        ],
+        "rna_synth_prob_listener": [
+            [
+                "ecoli-metabolism-redux"
+            ]
+        ],
+        "monomer_counts_listener": [
+            [
+                "ecoli-metabolism-redux"
+            ]
+        ],
+        "dna_supercoiling_listener": [
+            [
+                "ecoli-metabolism-redux"
+            ]
+        ],
+        "replication_data_listener": [
+            [
+                "ecoli-metabolism-redux"
+            ]
+        ],
+        "rnap_data_listener": [
+            [
+                "ecoli-metabolism-redux"
+            ]
+        ],
+        "unique_molecule_counts": [
+            [
+                "ecoli-metabolism-redux"
+            ]
+        ],
+        "ribosome_data_listener": [
+            [
+                "ecoli-metabolism-redux"
+            ]
+        ]
     },
-    "raw_output": false
+    "raw_output": false,
+    "strip_pint_ports": {
+        "ecoli-metabolism-redux": [
+            "listeners"
+        ]
+    },
+    "attach_pint_ports": {
+        "ecoli-metabolism-redux": {
+            "boundary": "mM"
+        }
+    }
 }

--- a/workspace/investigations/v2ecoli-vecoli-comparison/studies/metabolism_redux/study.yaml
+++ b/workspace/investigations/v2ecoli-vecoli-comparison/studies/metabolism_redux/study.yaml
@@ -70,10 +70,15 @@ findings:
       cell_mass=1269 fg, boundary.external[GLC]=11.1 mM, counts_to_molar sane; (2) output_ports
       over-declaration (tested, no effect); (3) negative bulk counts (a clamp floored counts
       at 0 and fired 0 times — bulk never goes negative). The negatives are INTERNAL to the
-      ODE integration. Conclusion: injecting MetabolismRedux perturbs the metabolic state
-      enough that the FBA-tuned downstream signaling ODEs (two-component, equilibrium) go
-      stiff from tick 2 on. Likely lead: redux runs against an FBA-fit initial state (not a
-      redux-fit ParCa), producing a transient the FBA-tuned ODEs cannot integrate cheaply.
-      This is an architecture-level dynamics mismatch, not a config/bridge bug. Fix paths:
-      redux-specific ParCa; redux-appropriate ODE tolerances/step caps; or full
-      partition/allocator integration instead of raw injection.'
+      ODE integration. PRECISE root cause (traced to the line): TwoComponentSystem is a Step
+      with NO allocator; its update() fallback (two_component_system.py:227, comment "no
+      allocator to protect against this now") re-solves over STEADY_STATE_HORIZON_S=10_000 s
+      with dt/2 recursion (~13 levels) x a 6-solver retry list (_IVP_METHODS) whenever the ODE
+      requests more molecules than available (molecules_required > molecule_counts) — that is
+      the 25-45 s. Tick 1 does 0 solve calls (fallback never fires from the clean matched-init
+      state); after redux''s first update ~20 of the 41 two-component molecules sit at 0 and
+      the redux-modified rates over-consume, so the fallback fires EVERY tick. FBA rarely trips
+      it. Fix paths: (a) run injected redux through the partition/allocator so requests are
+      capped (the real fix); (b) make two-component''s fallback cheap (lower STEADY_STATE_HORIZON_S
+      / trim _IVP_METHODS / cap recursion); (c) redux-specific ParCa so redux starts near its
+      own homeostasis.'

--- a/workspace/investigations/v2ecoli-vecoli-comparison/studies/metabolism_redux/study.yaml
+++ b/workspace/investigations/v2ecoli-vecoli-comparison/studies/metabolism_redux/study.yaml
@@ -1,13 +1,16 @@
 schema_version: 4
 name: metabolism_redux
 investigation: v2ecoli-vecoli-comparison
-title: v2ecoli reproduces vEcoli with MetabolismRedux (basal)
+title: v2ecoli reproduces vEcoli with MetabolismRedux (basal, short-horizon)
 condition: basal
 question: Does v2ecoli reproduce vEcoli on basal when both engines swap FBA Metabolism
   for MetabolismRedux?
 comparison:
   seeds: 1
-  generations: 4
+  generations: 1
+  # MetabolismRedux solves an LP per tick (far slower than FBA), so this is a
+  # short-horizon comparison (first ~300 s of basal) rather than a full 4-gen run.
+  max_steps_per_gen: 300
 # Fork-relative vEcoli config that swaps ecoli-metabolism -> ecoli-metabolism-redux
 # on BOTH engines (vEcoli applies it natively; the v2ecoli side convert+injects it).
 from_vecoli_config: configs/metabolism_redux_basal.json
@@ -55,9 +58,10 @@ findings:
 - id: metabolism_redux-standard
   kind: computational
   status: investigating
-  statement: Pending run — does v2ecoli reproduce vEcoli's mass/growth trajectories
-    on basal when both engines run MetabolismRedux in place of FBA metabolism?
+  statement: Pending short-horizon run — does v2ecoli reproduce vEcoli's early mass/growth
+    trajectory on basal (first ~300 s) when both engines run MetabolismRedux in place
+    of FBA metabolism?
   evidence:
     from_card: standard
-    observed: 'not yet run: awaiting both-engine ParCa build + 2-generation basal
-      comparison'
+    observed: 'short-horizon (300-step) both-engine MetabolismRedux comparison; full-generation
+      run is ~a day of compute (LP per tick)'

--- a/workspace/investigations/v2ecoli-vecoli-comparison/studies/metabolism_redux/study.yaml
+++ b/workspace/investigations/v2ecoli-vecoli-comparison/studies/metabolism_redux/study.yaml
@@ -1,0 +1,63 @@
+schema_version: 4
+name: metabolism_redux
+investigation: v2ecoli-vecoli-comparison
+title: v2ecoli reproduces vEcoli with MetabolismRedux (basal)
+condition: basal
+question: Does v2ecoli reproduce vEcoli on basal when both engines swap FBA Metabolism
+  for MetabolismRedux?
+comparison:
+  seeds: 1
+  generations: 4
+# Fork-relative vEcoli config that swaps ecoli-metabolism -> ecoli-metabolism-redux
+# on BOTH engines (vEcoli applies it natively; the v2ecoli side convert+injects it).
+from_vecoli_config: configs/metabolism_redux_basal.json
+report_cards:
+- viz/report_card/config.html
+- viz/report_card/standard.html
+pipeline_gate:
+  prerequisites:
+  - parca
+  enables: []
+runs:
+- name: metabolism_redux-comparison
+  kind: analysis
+  canonical: true
+  description: v2e-compare study metabolism_redux (both engines on MetabolismRedux)
+  status: pending
+status: build
+tests:
+- name: config-vs-vecoli
+  kind: report_card
+  card: config
+  classification: primary
+  question: Does v2ecoli reproduce vEcoli's MetabolismRedux config on basal (config
+    card)?
+- name: standard-vs-vecoli
+  kind: report_card
+  card: standard
+  classification: primary
+  question: Does v2ecoli reproduce vEcoli's MetabolismRedux dynamics on basal (standard
+    card)?
+  measure:
+    kind: report_card_axis
+    card: docs/report_cards/v2ecoli-vecoli-comparison/metabolism_redux
+    group: standard
+conditions:
+  baseline:
+    composite: v2ecoli.composites.baseline.baseline
+    params:
+      condition: basal
+      swap: ecoli-metabolism-redux
+depends_on:
+- parca
+confidence: Investigating
+findings:
+- id: metabolism_redux-standard
+  kind: computational
+  status: investigating
+  statement: Pending run — does v2ecoli reproduce vEcoli's mass/growth trajectories
+    on basal when both engines run MetabolismRedux in place of FBA metabolism?
+  evidence:
+    from_card: standard
+    observed: 'not yet run: awaiting both-engine ParCa build + 2-generation basal
+      comparison'

--- a/workspace/investigations/v2ecoli-vecoli-comparison/studies/metabolism_redux/study.yaml
+++ b/workspace/investigations/v2ecoli-vecoli-comparison/studies/metabolism_redux/study.yaml
@@ -55,13 +55,25 @@ depends_on:
 - parca
 confidence: Investigating
 findings:
-- id: metabolism_redux-standard
-  kind: computational
-  status: investigating
-  statement: Pending short-horizon run — does v2ecoli reproduce vEcoli's early mass/growth
-    trajectory on basal (first ~300 s) when both engines run MetabolismRedux in place
-    of FBA metabolism?
+- id: metabolism_redux-perf-blocker
+  kind: methodological
+  status: blocked
+  statement: BLOCKED on a runtime issue, not wiring. Both engines correctly swap FBA
+    Metabolism -> MetabolismRedux (vEcoli native via EcoliSim; v2ecoli via convert+inject
+    bridge). The v2-side run is fast on tick 1 (~1.3 s) but degrades to 25-45 s/tick from
+    tick 2 on, making even a 300-step run impractical (~a day for a full 2-gen run).
   evidence:
     from_card: standard
-    observed: 'short-horizon (300-step) both-engine MetabolismRedux comparison; full-generation
-      run is ~a day of compute (LP per tick)'
+    observed: 'Profiled root cause (systematic): the slowdown is LSODA inside
+      two_component_system/equilibrium, which recurse (dt/2 + solver retries) on negative
+      concentrations. RULED OUT with evidence: (1) bridge units are CORRECT — redux reads
+      cell_mass=1269 fg, boundary.external[GLC]=11.1 mM, counts_to_molar sane; (2) output_ports
+      over-declaration (tested, no effect); (3) negative bulk counts (a clamp floored counts
+      at 0 and fired 0 times — bulk never goes negative). The negatives are INTERNAL to the
+      ODE integration. Conclusion: injecting MetabolismRedux perturbs the metabolic state
+      enough that the FBA-tuned downstream signaling ODEs (two-component, equilibrium) go
+      stiff from tick 2 on. Likely lead: redux runs against an FBA-fit initial state (not a
+      redux-fit ParCa), producing a transient the FBA-tuned ODEs cannot integrate cheaply.
+      This is an architecture-level dynamics mismatch, not a config/bridge bug. Fix paths:
+      redux-specific ParCa; redux-appropriate ODE tolerances/step caps; or full
+      partition/allocator integration instead of raw injection.'


### PR DESCRIPTION
## Summary
Two related additions to the `v2ecoli-vecoli-comparison` investigation:

### 1. Investigation report-card summary generator (main deliverable)
A standalone generator — `reports/investigation_summary.py --investigation <slug>` → a self-contained `reports/summaries/<slug>_summary.html` — that aggregates every study's `report_card` verdicts into one page:
- **Overview**: title, question, roll-up counts, pipeline DAG, **sticky top nav** linking to each study.
- **Verdict matrix**: study × observable grid, colored `within_tol`/`drift`/`mismatch`.
- **Per-study sections**: collapsible, embedding each rendered card (fragments inline, full-doc via `<iframe srcdoc>`); the **config card is replaced by the real baseline config JSON** (`composite` + `params` + seeds/generations).
- Pure `aggregate.py` (fs→dict) + `render.py` (dict→HTML) + thin CLI; `tests/test_investigation_summary.py` (15 tests).

Built via TDD + per-task review + a whole-branch review; review-driven hardening (badge-class whitelisting, iframe-isolation for any page-level markup, escaping, clean CLI errors).

### 2. metabolism_redux comparison study (added build-phase, BLOCKED)
Wires a both-engine FBA→`MetabolismRedux` swap (vEcoli native via `EcoliSim`; v2ecoli via convert+inject bridge), a `from_vecoli_config` StudySpec field threaded to both engines, and a `max_steps_per_gen` cap. **The wiring is correct but the run is blocked on a profiled perf issue** — the injected redux makes downstream two-component/equilibrium ODEs stiff (25-45 s/tick from tick 2). Root cause + ruled-out hypotheses (units, output_ports, negative counts — all disproven) are recorded in the study's `study.yaml` finding and in project memory. The study is parked build-phase.

## Test plan
- `python reports/investigation_summary.py --investigation v2ecoli-vecoli-comparison` → opens a self-contained summary with nav + config JSON + the new study row.
- `pytest tests/test_investigation_summary.py` (15 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)