### PR TITLE
fix(ray-entrypoint): give the sole node CPUs on single-node MNP jobs

### DIFF
--- a/docker/ray-batch-entrypoint.sh
+++ b/docker/ray-batch-entrypoint.sh
@@ -274,10 +274,17 @@ build_upstream_parca   # optional self-build of the upstream simData (gated; see
 if [[ "${NODE_INDEX}" == "${MAIN_INDEX}" ]]; then
   trap upload_logs EXIT                       # ship session logs no matter how we exit
   echo "[ray-batch] HEAD on node ${NODE_INDEX} (${SELF_IP}), expecting ${NUM_NODES} node(s)"
+  # The head deliberately runs no tasks (--num-cpus=0) so the workload's tasks land on
+  # the WORKER nodes — but that is only correct when workers EXIST. On a single-node job
+  # the head IS the only node, so it must supply CPUs itself; otherwise every task keeps
+  # `{CPU: 1}` and the scheduler marks it INFEASIBLE, the job pins at ~0% CPU and hangs
+  # forever. Give the sole node its real core count so it is both head and worker.
+  head_cpu_flag=(--num-cpus=0)
+  [[ "${NUM_NODES}" -gt 1 ]] || head_cpu_flag=(--num-cpus="$(nproc)")
   ray start --head \
     --node-ip-address="${SELF_IP}" \
     --port="${GCS_PORT}" \
-    --num-cpus=0 \
+    "${head_cpu_flag[@]}" \
     --dashboard-host=0.0.0.0
 
   registered=0


### PR DESCRIPTION
## What

On a **single-node** AWS Batch MNP job, start the Ray head with `--num-cpus=$(nproc)` instead of `--num-cpus=0`, so the sole node is **both head and worker**. Multi-node jobs are unchanged.

This is the entrypoint copy **baked into the v2ecoli Ray image** (`docker/Dockerfile` → `/opt/ray-batch-entrypoint.sh`) — i.e. the one the compose path actually executes. The `sms-cdk/scripts/` mirror gets the same fix in vivarium-collective/sms-cdk#25.

```diff
+  head_cpu_flag=(--num-cpus=0)
+  [[ "${NUM_NODES}" -gt 1 ]] || head_cpu_flag=(--num-cpus="$(nproc)")
   ray start --head \
     --node-ip-address="${SELF_IP}" \
     --port="${GCS_PORT}" \
-    --num-cpus=0 \
+    "${head_cpu_flag[@]}" \
     --dashboard-host=0.0.0.0
```

## Why — this deadlocked a real GovCloud run

The head runs no tasks (`--num-cpus=0`) so work lands on **worker** nodes — correct only when workers exist. The compose path hardcodes `num_nodes=1` (`sms-api` → `compose/simulation_service_ray.py:165`), so the head is the *only* node and the cluster has **0 CPU**: every `{CPU:1}` seed task is `INFEASIBLE`, the node pins at ~0% CPU, the job hangs.

Observed on the `batch_baseline` compose pilot (`n_seeds=20`, image `868cf2a3`): flat **0.27% CPU for ~58 min**, `Infeasible queue length: 10` in Ray's `debug_state.txt`. `n_seeds=1` dodged it (single seed runs inline on the driver, no Ray task). Full post-mortem: https://claude.ai/code/artifact/9a2c8a38-1e75-41e8-957e-30460d1cd53e

## Test plan
- [x] `bash -n docker/ray-batch-entrypoint.sh` — clean
- [x] Branch logic under `set -euo pipefail` for `NUM_NODES ∈ {1,4}` → `--num-cpus=16` / `--num-cpus=0`
- [ ] Re-run the `n_seeds=20` compose pilot on a rebuilt image → CPU pegs ~100% + results sync

## Deploy note
The entrypoint is unchanged between `868cf2a3` (deployed) and `main`, so this fix can be built either on top of `868cf2a3` (keeps the existing ParCa cache valid — plain `aws s3 cp` to the new tag) or on `main`. Building on `main` pulls in #357/#361/#363, which touch composites/sim_data and may **invalidate the ParCa cache** (regen = 4–8h). For an isolated re-pilot of *just this fix*, `868cf2a3 + this commit` is the cheap path.
