### PR TITLE
feat(viewers): add the 3D E. coli viewer to the Analyses page

### DIFF
--- a/v2ecoli/workbench_viewers.py
+++ b/v2ecoli/workbench_viewers.py
@@ -215,8 +215,51 @@ def _ptools_targets(ws_root) -> list:
     return out
 
 
+def _has_3d_pack(ws_root) -> bool:
+    """Cheap check: does any study have a saved parsimony 3D pack?"""
+    root = _studies_root(Path(ws_root))
+    return bool(root.is_dir() and next(root.glob("*/viz/3d/*.pack.json"), None))
+
+
+def _ecoli_3d_targets(ws_root) -> list:
+    """Studies with a saved parsimony 3D pack → a deep-link to the HOSTED viewer.
+
+    Reuses the workbench's saved-visualizations builder (which computes the public
+    ``viewer_url`` for each 3D pack). Each target carries an external ``href`` so
+    it opens directly in both the live workbench and the read-only dashboard —
+    the hosted viewer needs no local launch backend.
+    """
+    try:
+        from vivarium_workbench.lib import saved_visualizations as _sv
+        payload = _sv.build_saved_visualizations(Path(ws_root))
+    except Exception:
+        return []
+    out = []
+    for item in (payload.get("saved") or []):
+        url = item.get("viewer_url")
+        if not url:
+            continue
+        n = item.get("n_placed")
+        detail = f"{n:,} molecules placed" if isinstance(n, int) else "hosted 3D view"
+        out.append({
+            "study": item.get("study"),
+            "label": item.get("study"),
+            "detail": detail,
+            "href": url,
+        })
+    return out
+
+
 def get_viewers(ws_root) -> list:
-    """Contribute the Pathway Tools Omics Viewer launcher (when configured)."""
+    """Contribute the analysis viewers v2ecoli ships:
+
+    * **Pathway Tools — Omics Viewer** (launcher; needs a configured PTools server).
+    * **3D E. coli viewer** (deep-link to the hosted parsimony 3D viewer; available
+      wherever a study has a saved 3D pack, including the read-only dashboard).
+
+    The Data Explorer (timeseries / scatter / flux maps for any run) is the
+    workbench's own built-in and is shown alongside these automatically.
+    """
     return [
         {
             "id": "pathway-tools",
@@ -230,5 +273,17 @@ def get_viewers(ws_root) -> list:
             "applies": _ptools_configured,
             "launch": _launch,
             "targets": _ptools_targets,
-        }
+        },
+        {
+            "id": "ecoli-3d",
+            "title": "3D E. coli viewer",
+            "description": (
+                "Open an interactive 3D molecular view of the cell — every "
+                "molecule placed in real 3D space by parsimony — in the hosted "
+                "viewer."
+            ),
+            "kind": "launcher",
+            "applies": _has_3d_pack,
+            "targets": _ecoli_3d_targets,
+        },
     ]


### PR DESCRIPTION
Adds an `ecoli-3d` analysis viewer alongside Pathway Tools (and the built-in Data Explorer). It deep-links to the hosted parsimony 3D viewer (reusing the workbench's saved-visualizations `viewer_url`), so each study with a saved 3D pack opens directly — in the live workbench **and** the read-only dashboard (the hosted viewer needs no local backend). Pairs with the vivarium-workbench PR that makes the read-only Analyses page render viewers instead of erroring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)