### PR TITLE
fix(parallel-seeds): reserve per-seed Ray memory to prevent OOM on shared nodes

### DIFF
--- a/v2ecoli/library/parallel_seeds.py
+++ b/v2ecoli/library/parallel_seeds.py
@@ -67,6 +67,23 @@ def _resolve_threads(n_seeds: int, num_threads: int | None) -> int:
     return max(1, (os.cpu_count() or 1) // max(1, n_seeds))
 
 
+# A single whole-cell seed worker resides ~4 GB (peaks ~4.4 GB); reserve a bit
+# more so Ray bounds seed concurrency by RAM, not just CPUs. Without this, N cpus
+# schedule N ~4 GB workers and OOM a node — e.g. a single-node compose run packed
+# 16 seeds onto a 58 GB box (16×~4 GB), tripping Ray's OOM-killer and failing the
+# job. Override with V2E_RAY_SEED_MEMORY_GB; set it to 0 to disable the reservation.
+_DEFAULT_SEED_MEMORY_GB = 6.0
+
+
+def _resolve_seed_memory(memory_per_worker: int | None) -> int:
+    """Bytes of Ray logical ``memory`` to reserve per seed task (0 = disabled)."""
+    if memory_per_worker is not None:
+        return max(0, int(memory_per_worker))
+    env = os.environ.get("V2E_RAY_SEED_MEMORY_GB")
+    gb = float(env) if env not in (None, "") else _DEFAULT_SEED_MEMORY_GB
+    return int(gb * 1024**3)
+
+
 def run_seeds_parallel(
     seeds: Iterable[int],
     run_one: Callable[..., Any],
@@ -75,6 +92,7 @@ def run_seeds_parallel(
     run_kwargs: dict | None = None,
     num_threads: int | None = None,
     ray_env: dict | None = None,
+    memory_per_worker: int | None = None,
 ) -> ParallelResult:
     """Run ``run_one(seed, **run_kwargs)`` for every seed; fan out across Ray
     workers when ``mode == "ray"``, else run sequentially. Always falls back to
@@ -94,6 +112,10 @@ def run_seeds_parallel(
       num_threads: BLAS/OpenMP threads per worker; default ``cores // n_seeds``.
       ray_env: extra ``env_vars`` to merge into the Ray worker environment
         (e.g. ``{"PYTHONPATH": ...}``). Thread caps are added automatically.
+      memory_per_worker: bytes of Ray logical ``memory`` to reserve per seed task
+        so concurrency is bounded by RAM as well as CPUs (prevents OOM when many
+        ~4 GB whole-cell seeds share one node). Default: ``V2E_RAY_SEED_MEMORY_GB``
+        env or ~6 GiB; pass ``0`` to disable.
 
     Returns:
       ParallelResult with per-seed ``results`` (seed order) + timing.
@@ -127,6 +149,7 @@ def run_seeds_parallel(
 
     # ---- Ray fan-out: one worker process per seed -----------------------
     threads = _resolve_threads(n, num_threads)
+    mem_bytes = _resolve_seed_memory(memory_per_worker)
     env_vars = {k: str(threads) for k in _THREAD_ENV_KEYS}
     if ray_env:
         env_vars.update({k: str(v) for k, v in ray_env.items()})
@@ -144,10 +167,13 @@ def run_seeds_parallel(
         remote = ray.remote(run_one)
         t0 = time.time()
         # Pass the thread env per task so workers get it whether or not we started
-        # Ray (a reused cluster keeps its own top-level runtime_env).
-        futures = [remote.options(num_cpus=threads,
-                                  runtime_env={"env_vars": env_vars}).remote(s, **kw)
-                   for s in seeds]
+        # Ray (a reused cluster keeps its own top-level runtime_env). `memory`
+        # bounds seed concurrency by RAM so N cpus don't schedule N ~4 GB workers
+        # and OOM the node (see _resolve_seed_memory).
+        opts: dict[str, Any] = {"num_cpus": threads, "runtime_env": {"env_vars": env_vars}}
+        if mem_bytes > 0:
+            opts["memory"] = mem_bytes
+        futures = [remote.options(**opts).remote(s, **kw) for s in seeds]
         results = ray.get(futures)           # critical-path wall = slowest seed
         wall = time.time() - t0
     finally:
@@ -157,5 +183,6 @@ def run_seeds_parallel(
     return ParallelResult(
         results=results, wall_s=round(wall, 2), mode="ray", n_seeds=n,
         n_threads_per_worker=threads,
-        detail={"cpu_total": os.cpu_count()},
+        detail={"cpu_total": os.cpu_count(),
+                "mem_per_worker_gb": round(mem_bytes / 1024**3, 2) if mem_bytes else 0},
     )


### PR DESCRIPTION
## What

Reserve Ray logical `memory` per seed task in `run_seeds_parallel`, so seed concurrency is bounded by **RAM as well as CPUs**.

```diff
+  mem_bytes = _resolve_seed_memory(memory_per_worker)   # default ~6 GiB
   ...
-  futures = [remote.options(num_cpus=threads,
-                            runtime_env={"env_vars": env_vars}).remote(s, **kw)
-             for s in seeds]
+  opts = {"num_cpus": threads, "runtime_env": {"env_vars": env_vars}}
+  if mem_bytes > 0:
+      opts["memory"] = mem_bytes
+  futures = [remote.options(**opts).remote(s, **kw) for s in seeds]
```

- Default **~6 GiB/seed** (observed peak ~4.4 GB + headroom). Override with `V2E_RAY_SEED_MEMORY_GB`; set `0` to disable.
- **Default-on**, so the compose / Ray-on-Batch path is protected without threading a param through every caller.
- New `memory_per_worker` kwarg for explicit control; reservation echoed in `ParallelResult.detail["mem_per_worker_gb"]`.

## Why

`run_seeds_parallel` reserved `num_cpus` but **no memory**, so N CPUs scheduled N ~4 GB whole-cell workers on one node. Once the single-node CPU deadlock was fixed (#364) and the fan-out actually ran, the `batch_baseline` `n_seeds=20` GovCloud re-pilot packed **16 seeds × ~4 GB onto a 58 GB m5.4xlarge**, exceeded Ray's 0.95 OOM threshold, and Ray culled workers → job FAILED ~80 min in (after producing 7.35 GB of partial output).

Ray log:
```
node memory 55.7GB / 58.6GB (0.95) exceeds threshold 0.95
Ray killed 1 worker(s) — task _run_seed_worker {CPU:1}
error_type: OUT_OF_MEMORY
```

## Effect on concurrency

| Node | before (no reservation) | after (6 GiB default) |
|---|---|---|
| m5.4xlarge (58 GB) | 16 seeds → **OOM** | ~9 seeds, safe |
| r5.4xlarge (122 GB) | 16 → risky | ~15 seeds (near-full 16-core) |

Pairs with the Ray-CE instance right-sizing (sms-cdk, m5.4xlarge→r5.4xlarge) to restore full 16-core throughput without OOM.

## Test plan
- [x] `py_compile` clean; `_resolve_seed_memory` verified for default / env-override / `0`-disable / explicit
- [ ] Re-run `batch_baseline` `n_seeds=20` on GovCloud → confirm no OOM, job SUCCEEDS, results sync

Full context / post-mortem: https://claude.ai/code/artifact/9a2c8a38-1e75-41e8-957e-30460d1cd53e

cc @eagmon — this is your `run_seeds_parallel`; flagging since it changes default scheduling (adds a memory reservation). Default is safe/conservative and env-tunable.
