### PR TITLE
chore(deps): bump pbg-emitters to 0.2.1 (zarr provenance write)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2841,8 +2841,8 @@ dependencies = [
 
 [[package]]
 name = "pbg-emitters"
-version = "0.2.0"
-source = { git = "https://github.com/vivarium-collective/pbg-emitters.git?branch=main#00c91b2800fe684ac09bb490dfd65a8107c85b17" }
+version = "0.2.1"
+source = { git = "https://github.com/vivarium-collective/pbg-emitters.git?branch=main#55c482bfbafcce258942050455e33ffc47450c3a" }
 dependencies = [
     { name = "bigraph-schema" },
     { name = "numpy" },


### PR DESCRIPTION
Pins the git-sourced `pbg-emitters` to `55c482b` — **#20 (zarr root-attr provenance write) + #18 (sqlite pint magnitude)**, deliberately **without #19** (parquet drop-shape-varying-columns).

#20 makes the self-describing-output wiring merged in #362 actually write `{composite, config, run_id}` to the zarr (until now a harmless no-op). #19 is excluded because its drop-instead-of-crash change needs separate review for whole-cell data integrity (it flipped `test_parquet_emitter_ported::test_expected_failures`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)