### PR TITLE
Colony: loom drill-down support + biological port types

### DIFF
--- a/v2ecoli/bridge.py
+++ b/v2ecoli/bridge.py
@@ -55,6 +55,36 @@ class EcoliWCM(Process):
     update() to avoid heavy imports at discovery time.
     """
 
+    # Structured contract — what this process reads, computes, and writes.
+    # Surfaced by the workbench loom (card contract band + Inspector) and by
+    # ``bigraph_schema.contract.resolve_contract``. Each port bridges an
+    # internal store of the embedded 55-process whole-cell model.
+    contract = {
+        "summary": (
+            "Whole-cell E. coli as one process — the full v2ecoli model "
+            "(transcription, translation, metabolism, replication, …) embedded "
+            "via a Composite bridge, exposing a handful of colony-facing ports."
+        ),
+        "inputs": {
+            "local": "Local environment metabolite concentrations (mM) the cell senses/imports.",
+            "agent_id": "This cell's unique id within the colony.",
+            "location": "Cell centroid (x, y) in the 2D environment (µm).",
+            "angle": "Cell body orientation (radians).",
+        },
+        "outputs": {
+            "mass": "Dry-mass increment this step (fg), accumulated onto the physical body.",
+            "length": "Updated cell length (µm) from biomass growth.",
+            "volume": "Updated cell volume (µm³).",
+            "exchange": "Net metabolite exchange fluxes with the environment (counts/step).",
+            "agents": "Division events written to the colony agents map ({_add: daughter, _remove: mother}).",
+        },
+        "assumptions": [
+            "Each cell runs an independent whole-cell model; cells couple only through pymunk physics + the shared environment.",
+            "The inner Composite is built lazily on first update() and needs a ParCa cache.",
+            "The embedded model's own emitter is minimized (global_time only) to avoid a per-cell RAM leak in growing colonies.",
+        ],
+    }
+
     config_schema = {
         'cache_dir':      {'_type': 'string', '_default': ''},
         'seed':           {'_type': 'integer', '_default': 0},
@@ -76,12 +106,25 @@ class EcoliWCM(Process):
         self._prev_volume = 0.0
         self._prev_length = 2.0
 
+    def inner_composite(self):
+        """The full inner whole-cell ``Composite`` this process wraps.
+
+        The ``inner_composite()`` convention marks this as a "Composite Process"
+        and lets tooling (the workbench loom Explorer) drill from this single
+        ``EcoliWCM`` node into the 55-process model it embeds. Built lazily (same
+        path as ``update()``), so browsing a colony only pays the ParCa cost for
+        the cell actually opened.
+        """
+        if self._composite is None:
+            self._build_composite()
+        return self._composite
+
     def inputs(self):
         return {
-            'local': 'map[float]',
+            'local': 'map[millimolar]',       # environment metabolite concentrations (mM)
             'agent_id': 'string',
-            'location': 'tuple[float,float]',
-            'angle': 'float',
+            'location': 'tuple[micrometer,micrometer]',  # cell centroid (x, y) in µm
+            'angle': 'radian',                # body orientation (rad)
         }
 
     def _build_composite(self):
@@ -209,12 +252,12 @@ class EcoliWCM(Process):
 
     def outputs(self):
         return {
-            'mass': 'float',
-            'length': 'float',
-            'volume': 'float',
-            'exchange': 'map[float]',
-            'agents': 'map[map]',
-            'chromosome_state': 'map',  # snapshot of chromosome for visualization
+            'mass': 'femtogram',          # dry-mass increment (fg)
+            'length': 'micrometer',       # cell length (µm)
+            'volume': 'femtoliter',       # cell volume (fL)
+            'exchange': 'map[float]',     # net metabolite exchange (counts/step)
+            'agents': 'map[map]',         # division events ({_add, _remove})
+            'chromosome_state': 'map',    # snapshot of chromosome for visualization
         }
 
     def update(self, state, interval):

--- a/v2ecoli/colony.py
+++ b/v2ecoli/colony.py
@@ -81,8 +81,14 @@ def make_colony_document(
         y = env_size / 2 + rng.uniform(-5, 5)
         angle = rng.uniform(0, 2 * np.pi)
 
+        # Deterministic initial-cell id (a_0, a_1, …). build_microbe's default id
+        # is randomly generated (untied to the seed), so it changes on every
+        # build — which breaks resolving a cell by id across two builds (the loom
+        # Explorer re-builds the colony to instantiate + drill into a cell).
+        # Seeding a stable id keeps the composite reproducible; daughters spawned
+        # at division still get fresh unique ids.
         agent_id, cell_body = build_microbe(
-            rng, env_size=env_size,
+            rng, agent_id=f'a_{i}', env_size=env_size,
             x=x, y=y, angle=angle,
             length=2.0, radius=0.5, density=0.02,
         )

--- a/v2ecoli/composites/colony.py
+++ b/v2ecoli/composites/colony.py
@@ -17,6 +17,25 @@ from viva_superpowers.composite_generator import composite_generator
 from v2ecoli.colony import make_colony_document
 
 
+def _register_colony_core(core=None):
+    """Return a core with everything the colony composite needs registered:
+    viva_munk base + pymunk types (notably ``pymunk_agent``), v2ecoli
+    ``ECOLI_TYPES``, and the ``EcoliWCM`` link. Declared as a ``core_extension``
+    so tooling can INSTANTIATE the colony on a proper core — notably the loom
+    Explorer, which instantiates it to drill into / preview a cell's inner model.
+    Builds a FRESH ``core_import()`` core (viva_munk's base) rather than mutating
+    the passed ``allocate_core()`` — whose base types conflict with viva_munk's
+    (e.g. ``positive_float``). ``apply_core_extensions`` captures this return."""
+    from viva_munk import core_import
+    from v2ecoli.bridge import EcoliWCM
+    from v2ecoli.types import ECOLI_TYPES
+
+    core = core_import()
+    core.register_types(ECOLI_TYPES)
+    core.register_link("EcoliWCM", EcoliWCM)
+    return core
+
+
 # Canonical visualizations for the multi-cell colony composite. ColonyVisualization
 # is the integrated colony report (per-cell positions over time + colony total
 # mass + cell-count trajectory). Standalone TimeSeriesPlots aren't appropriate
@@ -75,6 +94,7 @@ DEFAULT_COLONY_VISUALIZATIONS = [
         },
     },
     visualizations=DEFAULT_COLONY_VISUALIZATIONS,
+    core_extensions=[_register_colony_core],
 )
 def colony(
     core: Any = None,

--- a/v2ecoli/types/__init__.py
+++ b/v2ecoli/types/__init__.py
@@ -387,6 +387,18 @@ ECOLI_TYPES = {
     'labeled_array': LabeledArray,
 }
 
+# Biological unit types — named scalars (each inherits `float`) that advertise a
+# UNIT on a port, so the loom / Inspector shows e.g. `femtogram` instead of a
+# bare `float`. Because they are subtypes of `float` they bind to plain-float
+# stores with no wiring change, and carry through to the value's meaning.
+ECOLI_TYPES.update({
+    'femtogram':  {'_inherit': 'float', '_description': 'mass, femtograms (fg)'},
+    'micrometer': {'_inherit': 'float', '_description': 'length, micrometers (µm)'},
+    'femtoliter': {'_inherit': 'float', '_description': 'volume, femtoliters (fL)'},
+    'radian':     {'_inherit': 'float', '_description': 'angle, radians'},
+    'millimolar': {'_inherit': 'float', '_description': 'concentration, millimolar (mM)'},
+})
+
 # Study-evaluation framework enums (target_class, verdict_result,
 # failure_cause, ...). Kept in a separate module so per-investigation
 # layers can extend the framework without touching this file.


### PR DESCRIPTION
Makes the colony composite drillable/previewable in the workbench loom, and gives its ports biological types.

- `EcoliWCM`: `inner_composite()` (Composite-Process convention), a structured contract, and biological port types with units (mass→femtogram, length→micrometer, volume→femtoliter, angle→radian, local→map[millimolar]).
- `colony`: `core_extensions=[_register_colony_core]` so the composite can be instantiated on a proper core (loom drill/preview); deterministic initial cell ids (`a_0`, `a_1`) so a cell resolves by id across builds.
- `types`: register biological unit types (inherit `float`; bind to plain-float stores, no wiring change).

Verified: colony builds, runs, and drills; ports render with units.

🤖 Generated with [Claude Code](https://claude.com/claude-code)