### PR TITLE
chore(ci): drop vestigial bigraph-loom reinstall from publish-dashboard

### DIFF
--- a/.github/workflows/publish-dashboard.yml
+++ b/.github/workflows/publish-dashboard.yml
@@ -62,14 +62,14 @@ jobs:
         # `vivarium-workbench-publish` exists and carries the latest publish
         # robustness fixes.
         #
-        # bigraph-loom needs the SAME treatment: the read-only snapshot bundles
-        # loom's built `_dist` from the installed package, but reinstalling
-        # vivarium-workbench alone does NOT re-fetch loom (the uv.lock-pinned
-        # loom already satisfies the `@main` git spec), so the snapshot would
-        # ship a stale loom UI. Force loom@main too.
+        # This also refreshes the loom UI: bigraph-loom is now vendored INTO
+        # vivarium-workbench (vivarium_workbench/loom/), and the workbench wheel
+        # build hook (hatch_build.py) runs scripts/build_loom.sh to produce the
+        # `_dist` bundle that publish.py ships via loom_assets.asset_dir(). So a
+        # workbench@main reinstall already rebuilds the loom from current source
+        # — no separate bigraph-loom install (that external repo is archived).
         run: |
           uv pip install --reinstall-package vivarium-workbench "vivarium-workbench @ git+https://github.com/vivarium-collective/vivarium-workbench.git@main"
-          uv pip install --reinstall-package bigraph-loom "bigraph-loom @ git+https://github.com/vivarium-collective/bigraph-loom.git@main"
 
       - name: Build dashboard snapshot
         # Builds the static SPA bundle (all investigations + studies) and strips


### PR DESCRIPTION
`bigraph-loom` is vendored into `vivarium-workbench` (`vivarium_workbench/loom/`). The workbench wheel build hook (`hatch_build.py`) runs `scripts/build_loom.sh` to produce the `_dist` bundle, and `publish.py` ships it via `loom_assets.asset_dir()` — it never imports the external `bigraph_loom` package.

The `bigraph-loom @ main` reinstall in `publish-dashboard.yml` was therefore a no-op for the read-only snapshot: a `workbench @ main` reinstall already rebuilds the loom from current vendored source. This drops the last reference to the external `bigraph-loom` repo, which is now **archived** (no longer maintained).

No functional change to the published dashboard — the vendored loom already carries the current UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)