### PR TITLE
ci(publish): require loom bundle in dashboard/report publishes

### DIFF
--- a/.github/workflows/publish-dashboard.yml
+++ b/.github/workflows/publish-dashboard.yml
@@ -39,6 +39,12 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    # The workbench wheel build warns+skips the loom bundle when npm is absent
+    # (so Node-less consumer builds don't fail). But the published read-only
+    # dashboard MUST include the Composite Explorer — require it here so a
+    # missing/broken bundle fails loudly instead of shipping a loom-less site.
+    env:
+      VIVARIUM_WORKBENCH_REQUIRE_LOOM: "1"
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/publish-reports.yml
+++ b/.github/workflows/publish-reports.yml
@@ -36,6 +36,10 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    # Investigation reports embed the loom Explorer — require the bundle so a
+    # missing/broken build fails loudly rather than publishing without it.
+    env:
+      VIVARIUM_WORKBENCH_REQUIRE_LOOM: "1"
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Companion to vivarium-collective/vivarium-workbench#574. That PR makes the loom bundle **optional** in the workbench wheel build (warn+skip when npm absent) so Node-less consumer builds stop failing. To ensure the *published* read-only dashboard + investigation reports still ship the Composite Explorer, set `VIVARIUM_WORKBENCH_REQUIRE_LOOM=1` on the publish jobs — a missing/broken bundle fails loudly instead of silently publishing without it.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)